### PR TITLE
dataconnect: Remove obsolete "alpha" release notes from the kdoc comments of FirebaseDataConnect

### DIFF
--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/FirebaseDataConnect.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/FirebaseDataConnect.kt
@@ -82,44 +82,6 @@ import kotlinx.serialization.modules.SerializersModule
  * deserializers for classes annotated with `@Serializable`. Of course, applications are free to
  * write the serializers by hand as well.
  *
- * ### Release Notes
- *
- * Release notes for the Firebase Data Connect Android SDK will be published here until it is merged
- * into the `master` branch of https://github.com/firebase/firebase-android-sdk, at which point the
- * release notes will become part of the regular Android SDK releases.
- *
- * #### 16.0.0-alpha05 (June 24, 2024)
- * - [#6003](https://github.com/firebase/firebase-android-sdk/pull/6003]) Fixed [close] to
- * _actually_ close the underlying grpc network resources. Also, added [suspendingClose] to allow
- * callers to wait for the asynchronous closing work to complete, such as in integration tests.
- * - [#6005](https://github.com/firebase/firebase-android-sdk/pull/6005) Fixed a StrictMode
- * violation upon the first network request being sent.
- * - [#6006](https://github.com/firebase/firebase-android-sdk/pull/6006) Improved debug logging of
- * GRPC requests and responses.
- * - [#6038](https://github.com/firebase/firebase-android-sdk/pull/6038) Fixed a bug with incorrect
- * Timestamp serialization due to miscalculation in timezone decoding.
- * - [#6052](https://github.com/firebase/firebase-android-sdk/pull/6052) Automatically retry
- * operations (queries and mutations) that fail due to an expired authentication token, with a new
- * authentication token.
- *
- * #### 16.0.0-alpha04 (May 29, 2024)
- * - [#5976](https://github.com/firebase/firebase-android-sdk/pull/5976) Fixed time zone issues when
- * serializing java.util.Date objects
- * - [#5996](https://github.com/firebase/firebase-android-sdk/pull/5996) Changed default port of
- * useEmulator() to 9399 (was 9510); this goes with a change to the Data Connect Emulator v1.1.19
- * (firebase-tools v13.10.2) that changes the default port to 9399.
- *
- * #### 16.0.0-alpha03 (May 15, 2024)
- * - KDoc comments added.
- * - OptionalVariable: fix potential NullPointerException in toString() and hashCode().
- * - TimestampSerializer: add support for time zones specified using +HH:MM or -HH:MM.
- *
- * #### 16.0.0-alpha02 (May 13, 2024)
- * - Internal code cleanup; no externally-visible changes.
- *
- * #### 16.0.0-alpha01 (May 08, 2024)
- * - Initial release.
- *
  * ### Safe for Concurrent Use
  *
  * All methods and properties of [FirebaseDataConnect] are thread-safe and may be safely called


### PR DESCRIPTION
During the "alpha" release cycle of Data Connect, the release notes were published in the kdoc comments of the `FirebaseDataConnect` class. Now that Data Connect has been in "beta" for 1.5 months, these "alpha" release notes are no longer relevant because the release notes of the Data Connect SDK are now published, along with the release notes of other Firebase products, at https://firebase.google.com/support/release-notes/android. This PR removes these obsolete "alpha" release notes.