### PR TITLE
dataconnect: DataConnectExecutableVersions.json updated with version 1.7.0

### DIFF
--- a/firebase-dataconnect/connectors/src/androidTest/kotlin/com/google/firebase/dataconnect/connectors/demo/KeyVariablesIntegrationTest.kt
+++ b/firebase-dataconnect/connectors/src/androidTest/kotlin/com/google/firebase/dataconnect/connectors/demo/KeyVariablesIntegrationTest.kt
@@ -19,7 +19,6 @@ package com.google.firebase.dataconnect.connectors.demo
 import com.google.firebase.dataconnect.connectors.demo.testutil.DemoConnectorIntegrationTestBase
 import com.google.firebase.dataconnect.testutil.property.arbitrary.dataConnect
 import com.google.firebase.dataconnect.testutil.property.arbitrary.dateTestData
-import com.google.firebase.dataconnect.testutil.property.arbitrary.toJavaUtilDate
 import com.google.firebase.dataconnect.testutil.randomTimestamp
 import com.google.firebase.dataconnect.testutil.withMicrosecondPrecision
 import io.kotest.matchers.shouldBe
@@ -86,7 +85,7 @@ class KeyVariablesIntegrationTest : DemoConnectorIntegrationTestBase() {
 
   @Test
   fun primaryKeyIsDate() = runTest {
-    val id = Arb.dataConnect.dateTestData().next(rs).toJavaUtilDate()
+    val id = Arb.dataConnect.dateTestData().next(rs).date
     val value = Arb.dataConnect.string().next(rs)
 
     val key = connector.insertPrimaryKeyIsDate.execute(foo = id, value = value).data.key

--- a/firebase-dataconnect/connectors/src/androidTest/kotlin/com/google/firebase/dataconnect/connectors/demo/ListVariablesAndDataIntegrationTest.kt
+++ b/firebase-dataconnect/connectors/src/androidTest/kotlin/com/google/firebase/dataconnect/connectors/demo/ListVariablesAndDataIntegrationTest.kt
@@ -17,12 +17,12 @@
 package com.google.firebase.dataconnect.connectors.demo
 
 import com.google.firebase.Timestamp
+import com.google.firebase.dataconnect.LocalDate
 import com.google.firebase.dataconnect.connectors.demo.testutil.DemoConnectorIntegrationTestBase
 import com.google.firebase.dataconnect.testutil.property.arbitrary.DataConnectArb
 import com.google.firebase.dataconnect.testutil.property.arbitrary.EdgeCases
 import com.google.firebase.dataconnect.testutil.property.arbitrary.dataConnect
-import com.google.firebase.dataconnect.testutil.property.arbitrary.dateTestData
-import com.google.firebase.dataconnect.testutil.property.arbitrary.toJavaUtilDate
+import com.google.firebase.dataconnect.testutil.property.arbitrary.localDate
 import com.google.firebase.dataconnect.testutil.withMicrosecondPrecision
 import io.kotest.common.ExperimentalKotest
 import io.kotest.matchers.shouldBe
@@ -37,7 +37,6 @@ import io.kotest.property.arbitrary.long
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.uuid
 import io.kotest.property.checkAll
-import java.util.Date
 import java.util.UUID
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.test.runTest
@@ -475,7 +474,7 @@ class ListVariablesAndDataIntegrationTest : DemoConnectorIntegrationTestBase() {
     val booleans: List<Boolean>,
     val uuids: List<UUID>,
     val int64s: List<Long>,
-    val dates: List<Date>,
+    val dates: List<LocalDate>,
     val timestamps: List<Timestamp>,
   ) {
 
@@ -524,7 +523,7 @@ class ListVariablesAndDataIntegrationTest : DemoConnectorIntegrationTestBase() {
             booleans = EdgeCases.booleans,
             uuids = EdgeCases.uuids,
             int64s = EdgeCases.int64s,
-            dates = EdgeCases.dates.all().map { it.toJavaUtilDate() },
+            dates = EdgeCases.dates.all().map { it.date },
             timestamps = EdgeCases.javaTime.instants.all.map { it.timestamp },
           )
     }
@@ -546,8 +545,7 @@ class ListVariablesAndDataIntegrationTest : DemoConnectorIntegrationTestBase() {
       booleans: Arb<List<Boolean>> = Arb.list(Arb.boolean(), 1..100),
       uuids: Arb<List<UUID>> = Arb.list(Arb.uuid(), 1..100),
       int64s: Arb<List<Long>> = Arb.list(Arb.long(), 1..100),
-      dates: Arb<List<Date>> =
-        Arb.list(Arb.dataConnect.dateTestData().map { it.toJavaUtilDate() }, 1..100),
+      dates: Arb<List<LocalDate>> = Arb.list(Arb.dataConnect.localDate(), 1..100),
       timestamps: Arb<List<Timestamp>> =
         Arb.list(Arb.dataConnect.javaTime.instantTestCase().map { it.timestamp }, 1..100),
     ): Arb<Lists> = arbitrary {

--- a/firebase-dataconnect/gradleplugin/plugin/src/main/resources/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableVersions.json
+++ b/firebase-dataconnect/gradleplugin/plugin/src/main/resources/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableVersions.json
@@ -1,5 +1,5 @@
 {
-  "defaultVersion": "1.6.1",
+  "defaultVersion": "1.7.0",
   "versions": [
     {
       "version": "1.3.4",
@@ -270,6 +270,24 @@
       "os": "linux",
       "size": 25223320,
       "sha512DigestHex": "5e8002a048b55a358d6d4a8c59c30ef8c3615461fd400bf4c8e86e84cc1b6482da604cb2635ec1639276c3b9c9f22a9c570f6729934e4fc77b09c8ccb6f3b986"
+    },
+    {
+      "version": "1.7.0",
+      "os": "windows",
+      "size": 25783808,
+      "sha512DigestHex": "9fc0bf918ea2c20bc8dcf26efd101e7a567a13bf7b0967c16f35989e3557d0055edce6522b23fb70361f26f3ad1abd93458af5b33d3fa3019333ca72680353a2"
+    },
+    {
+      "version": "1.7.0",
+      "os": "macos",
+      "size": 25350912,
+      "sha512DigestHex": "f887290a6083c3c88ee92f532c6fceb993a64714d5703ea7c389381222eab05998e8a25e0bee0770686433d5e7915fe6bfd58b3a0098d13ad0800c4e515fee0d"
+    },
+    {
+      "version": "1.7.0",
+      "os": "linux",
+      "size": 25272472,
+      "sha512DigestHex": "795c3f63a3c78b94204ae8c525227f3295a02cd90e553f52bde543029a91f68da0d17653cc6b4c863ed778104fd2baa97a729f80ab4bd54dd5dd4f5e15354b7a"
     }
   ]
 }

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/DateTimeTestUtils.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/DateTimeTestUtils.kt
@@ -18,30 +18,9 @@ package com.google.firebase.dataconnect.testutil
 
 import com.google.firebase.Timestamp
 import java.util.Calendar
-import java.util.Date
 import java.util.GregorianCalendar
 import java.util.TimeZone
 import kotlin.random.Random
-
-/**
- * Creates and returns a new [Date] object that represents the given year, month, and day in UTC.
- *
- * @param year The year; must be between 0 and 9999, inclusive.
- * @param month The month; must be between 1 and 12, inclusive.
- * @param day The day of the month; must be between 1 and 31, inclusive.
- */
-fun dateFromYearMonthDayUTC(year: Int, month: Int, day: Int): Date {
-  require(year in 0..9999) { "year must be between 0 and 9999, inclusive" }
-  require(month in 1..12) { "month must be between 1 and 12, inclusive" }
-  require(day in 1..31) { "day must be between 1 and 31, inclusive" }
-
-  return GregorianCalendar(TimeZone.getTimeZone("UTC"))
-    .apply {
-      set(year, month - 1, day, 0, 0, 0)
-      set(Calendar.MILLISECOND, 0)
-    }
-    .time
-}
 
 /** Generates and returns a random [Timestamp] object. */
 fun randomTimestamp(): Timestamp {

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/dates.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/dates.kt
@@ -20,7 +20,6 @@ package com.google.firebase.dataconnect.testutil.property.arbitrary
 
 import com.google.firebase.dataconnect.LocalDate
 import com.google.firebase.dataconnect.testutil.NullableReference
-import com.google.firebase.dataconnect.testutil.dateFromYearMonthDayUTC
 import com.google.firebase.dataconnect.testutil.dayRangeInYear
 import com.google.firebase.dataconnect.testutil.property.arbitrary.DateEdgeCases.MAX_YEAR
 import com.google.firebase.dataconnect.testutil.property.arbitrary.DateEdgeCases.MIN_YEAR
@@ -101,9 +100,6 @@ data class DateTestData(
   val date: LocalDate,
   val string: String,
 )
-
-fun DateTestData.toJavaUtilDate(): java.util.Date =
-  dateFromYearMonthDayUTC(year = date.year, month = date.month, day = date.day)
 
 @Suppress("MemberVisibilityCanBePrivate")
 object DateEdgeCases {


### PR DESCRIPTION
The update to CLI version 1.7.0 causes `com.google.firebase.dataconnect.LocalDate` to be used instead of `java.util.Date` in generated code. As a result, some of the integration tests needed to be fixed to compile and pass as part of this PR.