### PR TITLE
dataconnect: relax variance of the NullableReference type parameter to covariant (was invariant)

### DIFF
--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/NullableReference.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/NullableReference.kt
@@ -15,7 +15,7 @@
  */
 package com.google.firebase.dataconnect.util
 
-internal class NullableReference<T>(val ref: T? = null) {
+internal class NullableReference<out T>(val ref: T? = null) {
   override fun equals(other: Any?) = (other is NullableReference<*>) && other.ref == ref
   override fun hashCode() = ref?.hashCode() ?: 0
   override fun toString() = ref?.toString() ?: "null"

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/NullableReference.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/NullableReference.kt
@@ -15,6 +15,11 @@
  */
 package com.google.firebase.dataconnect.util
 
+/**
+ * A class that simply wraps a reference to another object, possibly a null reference. Instances of
+ * this class can be useful for the case where the meaning of `null` is overloaded, such as
+ * [kotlinx.coroutines.flow.MutableStateFlow.compareAndSet].
+ */
 internal class NullableReference<out T>(val ref: T? = null) {
   override fun equals(other: Any?) = (other is NullableReference<*>) && other.ref == ref
   override fun hashCode() = ref?.hashCode() ?: 0


### PR DESCRIPTION
This is an internal-only improvement and has no effects on customers.