### PR TITLE
Replaced defaultConfig.targetSdk with testOptions.targetSdk

### DIFF
--- a/firebase-common/firebase-common.gradle.kts
+++ b/firebase-common/firebase-common.gradle.kts
@@ -32,7 +32,6 @@ android {
   namespace = "com.google.firebase"
   defaultConfig {
     minSdk = minSdkVersion
-    targetSdk = targetSdkVersion
     multiDexEnabled = true
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles("proguard.txt")
@@ -46,7 +45,11 @@ android {
     targetCompatibility = JavaVersion.VERSION_1_8
   }
   kotlinOptions { jvmTarget = "1.8" }
-  testOptions.unitTests.isIncludeAndroidResources = true
+  testOptions {
+    targetSdk = targetSdkVersion
+    unitTests { isIncludeAndroidResources = true }
+  }
+  lint { targetSdk = targetSdkVersion }
 }
 
 dependencies {

--- a/firebase-components/firebase-components.gradle.kts
+++ b/firebase-components/firebase-components.gradle.kts
@@ -23,11 +23,11 @@ android {
   val compileSdkVersion: Int by rootProject
   val targetSdkVersion: Int by rootProject
   val minSdkVersion: Int by rootProject
+
   compileSdk = compileSdkVersion
   namespace = "com.google.firebase.components"
   defaultConfig {
     minSdk = minSdkVersion
-    targetSdk = targetSdkVersion
     multiDexEnabled = true
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles("proguard.txt")
@@ -36,7 +36,11 @@ android {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
-  testOptions.unitTests.isIncludeAndroidResources = true
+  testOptions {
+    targetSdk = targetSdkVersion
+    unitTests { isIncludeAndroidResources = true }
+  }
+  lint { targetSdk = targetSdkVersion }
 }
 
 dependencies {

--- a/firebase-components/firebase-dynamic-module-support/firebase-dynamic-module-support.gradle.kts
+++ b/firebase-components/firebase-dynamic-module-support/firebase-dynamic-module-support.gradle.kts
@@ -34,7 +34,6 @@ android {
   namespace = "com.google.firebase.dynamicloading"
   defaultConfig {
     minSdk = minSdkVersion
-    targetSdk = targetSdkVersion
     multiDexEnabled = true
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
@@ -42,7 +41,11 @@ android {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
-  testOptions.unitTests.isIncludeAndroidResources = true
+  testOptions {
+    targetSdk = targetSdkVersion
+    unitTests { isIncludeAndroidResources = true }
+  }
+  lint { targetSdk = targetSdkVersion }
 }
 
 dependencies {

--- a/firebase-config-interop/firebase-config-interop.gradle.kts
+++ b/firebase-config-interop/firebase-config-interop.gradle.kts
@@ -31,7 +31,6 @@ android {
 
   defaultConfig {
     minSdk = minSdkVersion
-    targetSdk = targetSdkVersion
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
@@ -40,6 +39,9 @@ android {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
+
+  testOptions { targetSdk = targetSdkVersion }
+  lint { targetSdk = targetSdkVersion }
 }
 
 dependencies {

--- a/firebase-config/firebase-config.gradle.kts
+++ b/firebase-config/firebase-config.gradle.kts
@@ -38,7 +38,6 @@ android {
 
   defaultConfig {
     minSdk = 21
-    targetSdk = targetSdkVersion
     multiDexEnabled = true
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
@@ -49,8 +48,14 @@ android {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
+
   kotlinOptions { jvmTarget = "1.8" }
-  testOptions.unitTests.isIncludeAndroidResources = true
+
+  testOptions {
+    targetSdk = targetSdkVersion
+    unitTests { isIncludeAndroidResources = true }
+  }
+  lint { targetSdk = targetSdkVersion }
 }
 
 dependencies {

--- a/firebase-database-collection/firebase-database-collection.gradle.kts
+++ b/firebase-database-collection/firebase-database-collection.gradle.kts
@@ -27,15 +27,14 @@ android {
   compileSdk = compileSdkVersion
 
   namespace = "com.google.firebase.database.collection"
-  defaultConfig {
-    minSdk = minSdkVersion
-    targetSdk = targetSdkVersion
-  }
+  defaultConfig { minSdk = minSdkVersion }
 
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
+  testOptions { targetSdk = targetSdkVersion }
+  lint { targetSdk = targetSdkVersion }
 }
 
 dependencies {

--- a/firebase-database/firebase-database.gradle.kts
+++ b/firebase-database/firebase-database.gradle.kts
@@ -38,7 +38,6 @@ android {
   namespace = "com.google.firebase.database"
   defaultConfig {
     minSdk = minSdkVersion
-    targetSdk = targetSdkVersion
     multiDexEnabled = true
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
@@ -56,7 +55,12 @@ android {
     kotlinOptions { jvmTarget = "1.8" }
 
     packagingOptions.resources.excludes += "META-INF/DEPENDENCIES"
-    testOptions.unitTests.isIncludeAndroidResources = true
+
+    testOptions {
+      targetSdk = targetSdkVersion
+      unitTests { isIncludeAndroidResources = true }
+    }
+    lint { targetSdk = targetSdkVersion }
   }
 }
 

--- a/firebase-dataconnect/firebase-dataconnect.gradle.kts
+++ b/firebase-dataconnect/firebase-dataconnect.gradle.kts
@@ -57,11 +57,14 @@ android {
 
   @Suppress("UnstableApiUsage")
   testOptions {
+    targetSdk = targetSdkVersion
     unitTests {
       isIncludeAndroidResources = true
       isReturnDefaultValues = true
     }
   }
+
+  lint { targetSdk = targetSdkVersion }
 
   packaging {
     resources {

--- a/firebase-functions/firebase-functions.gradle.kts
+++ b/firebase-functions/firebase-functions.gradle.kts
@@ -40,7 +40,6 @@ android {
   compileSdk = compileSdkVersion
   defaultConfig {
     minSdk = minSdkVersion
-    targetSdk = targetSdkVersion
     multiDexEnabled = true
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles("proguard.txt")
@@ -51,7 +50,11 @@ android {
     targetCompatibility = JavaVersion.VERSION_1_8
   }
   kotlinOptions { jvmTarget = "1.8" }
-  testOptions.unitTests.isIncludeAndroidResources = true
+  testOptions {
+    targetSdk = targetSdkVersion
+    unitTests { isIncludeAndroidResources = true }
+  }
+  lint { targetSdk = targetSdkVersion }
 }
 
 // Enable Kotlin "Explicit API Mode". This causes the Kotlin compiler to fail if any

--- a/firebase-sessions/firebase-sessions.gradle.kts
+++ b/firebase-sessions/firebase-sessions.gradle.kts
@@ -39,7 +39,6 @@ android {
   compileSdk = compileSdkVersion
   defaultConfig {
     minSdk = minSdkVersion
-    targetSdk = targetSdkVersion
     multiDexEnabled = true
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
@@ -48,7 +47,11 @@ android {
     targetCompatibility = JavaVersion.VERSION_1_8
   }
   kotlinOptions { jvmTarget = "1.8" }
-  testOptions.unitTests.isIncludeAndroidResources = true
+  testOptions {
+    targetSdk = targetSdkVersion
+    unitTests { isIncludeAndroidResources = true }
+  }
+  lint { targetSdk = targetSdkVersion }
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KaptGenerateStubs::class.java).configureEach {

--- a/firebase-vertexai/firebase-vertexai.gradle.kts
+++ b/firebase-vertexai/firebase-vertexai.gradle.kts
@@ -41,7 +41,6 @@ android {
   compileSdk = 34
   defaultConfig {
     minSdk = 21
-    targetSdk = 34
     consumerProguardFiles("consumer-rules.pro")
     multiDexEnabled = true
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -58,9 +57,13 @@ android {
   }
   kotlinOptions { jvmTarget = "1.8" }
   testOptions {
-    unitTests.isIncludeAndroidResources = true
-    unitTests.isReturnDefaultValues = true
+    targetSdk = targetSdkVersion
+    unitTests {
+      isIncludeAndroidResources = true
+      isReturnDefaultValues = true
+    }
   }
+  lint { targetSdk = targetSdkVersion }
 }
 
 // Enable Kotlin "Explicit API Mode". This causes the Kotlin compiler to fail if any


### PR DESCRIPTION
`targetSdk` has been moved out of `defaultConfig` for libraries, and should be declared inside `testOptions` and/or `lint`

NO_RELEASE_CHANGE