### PR TITLE
dataconnect: TestFirebaseAppFactory.kt: work around IllegalStateException in tests by adding a delay before calling FirebaseApp.delete()

### DIFF
--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
@@ -552,43 +552,6 @@ class DataConnectAuthUnitTest {
       )
     }
 
-  @Test
-  fun `addIdTokenListener() throwing IllegalStateException due to FirebaseApp deleted should be ignored`() =
-    runTest {
-      every { mockInternalAuthProvider.addIdTokenListener(any()) } throws
-        firebaseAppDeletedException
-      coEvery { mockInternalAuthProvider.getAccessToken(any()) } returns taskForToken(accessToken)
-      val dataConnectAuth = newDataConnectAuth()
-      dataConnectAuth.initialize()
-      advanceUntilIdle()
-
-      eventually(`check every 100 milliseconds for 2 seconds`) {
-        mockLogger.shouldHaveLoggedExactlyOneMessageContaining(
-          "ignoring exception: $firebaseAppDeletedException"
-        )
-      }
-      val result = dataConnectAuth.getToken(requestId)
-      withClue("result=$result") { result shouldBe accessToken }
-    }
-
-  @Test
-  fun `removeIdTokenListener() throwing IllegalStateException due to FirebaseApp deleted should be ignored`() =
-    runTest {
-      every { mockInternalAuthProvider.removeIdTokenListener(any()) } throws
-        firebaseAppDeletedException
-      val dataConnectAuth = newDataConnectAuth()
-      dataConnectAuth.initialize()
-      advanceUntilIdle()
-
-      dataConnectAuth.close()
-
-      eventually(`check every 100 milliseconds for 2 seconds`) {
-        mockLogger.shouldHaveLoggedExactlyOneMessageContaining(
-          "ignoring exception: $firebaseAppDeletedException"
-        )
-      }
-    }
-
   private fun TestScope.newDataConnectAuth(
     deferredInternalAuthProvider: DeferredInternalAuthProvider =
       ImmediateDeferred(mockInternalAuthProvider),


### PR DESCRIPTION
This PR fixes a race condition in the Data Connect tests where if a `FirebaseApp` is deleted very shortly after creating it then an IllegalStateException can be thrown, crashing the test app entirely, resulting in a flaky test.

The "fix" is really a "workaround", in that it waits for 1 second before calling `FirebaseApp.delete()` to minimize the chances that the FirebaseAuth worker thread will try to access the deleted FirebaseApp instance. Googlers see b/378116261 for details.

The crash fixed by this PR looks like this:

```
FATAL EXCEPTION: TokenRefresher
Process: com.google.firebase.dataconnect.connectors.test, PID: 7058
java.lang.IllegalStateException: FirebaseApp with name test-app-nwdpj3757g doesn't exist. Available app names: [DEFAULT]
  at com.google.firebase.FirebaseApp.getInstance(FirebaseApp.java:212)
  at com.google.firebase.auth.internal.zzat.run(com.google.firebase:firebase-auth@@22.3.1:4)                                
  at android.os.Handler.handleCallback(Handler.java:958)                                                         
  at android.os.Handler.dispatchMessage(Handler.java:99)                                         
  at android.os.Looper.loopOnce(Looper.java:205)                                                                             
  at android.os.Looper.loop(Looper.java:294)                                                                        
  at android.os.HandlerThread.run(HandlerThread.java:67)    
```