### PR TITLE
dataconnect: DataConnectCredentialsTokenManager: initialize synchronously to fix race condition

### DIFF
--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/AuthIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/AuthIntegrationTest.kt
@@ -17,6 +17,7 @@
 package com.google.firebase.dataconnect
 
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.dataconnect.core.FirebaseDataConnectInternal
 import com.google.firebase.dataconnect.testutil.DataConnectBackend
 import com.google.firebase.dataconnect.testutil.DataConnectIntegrationTestBase
 import com.google.firebase.dataconnect.testutil.InProcessDataConnectGrpcServer
@@ -201,6 +202,7 @@ class AuthIntegrationTest : DataConnectIntegrationTestBase() {
   }
 
   private suspend fun signIn() {
+    (personSchema.dataConnect as FirebaseDataConnectInternal).awaitAuthReady()
     val authResult = auth.run { signInAnonymously().await() }
     withClue("authResult.user returned from signInAnonymously()") {
       authResult.user.shouldNotBeNull()

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAppCheck.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAppCheck.kt
@@ -32,24 +32,20 @@ internal class DataConnectAppCheck(
   blockingDispatcher: CoroutineDispatcher,
   logger: Logger,
 ) :
-  DataConnectCredentialsTokenManager<InteropAppCheckTokenProvider, AppCheckTokenListener>(
+  DataConnectCredentialsTokenManager<InteropAppCheckTokenProvider>(
     deferredProvider = deferredAppCheckTokenProvider,
     parentCoroutineScope = parentCoroutineScope,
     blockingDispatcher = blockingDispatcher,
     logger = logger,
   ) {
-  override fun newTokenListener(): AppCheckTokenListener = AppCheckTokenListenerImpl(logger)
+  private val appCheckTokenListener = AppCheckTokenListenerImpl(logger)
 
   @DeferredApi
-  override fun addTokenListener(
-    provider: InteropAppCheckTokenProvider,
-    listener: AppCheckTokenListener
-  ) = provider.addAppCheckTokenListener(listener)
+  override fun addTokenListener(provider: InteropAppCheckTokenProvider) =
+    provider.addAppCheckTokenListener(appCheckTokenListener)
 
-  override fun removeTokenListener(
-    provider: InteropAppCheckTokenProvider,
-    listener: AppCheckTokenListener
-  ) = provider.removeAppCheckTokenListener(listener)
+  override fun removeTokenListener(provider: InteropAppCheckTokenProvider) =
+    provider.removeAppCheckTokenListener(appCheckTokenListener)
 
   override suspend fun getToken(provider: InteropAppCheckTokenProvider, forceRefresh: Boolean) =
     provider.getToken(forceRefresh).await().let { GetTokenResult(it.token) }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAuth.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAuth.kt
@@ -32,20 +32,20 @@ internal class DataConnectAuth(
   blockingDispatcher: CoroutineDispatcher,
   logger: Logger,
 ) :
-  DataConnectCredentialsTokenManager<InternalAuthProvider, IdTokenListener>(
+  DataConnectCredentialsTokenManager<InternalAuthProvider>(
     deferredProvider = deferredAuthProvider,
     parentCoroutineScope = parentCoroutineScope,
     blockingDispatcher = blockingDispatcher,
     logger = logger,
   ) {
-  override fun newTokenListener(): IdTokenListener = IdTokenListenerImpl(logger)
+  private val idTokenListener = IdTokenListenerImpl(logger)
 
   @DeferredApi
-  override fun addTokenListener(provider: InternalAuthProvider, listener: IdTokenListener) =
-    provider.addIdTokenListener(listener)
+  override fun addTokenListener(provider: InternalAuthProvider) =
+    provider.addIdTokenListener(idTokenListener)
 
-  override fun removeTokenListener(provider: InternalAuthProvider, listener: IdTokenListener) =
-    provider.removeIdTokenListener(listener)
+  override fun removeTokenListener(provider: InternalAuthProvider) =
+    provider.removeIdTokenListener(idTokenListener)
 
   override suspend fun getToken(provider: InternalAuthProvider, forceRefresh: Boolean) =
     provider.getAccessToken(forceRefresh).await().let { GetTokenResult(it.token) }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImpl.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImpl.kt
@@ -86,9 +86,8 @@ internal class FirebaseDataConnectImpl(
   override val config: ConnectorConfig,
   override val blockingExecutor: Executor,
   override val nonBlockingExecutor: Executor,
-  private val deferredAuthProvider: com.google.firebase.inject.Deferred<InternalAuthProvider>,
-  private val deferredAppCheckProvider:
-    com.google.firebase.inject.Deferred<InteropAppCheckTokenProvider>,
+  deferredAuthProvider: com.google.firebase.inject.Deferred<InternalAuthProvider>,
+  deferredAppCheckProvider: com.google.firebase.inject.Deferred<InteropAppCheckTokenProvider>,
   private val creator: FirebaseDataConnectFactory,
   override val settings: DataConnectSettings,
 ) : FirebaseDataConnectInternal {
@@ -146,8 +145,8 @@ internal class FirebaseDataConnectImpl(
   }
 
   init {
-    coroutineScope.launch(CoroutineName("DataConnectAuth initializer for $instanceId")) {
-      dataConnectAuth.initialize()
+    val name = CoroutineName("DataConnectAuth isProviderAvailable pipe for $instanceId")
+    coroutineScope.launch(name) {
       dataConnectAuth.providerAvailable.collect { isProviderAvailable ->
         logger.debug { "authProviderAvailable=$isProviderAvailable" }
         authProviderAvailable.value = isProviderAvailable
@@ -168,8 +167,8 @@ internal class FirebaseDataConnectImpl(
   }
 
   init {
-    coroutineScope.launch(CoroutineName("DataConnectAppCheck initializer for $instanceId")) {
-      dataConnectAppCheck.initialize()
+    val name = CoroutineName("DataConnectAppCheck isProviderAvailable pipe for $instanceId")
+    coroutineScope.launch(name) {
       dataConnectAppCheck.providerAvailable.collect { isProviderAvailable ->
         logger.debug { "appCheckProviderAvailable=$isProviderAvailable" }
         appCheckProviderAvailable.value = isProviderAvailable


### PR DESCRIPTION
This PR changes the initialization of Data Conect's "Auth" and "AppCheck" mechanisms to be more synchronous. Not only does this fix a bug introduced a few commits ago by #6446 but also simplifies the logic and reduces the amount of non-determinism.

The race condition fixed by this PR manifested only on on my MacBook laptop (not on my Linux workstation) and is simply due to arbitrary thread scheduling differences. One such test failure looked like this:

```
failed: collect_gets_notified_of_per_data_deserializer_successes(com.google.firebase.dataconnect.QuerySubscriptionIntegrationTest)
java.lang.IllegalStateException: getToken() cannot be called before initialize()
	at com.google.firebase.dataconnect.core.DataConnectCredentialsTokenManager.getToken(DataConnectCredentialsTokenManager.kt:322)
	at com.google.firebase.dataconnect.core.DataConnectGrpcMetadata.get(DataConnectGrpcMetadata.kt:80)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCs.executeMutation(DataConnectGrpcRPCs.kt:142)
	at com.google.firebase.dataconnect.core.DataConnectGrpcClient.executeMutation(DataConnectGrpcClient.kt:95)
	at com.google.firebase.dataconnect.core.MutationRefImpl.execute(MutationRefImpl.kt:65)
	at com.google.firebase.dataconnect.QuerySubscriptionIntegrationTest$collect_gets_notified_of_per_data_deserializer_successes$1.invokeSuspend(QuerySubscriptionIntegrationTest.kt:441)
	at com.google.firebase.dataconnect.QuerySubscriptionIntegrationTest$collect_gets_notified_of_per_data_deserializer_successes$1.invoke(Unknown Source:8)
	at com.google.firebase.dataconnect.QuerySubscriptionIntegrationTest$collect_gets_notified_of_per_data_deserializer_successes$1.invoke(Unknown Source:4)

```

The reason is that the DataConnectAuth object was used _before_ its initialize() method was invoked. PR #6446 changed the logic to invoke initialize() in a separate coroutine, which introduced the race condition. By getting rid of the initialize() method altogether, and simply performing the initialization in an `init` block in DataConnectAuth (and DataConnectAppCheck) this race condition is completely eliminated.