### PR TITLE
dataconnect: GrpcMetadataIntegrationTest.kt: Fix race condition waiting for auth/appcheck to be ready

### DIFF
--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/GrpcMetadataIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/GrpcMetadataIntegrationTest.kt
@@ -23,6 +23,7 @@ import com.google.android.gms.tasks.Tasks
 import com.google.firebase.appcheck.AppCheckProvider
 import com.google.firebase.appcheck.AppCheckProviderFactory
 import com.google.firebase.appcheck.FirebaseAppCheck
+import com.google.firebase.dataconnect.core.FirebaseDataConnectInternal
 import com.google.firebase.dataconnect.generated.GeneratedConnector
 import com.google.firebase.dataconnect.generated.GeneratedMutation
 import com.google.firebase.dataconnect.generated.GeneratedQuery
@@ -137,6 +138,7 @@ class GrpcMetadataIntegrationTest : DataConnectIntegrationTestBase() {
   fun executeQueryShouldNotSendAuthMetadataWhenNotLoggedIn() = runTest {
     val grpcServer = inProcessDataConnectGrpcServer.newInstance()
     val dataConnect = dataConnectFactory.newInstance(grpcServer)
+    (dataConnect as FirebaseDataConnectInternal).awaitAuthReady()
     val queryRef = dataConnect.query("qryfyk7yfppfe", Unit, serializer<Unit>(), serializer<Unit>())
     val metadatasJob = async { grpcServer.metadatas.first() }
 
@@ -149,6 +151,7 @@ class GrpcMetadataIntegrationTest : DataConnectIntegrationTestBase() {
   fun executeMutationShouldNotSendAuthMetadataWhenNotLoggedIn() = runTest {
     val grpcServer = inProcessDataConnectGrpcServer.newInstance()
     val dataConnect = dataConnectFactory.newInstance(grpcServer)
+    (dataConnect as FirebaseDataConnectInternal).awaitAuthReady()
     val mutationRef =
       dataConnect.mutation("mutckjpte9v9j", Unit, serializer<Unit>(), serializer<Unit>())
     val metadatasJob = async { grpcServer.metadatas.first() }
@@ -162,6 +165,7 @@ class GrpcMetadataIntegrationTest : DataConnectIntegrationTestBase() {
   fun executeQueryShouldSendAuthMetadataWhenLoggedIn() = runTest {
     val grpcServer = inProcessDataConnectGrpcServer.newInstance()
     val dataConnect = dataConnectFactory.newInstance(grpcServer)
+    (dataConnect as FirebaseDataConnectInternal).awaitAuthReady()
     val queryRef = dataConnect.query("qryyarwrxe2fv", Unit, serializer<Unit>(), serializer<Unit>())
     val metadatasJob = async { grpcServer.metadatas.first() }
     firebaseAuthSignIn(dataConnect)
@@ -175,6 +179,7 @@ class GrpcMetadataIntegrationTest : DataConnectIntegrationTestBase() {
   fun executeMutationShouldSendAuthMetadataWhenLoggedIn() = runTest {
     val grpcServer = inProcessDataConnectGrpcServer.newInstance()
     val dataConnect = dataConnectFactory.newInstance(grpcServer)
+    (dataConnect as FirebaseDataConnectInternal).awaitAuthReady()
     val mutationRef =
       dataConnect.mutation("mutayn7as5k7d", Unit, serializer<Unit>(), serializer<Unit>())
     val metadatasJob = async { grpcServer.metadatas.first() }
@@ -189,6 +194,7 @@ class GrpcMetadataIntegrationTest : DataConnectIntegrationTestBase() {
   fun executeQueryShouldNotSendAuthMetadataAfterLogout() = runTest {
     val grpcServer = inProcessDataConnectGrpcServer.newInstance()
     val dataConnect = dataConnectFactory.newInstance(grpcServer)
+    (dataConnect as FirebaseDataConnectInternal).awaitAuthReady()
     val queryRef = dataConnect.query("qryyarwrxe2fv", Unit, serializer<Unit>(), serializer<Unit>())
     val metadatasJob1 = async { grpcServer.metadatas.first() }
     val metadatasJob2 = async { grpcServer.metadatas.take(2).last() }
@@ -206,6 +212,7 @@ class GrpcMetadataIntegrationTest : DataConnectIntegrationTestBase() {
   fun executeMutationShouldNotSendAuthMetadataAfterLogout() = runTest {
     val grpcServer = inProcessDataConnectGrpcServer.newInstance()
     val dataConnect = dataConnectFactory.newInstance(grpcServer)
+    (dataConnect as FirebaseDataConnectInternal).awaitAuthReady()
     val mutationRef =
       dataConnect.mutation("mutvw945ag3vv", Unit, serializer<Unit>(), serializer<Unit>())
     val metadatasJob1 = async { grpcServer.metadatas.first() }
@@ -226,6 +233,7 @@ class GrpcMetadataIntegrationTest : DataConnectIntegrationTestBase() {
     // appcheck token is sent at all.
     val grpcServer = inProcessDataConnectGrpcServer.newInstance()
     val dataConnect = dataConnectFactory.newInstance(grpcServer)
+    (dataConnect as FirebaseDataConnectInternal).awaitAppCheckReady()
     val queryRef = dataConnect.query("qrybbeekpkkck", Unit, serializer<Unit>(), serializer<Unit>())
     val metadatasJob = async { grpcServer.metadatas.first() }
 
@@ -240,6 +248,7 @@ class GrpcMetadataIntegrationTest : DataConnectIntegrationTestBase() {
     // appcheck token is sent at all.
     val grpcServer = inProcessDataConnectGrpcServer.newInstance()
     val dataConnect = dataConnectFactory.newInstance(grpcServer)
+    (dataConnect as FirebaseDataConnectInternal).awaitAppCheckReady()
     val mutationRef =
       dataConnect.mutation("mutbs7hhxk39c", Unit, serializer<Unit>(), serializer<Unit>())
     val metadatasJob = async { grpcServer.metadatas.first() }
@@ -253,6 +262,7 @@ class GrpcMetadataIntegrationTest : DataConnectIntegrationTestBase() {
   fun executeQueryShouldSendAppCheckMetadataWhenAppCheckIsEnabled() = runTest {
     val grpcServer = inProcessDataConnectGrpcServer.newInstance()
     val dataConnect = dataConnectFactory.newInstance(grpcServer)
+    (dataConnect as FirebaseDataConnectInternal).awaitAppCheckReady()
     val queryRef = dataConnect.query("qryyarwrxe2fv", Unit, serializer<Unit>(), serializer<Unit>())
     val metadatasJob = async { grpcServer.metadatas.first() }
     val appCheck = FirebaseAppCheck.getInstance(dataConnect.app)
@@ -267,6 +277,7 @@ class GrpcMetadataIntegrationTest : DataConnectIntegrationTestBase() {
   fun executeMutationShouldSendAppCheckMetadataWhenAppCheckIsEnabled() = runTest {
     val grpcServer = inProcessDataConnectGrpcServer.newInstance()
     val dataConnect = dataConnectFactory.newInstance(grpcServer)
+    (dataConnect as FirebaseDataConnectInternal).awaitAppCheckReady()
     val mutationRef =
       dataConnect.mutation("mutz4hzqzpgb4", Unit, serializer<Unit>(), serializer<Unit>())
     val metadatasJob = async { grpcServer.metadatas.first() }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectCredentialsTokenManager.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectCredentialsTokenManager.kt
@@ -45,6 +45,9 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
 
@@ -57,6 +60,9 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, L : Any>(
 ) {
   val instanceId: String
     get() = logger.nameWithId
+
+  private val _providerAvailable = MutableStateFlow(false)
+  val providerAvailable: StateFlow<Boolean> = _providerAvailable.asStateFlow()
 
   @Suppress("LeakingThis") private val weakThis = WeakReference(this)
 
@@ -448,6 +454,8 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, L : Any>(
         break
       }
     }
+
+    _providerAvailable.value = true
   }
 
   /**

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImpl.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImpl.kt
@@ -54,6 +54,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -72,6 +74,9 @@ internal interface FirebaseDataConnectInternal : FirebaseDataConnect {
 
   val lazyGrpcClient: SuspendingLazy<DataConnectGrpcClient>
   val lazyQueryManager: SuspendingLazy<QueryManager>
+
+  suspend fun awaitAuthReady()
+  suspend fun awaitAppCheckReady()
 }
 
 internal class FirebaseDataConnectImpl(
@@ -107,10 +112,17 @@ internal class FirebaseDataConnectImpl(
       SupervisorJob() +
         nonBlockingDispatcher +
         CoroutineName(instanceId) +
-        CoroutineExceptionHandler { _, throwable ->
-          logger.warn(throwable) { "uncaught exception from a coroutine" }
+        CoroutineExceptionHandler { context, throwable ->
+          logger.warn(throwable) {
+            val coroutineName = context[CoroutineName]?.name
+            "WARNING: uncaught exception from coroutine named \"$coroutineName\" " +
+              "(error code jszxcbe37k)"
+          }
         }
     )
+
+  private val authProviderAvailable = MutableStateFlow(false)
+  private val appCheckProviderAvailable = MutableStateFlow(false)
 
   // Protects `closed`, `grpcClient`, `emulatorSettings`, and `queryManager`.
   private val mutex = Mutex()
@@ -121,29 +133,49 @@ internal class FirebaseDataConnectImpl(
   // All accesses to this variable _must_ have locked `mutex`.
   private var closed = false
 
-  private val lazyDataConnectAuth =
-    SuspendingLazy(mutex) {
-      if (closed) throw IllegalStateException("FirebaseDataConnect instance has been closed")
-      DataConnectAuth(
-          deferredAuthProvider = deferredAuthProvider,
-          parentCoroutineScope = coroutineScope,
-          blockingDispatcher = blockingDispatcher,
-          logger = Logger("DataConnectAuth").apply { debug { "created by $instanceId" } },
-        )
-        .apply { initialize() }
-    }
+  private val dataConnectAuth: DataConnectAuth =
+    DataConnectAuth(
+      deferredAuthProvider = deferredAuthProvider,
+      parentCoroutineScope = coroutineScope,
+      blockingDispatcher = blockingDispatcher,
+      logger = Logger("DataConnectAuth").apply { debug { "created by $instanceId" } },
+    )
 
-  private val lazyDataConnectAppCheck =
-    SuspendingLazy(mutex) {
-      if (closed) throw IllegalStateException("FirebaseDataConnect instance has been closed")
-      DataConnectAppCheck(
-          deferredAppCheckTokenProvider = deferredAppCheckProvider,
-          parentCoroutineScope = coroutineScope,
-          blockingDispatcher = blockingDispatcher,
-          logger = Logger("DataConnectAppCheck").apply { debug { "created by $instanceId" } },
-        )
-        .apply { initialize() }
+  override suspend fun awaitAuthReady() {
+    authProviderAvailable.first { it }
+  }
+
+  init {
+    coroutineScope.launch(CoroutineName("DataConnectAuth initializer for $instanceId")) {
+      dataConnectAuth.initialize()
+      dataConnectAuth.providerAvailable.collect { isProviderAvailable ->
+        logger.debug { "authProviderAvailable=$isProviderAvailable" }
+        authProviderAvailable.value = isProviderAvailable
+      }
     }
+  }
+
+  private val dataConnectAppCheck: DataConnectAppCheck =
+    DataConnectAppCheck(
+      deferredAppCheckTokenProvider = deferredAppCheckProvider,
+      parentCoroutineScope = coroutineScope,
+      blockingDispatcher = blockingDispatcher,
+      logger = Logger("DataConnectAppCheck").apply { debug { "created by $instanceId" } },
+    )
+
+  override suspend fun awaitAppCheckReady() {
+    appCheckProviderAvailable.first { it }
+  }
+
+  init {
+    coroutineScope.launch(CoroutineName("DataConnectAppCheck initializer for $instanceId")) {
+      dataConnectAppCheck.initialize()
+      dataConnectAppCheck.providerAvailable.collect { isProviderAvailable ->
+        logger.debug { "appCheckProviderAvailable=$isProviderAvailable" }
+        appCheckProviderAvailable.value = isProviderAvailable
+      }
+    }
+  }
 
   private val lazyGrpcRPCs =
     SuspendingLazy(mutex) {
@@ -181,8 +213,8 @@ internal class FirebaseDataConnectImpl(
       val grpcMetadata =
         DataConnectGrpcMetadata.forSystemVersions(
           firebaseApp = app,
-          dataConnectAuth = lazyDataConnectAuth.getLocked(),
-          dataConnectAppCheck = lazyDataConnectAppCheck.getLocked(),
+          dataConnectAuth = dataConnectAuth,
+          dataConnectAppCheck = dataConnectAppCheck,
           connectorLocation = config.location,
           parentLogger = logger,
         )
@@ -210,8 +242,8 @@ internal class FirebaseDataConnectImpl(
         projectId = projectId,
         connector = config,
         grpcRPCs = lazyGrpcRPCs.getLocked(),
-        dataConnectAuth = lazyDataConnectAuth.getLocked(),
-        dataConnectAppCheck = lazyDataConnectAppCheck.getLocked(),
+        dataConnectAuth = dataConnectAuth,
+        dataConnectAppCheck = dataConnectAppCheck,
         logger = Logger("DataConnectGrpcClient").apply { debug { "created by $instanceId" } },
       )
     }
@@ -397,8 +429,8 @@ internal class FirebaseDataConnectImpl(
 
     // Close Auth and AppCheck synchronously to avoid race conditions with auth callbacks.
     // Since close() is re-entrant, this is safe even if they have already been closed.
-    lazyDataConnectAuth.initializedValueOrNull?.close()
-    lazyDataConnectAppCheck.initializedValueOrNull?.close()
+    dataConnectAuth.close()
+    dataConnectAppCheck.close()
 
     // Start the job to asynchronously close the gRPC client.
     while (true) {

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImplUnitTest.kt
@@ -16,11 +16,19 @@
 package com.google.firebase.dataconnect.core
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.firebase.appcheck.interop.InteropAppCheckTokenProvider
+import com.google.firebase.auth.internal.InternalAuthProvider
 import com.google.firebase.dataconnect.FirebaseDataConnect.CallerSdkType
+import com.google.firebase.dataconnect.testutil.CleanupsRule
 import com.google.firebase.dataconnect.testutil.DataConnectLogLevelRule
+import com.google.firebase.dataconnect.testutil.DelayedDeferred
 import com.google.firebase.dataconnect.testutil.FirebaseAppUnitTestingRule
+import com.google.firebase.dataconnect.testutil.RandomSeedTestRule
+import com.google.firebase.dataconnect.testutil.UnavailableDeferred
+import com.google.firebase.dataconnect.testutil.delayIgnoringTestScheduler
 import com.google.firebase.dataconnect.testutil.property.arbitrary.dataConnect
 import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.withClue
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
@@ -28,13 +36,16 @@ import io.kotest.property.Arb
 import io.kotest.property.RandomSource
 import io.kotest.property.arbitrary.enum
 import io.kotest.property.arbitrary.next
-import io.kotest.property.arbitrary.string
 import io.mockk.mockk
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asExecutor
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.modules.SerializersModule
-import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -44,6 +55,11 @@ class FirebaseDataConnectImplUnitTest {
 
   @get:Rule val dataConnectLogLevelRule = DataConnectLogLevelRule()
 
+  @get:Rule val cleanups = CleanupsRule()
+
+  @get:Rule val randomSeedTestRule = RandomSeedTestRule()
+  private val rs: RandomSource by randomSeedTestRule.rs
+
   @get:Rule
   val firebaseAppFactory =
     FirebaseAppUnitTestingRule(
@@ -52,33 +68,11 @@ class FirebaseDataConnectImplUnitTest {
       projectIdKey = "a988y548hz",
     )
 
-  private val rs = RandomSource.default()
-  private val dataConnect: FirebaseDataConnectImpl by lazy {
-    val app = firebaseAppFactory.newInstance()
-
-    FirebaseDataConnectImpl(
-      context = app.applicationContext,
-      app = app,
-      projectId = app.options.projectId!!,
-      config = Arb.dataConnect.connectorConfig().next(rs),
-      blockingExecutor = mockk(relaxed = true),
-      nonBlockingExecutor = mockk(relaxed = true),
-      deferredAuthProvider = mockk(relaxed = true),
-      deferredAppCheckProvider = mockk(relaxed = true),
-      creator = mockk(relaxed = true),
-      settings = Arb.dataConnect.dataConnectSettings().next(rs),
-    )
-  }
-
-  @After
-  fun closeDataConnect() {
-    dataConnect.close()
-  }
-
   @Test
   fun `query() with no options set should use null for each option`() = runTest {
+    val dataConnect = newDataConnect()
     val operationName = Arb.dataConnect.operationName().next(rs)
-    val variables = TestVariables(Arb.string(size = 8).next(rs))
+    val variables: TestVariables = mockk()
     val dataDeserializer: DeserializationStrategy<TestData> = mockk()
     val variablesSerializer: SerializationStrategy<TestVariables> = mockk()
 
@@ -103,8 +97,9 @@ class FirebaseDataConnectImplUnitTest {
 
   @Test
   fun `query() with all options specified should use the given options`() = runTest {
+    val dataConnect = newDataConnect()
     val operationName = Arb.dataConnect.operationName().next(rs)
-    val variables = TestVariables(Arb.string(size = 8).next(rs))
+    val variables: TestVariables = mockk()
     val dataDeserializer: DeserializationStrategy<TestData> = mockk()
     val variablesSerializer: SerializationStrategy<TestVariables> = mockk()
     val callerSdkType = Arb.enum<CallerSdkType>().next()
@@ -136,8 +131,9 @@ class FirebaseDataConnectImplUnitTest {
 
   @Test
   fun `mutation() with no options set should use null for each option`() = runTest {
+    val dataConnect = newDataConnect()
     val operationName = Arb.dataConnect.operationName().next(rs)
-    val variables = TestVariables(Arb.string(size = 8).next(rs))
+    val variables: TestVariables = mockk()
     val dataDeserializer: DeserializationStrategy<TestData> = mockk()
     val variablesSerializer: SerializationStrategy<TestVariables> = mockk()
 
@@ -162,8 +158,9 @@ class FirebaseDataConnectImplUnitTest {
 
   @Test
   fun `mutation() with all options specified should use the given options`() = runTest {
+    val dataConnect = newDataConnect()
     val operationName = Arb.dataConnect.operationName().next(rs)
-    val variables = TestVariables(Arb.string(size = 8).next(rs))
+    val variables: TestVariables = mockk()
     val dataDeserializer: DeserializationStrategy<TestData> = mockk()
     val variablesSerializer: SerializationStrategy<TestVariables> = mockk()
     val callerSdkType = Arb.enum<CallerSdkType>().next()
@@ -193,7 +190,76 @@ class FirebaseDataConnectImplUnitTest {
     }
   }
 
-  private data class TestVariables(val foo: String)
+  @Test
+  fun `awaitAuthReady() should return once the provider is available`() {
+    val deferredAuthProvider = DelayedDeferred<InternalAuthProvider>(mockk(relaxed = true))
+    val dataConnect =
+      newDataConnect(
+        deferredAuthProvider = deferredAuthProvider,
+        deferredAppCheckProvider = UnavailableDeferred(),
+      )
+    awaitReadyTest("awaitAuthReady", deferredAuthProvider) { dataConnect.awaitAuthReady() }
+  }
 
-  private data class TestData(val bar: String)
+  @Test
+  fun `awaitAppCheckReady() should return once the provider is available`() {
+    val deferredAppCheckProvider =
+      DelayedDeferred<InteropAppCheckTokenProvider>(mockk(relaxed = true))
+    val dataConnect =
+      newDataConnect(
+        deferredAuthProvider = UnavailableDeferred(),
+        deferredAppCheckProvider = deferredAppCheckProvider,
+      )
+    awaitReadyTest("awaitAppCheckReady", deferredAppCheckProvider) {
+      dataConnect.awaitAppCheckReady()
+    }
+  }
+
+  private fun awaitReadyTest(
+    functionName: String,
+    delayedDeferred: DelayedDeferred<*>,
+    block: suspend () -> Unit
+  ) =
+    runTest(timeout = 60.seconds) {
+      val job = launch { block() }
+
+      repeat(5) {
+        delayIgnoringTestScheduler(100.milliseconds)
+        withClue("job.isCompleted iteration $it") { job.isCompleted shouldBe false }
+      }
+
+      delayedDeferred.makeAvailable()
+
+      backgroundScope.launch {
+        delayIgnoringTestScheduler(20.seconds)
+        throw Exception("timeout waiting for $functionName() to return")
+      }
+
+      job.join()
+    }
+
+  private fun newDataConnect(
+    deferredAuthProvider: com.google.firebase.inject.Deferred<InternalAuthProvider> =
+      mockk(relaxed = true),
+    deferredAppCheckProvider: com.google.firebase.inject.Deferred<InteropAppCheckTokenProvider> =
+      mockk(relaxed = true),
+  ): FirebaseDataConnectImpl {
+    val app = firebaseAppFactory.newInstance()
+    return FirebaseDataConnectImpl(
+        context = app.applicationContext,
+        app = app,
+        projectId = app.options.projectId!!,
+        config = Arb.dataConnect.connectorConfig().next(rs),
+        blockingExecutor = Dispatchers.IO.asExecutor(),
+        nonBlockingExecutor = Dispatchers.Default.asExecutor(),
+        deferredAuthProvider = deferredAuthProvider,
+        deferredAppCheckProvider = deferredAppCheckProvider,
+        creator = mockk(relaxed = true),
+        settings = Arb.dataConnect.dataConnectSettings().next(rs),
+      )
+      .also { cleanups.register("close FirebaseDataConnectImpl") { it.close() } }
+  }
+
+  private interface TestVariables
+  private interface TestData
 }

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/CleanupsRule.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/CleanupsRule.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.firebase.dataconnect.testutil
+
+import android.util.Log
+import io.kotest.common.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.junit.rules.ExternalResource
+
+/**
+ * A JUnit test rule that allows tests to register "cleanups" to be run on test completion. If any
+ * one cleanup throws an exception then the exception will be logged and the rest of the cleanups
+ * will be executed, finally throwing the exception of the first failed cleanup. Cleanups will be
+ * executed in the opposite order in which they are registered. Instances are thread-safe and
+ * cleanups may be registered concurrently from multiple threads.
+ */
+class CleanupsRule : ExternalResource() {
+
+  private val mutex = Mutex()
+  private var beforeCalled = false
+  private var afterCalled = false
+  private val cleanups = mutableListOf<Cleanup>()
+
+  /**
+   * Registers a cleanup. This function potentially blocks briefly while acquiring the lock on the
+   * list of cleanups. Throws an exception if called before [before] or after [after] has started.
+   */
+  fun register(name: String? = null, cleanup: suspend () -> Unit) = runBlocking {
+    registerSuspending(name, cleanup)
+  }
+
+  /**
+   * Registers a cleanup. This function potentially suspends while acquiring the lock on the list of
+   * cleanups. Throws an exception if called before [before] or after [after] has started.
+   */
+  suspend fun registerSuspending(name: String? = null, cleanup: suspend () -> Unit) {
+    mutex.withLock {
+      check(beforeCalled) {
+        "cleanups can not be registered until before() is called " + "(error code 3yrwbehmvk)"
+      }
+
+      check(!afterCalled) {
+        "cleanups can not be registered after after() has started " + "(error code dw92ms797f)"
+      }
+
+      cleanups.add(Cleanup(name, cleanup))
+    }
+  }
+
+  override fun before(): Unit = runBlocking {
+    mutex.withLock {
+      check(!beforeCalled) { "before() has already been called (error code hg4a8ab5ve)" }
+      beforeCalled = true
+    }
+  }
+
+  override fun after(): Unit = runBlocking {
+    mutex.withLock {
+      check(!afterCalled) { "after() has already been called (error code brewwkxs6g)" }
+      afterCalled = true
+    }
+
+    var firstException: Throwable? = null
+
+    while (true) {
+      val cleanup = mutex.withLock { cleanups.removeLastOrNull() } ?: break
+
+      val result = cleanup.runCatching { action() }
+      result.onFailure {
+        Log.e("CleanupsRule", "cleanup ${cleanup.name} failed: $it", it)
+        if (firstException === null) {
+          firstException = it
+        }
+      }
+    }
+
+    firstException?.let { throw it }
+  }
+
+  private data class Cleanup(val name: String?, val action: suspend () -> Unit)
+}


### PR DESCRIPTION
This PR fixes a race condition in `GrpcMetadataIntegrationTest.kt` where the query/mutation may be sent before the Auth and/or AppCheck provider was registered, which is done asynchronously. This race condition resulted in flaky tests. We _may_ want to expose this functionality to customers if they run into similar issues.

For the record, the test case failures look like this:

```
failed: executeQueryShouldSendAppCheckMetadataWhenAppCheckIsEnabled(com.google.firebase.dataconnect.GrpcMetadataIntegrationTest)
java.lang.AssertionError: key=Key{name='x-firebase-appcheck'}, metadata=Metadata(user-agent=grpc-java-okhttp/1.62.2,content-type=application/grpc,te=trailers,x-goog-request-params=location=TestLocationr24xs74t3s&frontend=data,x-goog-api-client=gl-kotlin/1.8.22 gl-android/35 fire/16.0.0-beta03 grpc/,x-firebase-gmpid=1:12345678901:android:1234567890abcdef123456,grpc-accept-encoding=gzip)
Expected "7gwvj8c4xy" but actual was null
 	at com.google.firebase.dataconnect.GrpcMetadataIntegrationTest.verifyMetadataContains(GrpcMetadataIntegrationTest.kt:292)

failed: executeMutationShouldSendAuthMetadataWhenLoggedIn(com.google.firebase.dataconnect.GrpcMetadataIntegrationTest)
java.lang.AssertionError: key=Key{name='x-firebase-auth-token'}, metadata=Metadata(user-agent=grpc-java-okhttp/1.62.2,content-type=application/grpc,te=trailers,x-goog-request-params=location=TestLocationxbjfp54tnt&frontend=data,x-goog-api-client=gl-kotlin/1.8.22 gl-android/35 fire/16.0.0-beta03 grpc/,x-firebase-gmpid=1:12345678901:android:1234567890abcdef123456,x-firebase-appcheck=eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==,grpc-accept-encoding=gzip)
Expected value to not be null, but was null.
	at com.google.firebase.dataconnect.GrpcMetadataIntegrationTest.verifyMetadataContains(GrpcMetadataIntegrationTest.kt:290)

failed: executeQueryShouldNotSendAuthMetadataAfterLogout(com.google.firebase.dataconnect.GrpcMetadataIntegrationTest)
java.lang.AssertionError: key=Key{name='x-firebase-auth-token'}, metadata=Metadata(user-agent=grpc-java-okhttp/1.62.2,content-type=application/grpc,te=trailers,x-goog-request-params=location=TestLocationjf5zs743ev&frontend=data,x-goog-api-client=gl-kotlin/1.8.22 gl-android/35 fire/16.0.0-beta03 grpc/,x-firebase-gmpid=1:12345678901:android:1234567890abcdef123456,grpc-accept-encoding=gzip)
Expected value to not be null, but was null.
	at com.google.firebase.dataconnect.GrpcMetadataIntegrationTest.verifyMetadataContains(GrpcMetadataIntegrationTest.kt:290)
```