### PR TITLE
Improve error message for invalid locations

### DIFF
--- a/firebase-vertexai/CHANGELOG.md
+++ b/firebase-vertexai/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* [fixed] Improved error message when using an invalid location. (#6428)
 * [fixed] Fixed issue where Firebase App Check error tokens were unintentionally missing from the requests. (#6409)
 * [fixed] Clarified in the documentation that `Schema.integer` and `Schema.float` only provide hints to the model. (#6420)
 

--- a/firebase-vertexai/src/test/java/com/google/firebase/vertexai/GenerativeModelTesting.kt
+++ b/firebase-vertexai/src/test/java/com/google/firebase/vertexai/GenerativeModelTesting.kt
@@ -24,10 +24,13 @@ import com.google.firebase.vertexai.common.shared.Content
 import com.google.firebase.vertexai.common.shared.TextPart
 import com.google.firebase.vertexai.common.util.doBlocking
 import com.google.firebase.vertexai.type.RequestOptions
+import com.google.firebase.vertexai.type.ServerException
 import com.google.firebase.vertexai.type.content
 import io.kotest.assertions.json.shouldContainJsonKey
 import io.kotest.assertions.json.shouldContainJsonKeyValue
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -44,7 +47,7 @@ internal class GenerativeModelTesting {
   private val TEST_CLIENT_ID = "test"
 
   @Test
-  fun addition() = doBlocking {
+  fun `system calling in request`() = doBlocking {
     val mockEngine = MockEngine {
       respond(
         generateContentResponseAsJsonString("text response"),
@@ -83,6 +86,46 @@ internal class GenerativeModelTesting {
       it.shouldContainJsonKeyValue("$.system_instruction.parts[0].text", "system instruction")
     }
   }
+
+  @Test
+  fun `exception thrown when using invalid location`() = doBlocking {
+    val mockEngine = MockEngine {
+      respond(
+        """<!DOCTYPE html>
+           <html lang=en>
+            <title>Error 404 (Not Found)!!1</title>
+        """
+          .trimIndent(),
+        HttpStatusCode.NotFound,
+        headersOf(HttpHeaders.ContentType, "text/html; charset=utf-8")
+      )
+    }
+
+    val apiController =
+      APIController(
+        "super_cool_test_key",
+        "gemini-1.5-flash",
+        RequestOptions(),
+        mockEngine,
+        TEST_CLIENT_ID,
+        null,
+      )
+
+    // Creating the
+    val generativeModel =
+      GenerativeModel(
+        "projects/PROJECTID/locations/INVALID_LOCATION/publishers/google/models/gemini-1.5-flash",
+        controller = apiController
+      )
+
+    val exception = shouldThrow<ServerException> {
+      withTimeout(5.seconds) { generativeModel.generateContent("my test prompt") }
+    }
+
+    // Let's not be too strict on the wording to avoid breaking the test unnecessarily.
+    exception.message shouldContain "location"
+  }
+
 
   private fun generateContentResponseAsJsonString(text: String): String {
     return JSON.encodeToString(

--- a/firebase-vertexai/src/test/java/com/google/firebase/vertexai/GenerativeModelTesting.kt
+++ b/firebase-vertexai/src/test/java/com/google/firebase/vertexai/GenerativeModelTesting.kt
@@ -118,14 +118,14 @@ internal class GenerativeModelTesting {
         controller = apiController
       )
 
-    val exception = shouldThrow<ServerException> {
-      withTimeout(5.seconds) { generativeModel.generateContent("my test prompt") }
-    }
+    val exception =
+      shouldThrow<ServerException> {
+        withTimeout(5.seconds) { generativeModel.generateContent("my test prompt") }
+      }
 
     // Let's not be too strict on the wording to avoid breaking the test unnecessarily.
     exception.message shouldContain "location"
   }
-
 
   private fun generateContentResponseAsJsonString(text: String): String {
     return JSON.encodeToString(


### PR DESCRIPTION
If an invalid location is used when creating the `FirebaseVertexAI`
object, all requests will fail. The error returned is 404 and HTML
content. The message as-is is not easy to read.

The new messaging points to the most likely reason for the
404 (invalid location).