### PR TITLE
Add an overload to FirebaseCrashlytics.recordException to attach additional custom key value pairs

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,70 +1,9 @@
 # Unreleased
-* [feature] Added an overload to the `recordException` API to allow attaching additional custom
-  keys to the non fatal report.
 
-# 19.2.1
-* [changed] Updated protobuf dependency to `3.25.5` to fix
-  [CVE-2024-7254](https://nvd.nist.gov/vuln/detail/CVE-2024-7254).
-
-
-## Kotlin
-The Kotlin extensions library transitively includes the updated
-`firebase-crashlytics` library. The Kotlin extensions library has no additional
-updates.
-
-# 19.2.0
-* [fixed] Improved data consistency for rapid user actions.
-* [fixed] Fixed exception propagation in the case of no default uncaught exception handler.
-* [changed] Internal changes to improve startup time.
-* [changed] Internal changes to the way background tasks are scheduled.
-* [changed] Migrated SDK to use standard Firebase executors.
-
-# 19.1.0
-* [feature] Added the `isCrashlyticsCollectionEnabled` API to check if Crashlytics collection is
-  enabled.
-  (GitHub [#5919](https://github.com/firebase/firebase-android-sdk/issues/5919){: .external})
-* [fixed] Ensure that on-demand fatal events are never processed on the main thread.
-  (GitHub [#4345](https://github.com/firebase/firebase-android-sdk/issues/4345){: .external})
-* [changed] Internal changes to the way session IDs are generated.
-
-
-## Kotlin
-The Kotlin extensions library transitively includes the updated
-`firebase-crashlytics` library. The Kotlin extensions library has no additional
-updates.
-
-# 19.0.3
-* [changed] Update the internal file system to handle long file names.
-
-
-## Kotlin
-The Kotlin extensions library transitively includes the updated
-`firebase-crashlytics` library. The Kotlin extensions library has no additional
-updates.
-
-# 19.0.2
-* [changed] Changing caught exception type to fail safely on any exception type.
-
-
-## Kotlin
-The Kotlin extensions library transitively includes the updated
-`firebase-crashlytics` library. The Kotlin extensions library has no additional
-updates.
-
-# 19.0.1
-* [changed] Improve cold initialization time.
-* [fixed] Fixed version compatibility issues with other Firebase libraries.
-
-
-## Kotlin
-The Kotlin extensions library transitively includes the updated
-`firebase-crashlytics` library. The Kotlin extensions library has no additional
-updates.
 
 # 19.0.0
 * [fixed] Force validation or rotation of FIDs.
 * [fixed] Added keep rule for shrinkage of Crashlytics build resources in strict mode.
-
 
 ## Kotlin
 The Kotlin extensions library transitively includes the updated

--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
-
+* [feature] Added an overload to the `recordException` API to allow attaching additional custom
+  keys to the non fatal report.
 
 # 19.2.1
 * [changed] Updated protobuf dependency to `3.25.5` to fix

--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,9 +1,69 @@
 # Unreleased
 * [fixed] Execute failure listener outside the main thread  [#6535]
 
+# 19.2.1
+* [changed] Updated protobuf dependency to `3.25.5` to fix
+  [CVE-2024-7254](https://nvd.nist.gov/vuln/detail/CVE-2024-7254).
+
+
+## Kotlin
+The Kotlin extensions library transitively includes the updated
+`firebase-crashlytics` library. The Kotlin extensions library has no additional
+updates.
+
+# 19.2.0
+* [fixed] Improved data consistency for rapid user actions.
+* [fixed] Fixed exception propagation in the case of no default uncaught exception handler.
+* [changed] Internal changes to improve startup time.
+* [changed] Internal changes to the way background tasks are scheduled.
+* [changed] Migrated SDK to use standard Firebase executors.
+
+# 19.1.0
+* [feature] Added the `isCrashlyticsCollectionEnabled` API to check if Crashlytics collection is
+  enabled.
+  (GitHub [#5919](https://github.com/firebase/firebase-android-sdk/issues/5919){: .external})
+* [fixed] Ensure that on-demand fatal events are never processed on the main thread.
+  (GitHub [#4345](https://github.com/firebase/firebase-android-sdk/issues/4345){: .external})
+* [changed] Internal changes to the way session IDs are generated.
+
+
+## Kotlin
+The Kotlin extensions library transitively includes the updated
+`firebase-crashlytics` library. The Kotlin extensions library has no additional
+updates.
+
+# 19.0.3
+* [changed] Update the internal file system to handle long file names.
+
+
+## Kotlin
+The Kotlin extensions library transitively includes the updated
+`firebase-crashlytics` library. The Kotlin extensions library has no additional
+updates.
+
+# 19.0.2
+* [changed] Changing caught exception type to fail safely on any exception type.
+
+
+## Kotlin
+The Kotlin extensions library transitively includes the updated
+`firebase-crashlytics` library. The Kotlin extensions library has no additional
+updates.
+
+# 19.0.1
+* [changed] Improve cold initialization time.
+* [fixed] Fixed version compatibility issues with other Firebase libraries.
+
+
+## Kotlin
+The Kotlin extensions library transitively includes the updated
+`firebase-crashlytics` library. The Kotlin extensions library has no additional
+updates.
+
 # 19.0.0
 * [fixed] Force validation or rotation of FIDs.
 * [fixed] Added keep rule for shrinkage of Crashlytics build resources in strict mode.
+
 
 ## Kotlin
 The Kotlin extensions library transitively includes the updated

--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
-* [feature] Added an overload for `recordException` that allows setting custom keys limited 
-  to the non fatal [#3551]
+* [feature] Added an overload for `recordException` that allows logging additional custom
+  keys to the non fatal event [#3551]
 
 # 19.3.0
 * [fixed] Fixed inefficiency in the Kotlin `FirebaseCrashlytics.setCustomKeys` extension.

--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
-
+* [feature] Added an overload for `recordException` that allows setting custom keys limited 
+  to the non fatal [#3551]
 
 # 19.3.0
 * [fixed] Fixed inefficiency in the Kotlin `FirebaseCrashlytics.setCustomKeys` extension.

--- a/firebase-crashlytics/api.txt
+++ b/firebase-crashlytics/api.txt
@@ -20,10 +20,11 @@ package com.google.firebase.crashlytics {
     method public void deleteUnsentReports();
     method public boolean didCrashOnPreviousExecution();
     method @NonNull public static com.google.firebase.crashlytics.FirebaseCrashlytics getInstance();
+    method public boolean isCrashlyticsCollectionEnabled();
     method public void log(@NonNull String);
     method public void recordException(@NonNull Throwable);
+    method public void recordException(@NonNull Throwable, @NonNull java.util.Map<java.lang.String,java.lang.String>);
     method public void sendUnsentReports();
-    method public boolean isCrashlyticsCollectionEnabled();
     method public void setCrashlyticsCollectionEnabled(boolean);
     method public void setCrashlyticsCollectionEnabled(@Nullable Boolean);
     method public void setCustomKey(@NonNull String, boolean);

--- a/firebase-crashlytics/api.txt
+++ b/firebase-crashlytics/api.txt
@@ -23,7 +23,7 @@ package com.google.firebase.crashlytics {
     method public boolean isCrashlyticsCollectionEnabled();
     method public void log(@NonNull String);
     method public void recordException(@NonNull Throwable);
-    method public void recordException(@NonNull Throwable, @NonNull java.util.Map<java.lang.String,java.lang.String>);
+    method public void recordException(@NonNull Throwable, @NonNull com.google.firebase.crashlytics.CustomKeysAndValues);
     method public void sendUnsentReports();
     method public void setCrashlyticsCollectionEnabled(boolean);
     method public void setCrashlyticsCollectionEnabled(@Nullable Boolean);

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerTest.java
@@ -44,6 +44,7 @@ import com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider;
 import com.google.firebase.crashlytics.internal.NativeSessionFileProvider;
 import com.google.firebase.crashlytics.internal.analytics.AnalyticsEventLogger;
 import com.google.firebase.crashlytics.internal.concurrency.CrashlyticsWorkers;
+import com.google.firebase.crashlytics.internal.metadata.EventMetadata;
 import com.google.firebase.crashlytics.internal.metadata.LogFileManager;
 import com.google.firebase.crashlytics.internal.metadata.UserMetadata;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport;
@@ -57,6 +58,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.TreeSet;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -216,14 +218,14 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
     when(mockSessionReportingCoordinator.listSortedOpenSessionIds())
         .thenReturn(new TreeSet<>(Collections.singleton(sessionId)));
 
-    controller.writeNonFatalException(thread, nonFatal);
+    controller.writeNonFatalException(thread, nonFatal, Map.of());
     crashlyticsWorkers.common.submit(() -> controller.doCloseSessions(testSettingsProvider));
 
     crashlyticsWorkers.common.await();
     crashlyticsWorkers.diskWrite.await();
 
     verify(mockSessionReportingCoordinator)
-        .persistNonFatalEvent(eq(nonFatal), eq(thread), eq(sessionId), anyLong());
+        .persistNonFatalEvent(eq(nonFatal), eq(thread), any(EventMetadata.class));
   }
 
   @SdkSuppress(minSdkVersion = 30) // ApplicationExitInfo
@@ -377,7 +379,7 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
         testSettingsProvider, Thread.currentThread(), new RuntimeException());
 
     // This should not throw.
-    controller.writeNonFatalException(Thread.currentThread(), new RuntimeException());
+    controller.writeNonFatalException(Thread.currentThread(), new RuntimeException(), Map.of());
   }
 
   /**

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -275,6 +275,21 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     assertEquals("value", metadata.getCustomKeys().get("7"));
     assertEquals("value", metadata.getCustomKeys(Map.of()).get("7"));
     assertEquals("eventValue", metadata.getCustomKeys(eventKeysAndValues).get("7"));
+
+    // Test the event key behavior when the count of custom keys is max.
+    for (int i = keysAndValues.size(); i < UserMetadata.MAX_ATTRIBUTES; ++i) {
+      final String key = "key" + i;
+      final String value = "value" + i;
+      metadata.setCustomKey(key, value);
+      crashlyticsWorkers.common.await();
+      assertEquals(value, metadata.getCustomKeys().get(key));
+    }
+
+    assertEquals(UserMetadata.MAX_ATTRIBUTES, metadata.getCustomKeys().size());
+
+    assertEquals("value", metadata.getCustomKeys().get("7"));
+    assertEquals("value", metadata.getCustomKeys(Map.of()).get("7"));
+    assertEquals("eventValue", metadata.getCustomKeys(eventKeysAndValues).get("7"));
   }
 
   @Test

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -242,7 +242,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     keysAndValues.put("customKey2", "value");
     keysAndValues.put("customKey3", "value");
 
-    metadata.setCustomKeys(keysAndValues);
+    crashlyticsCore.setCustomKeys(keysAndValues);
     crashlyticsWorkers.common.await();
 
     Map<String, String> eventKeysAndValues = new HashMap<>();
@@ -269,7 +269,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
 
     // Tests overriding custom key with event keys.
     keysAndValues.put("eventKey1", "value");
-    metadata.setCustomKeys(keysAndValues);
+    crashlyticsCore.setCustomKeys(keysAndValues);
     crashlyticsWorkers.common.await();
 
     assertEquals("value", metadata.getCustomKeys().get("eventKey1"));
@@ -280,7 +280,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     for (int i = keysAndValues.size(); i < UserMetadata.MAX_ATTRIBUTES; ++i) {
       final String key = "key" + i;
       final String value = "value" + i;
-      metadata.setCustomKey(key, value);
+      crashlyticsCore.setCustomKey(key, value);
       crashlyticsWorkers.common.await();
       assertEquals(value, metadata.getCustomKeys().get(key));
     }

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -238,16 +238,16 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     UserMetadata metadata = crashlyticsCore.getController().getUserMetadata();
 
     Map<String, String> keysAndValues = new HashMap<>();
-    keysAndValues.put("1", "value");
-    keysAndValues.put("2", "value");
-    keysAndValues.put("3", "value");
+    keysAndValues.put("customKey1", "value");
+    keysAndValues.put("customKey2", "value");
+    keysAndValues.put("customKey3", "value");
 
     metadata.setCustomKeys(keysAndValues);
     crashlyticsWorkers.common.await();
 
     Map<String, String> eventKeysAndValues = new HashMap<>();
-    eventKeysAndValues.put("4", "eventValue");
-    eventKeysAndValues.put("5", "eventValue");
+    eventKeysAndValues.put("eventKey1", "eventValue");
+    eventKeysAndValues.put("eventKey2", "eventValue");
 
     // Tests reading custom keys with event keys.
     assertEquals(keysAndValues.size(), metadata.getCustomKeys().size());
@@ -261,20 +261,20 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     assertEquals(keysAndValues.size(), metadata.getCustomKeys(Map.of()).size());
 
     // Tests additional event keys.
-    eventKeysAndValues.put("6", "eventValue");
-    eventKeysAndValues.put("7", "eventValue");
+    eventKeysAndValues.put("eventKey3", "eventValue");
+    eventKeysAndValues.put("eventKey4", "eventValue");
     assertEquals(
         keysAndValues.size() + eventKeysAndValues.size(),
         metadata.getCustomKeys(eventKeysAndValues).size());
 
     // Tests overriding custom key with event keys.
-    keysAndValues.put("7", "value");
+    keysAndValues.put("eventKey1", "value");
     metadata.setCustomKeys(keysAndValues);
     crashlyticsWorkers.common.await();
 
-    assertEquals("value", metadata.getCustomKeys().get("7"));
-    assertEquals("value", metadata.getCustomKeys(Map.of()).get("7"));
-    assertEquals("eventValue", metadata.getCustomKeys(eventKeysAndValues).get("7"));
+    assertEquals("value", metadata.getCustomKeys().get("eventKey1"));
+    assertEquals("value", metadata.getCustomKeys(Map.of()).get("eventKey1"));
+    assertEquals("eventValue", metadata.getCustomKeys(eventKeysAndValues).get("eventKey1"));
 
     // Test the event key behavior when the count of custom keys is max.
     for (int i = keysAndValues.size(); i < UserMetadata.MAX_ATTRIBUTES; ++i) {
@@ -287,9 +287,13 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
 
     assertEquals(UserMetadata.MAX_ATTRIBUTES, metadata.getCustomKeys().size());
 
-    assertEquals("value", metadata.getCustomKeys().get("7"));
-    assertEquals("value", metadata.getCustomKeys(Map.of()).get("7"));
-    assertEquals("eventValue", metadata.getCustomKeys(eventKeysAndValues).get("7"));
+    // Tests event keys override global custom keys when the key exists.
+    assertEquals("value", metadata.getCustomKeys().get("eventKey1"));
+    assertEquals("value", metadata.getCustomKeys(Map.of()).get("eventKey1"));
+    assertEquals("eventValue", metadata.getCustomKeys(eventKeysAndValues).get("eventKey1"));
+
+    // Test when event keys *don't* override global custom keys.
+    assertNull(metadata.getCustomKeys(eventKeysAndValues).get("eventKey2"));
   }
 
   @Test

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -160,6 +160,124 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
   }
 
   @Test
+  public void testCustomAttributes_retrievedWithEmptyEventKeys() throws Exception {
+    UserMetadata metadata = crashlyticsCore.getController().getUserMetadata();
+
+    assertTrue(metadata.getCustomKeys(Map.of()).isEmpty());
+
+    final String id = "id012345";
+    crashlyticsCore.setUserId(id);
+    crashlyticsWorkers.common.await();
+    assertEquals(id, metadata.getUserId());
+
+    final StringBuffer idBuffer = new StringBuffer(id);
+    while (idBuffer.length() < UserMetadata.MAX_ATTRIBUTE_SIZE) {
+      idBuffer.append("0");
+    }
+    final String longId = idBuffer.toString();
+    final String superLongId = longId + "more chars";
+
+    crashlyticsCore.setUserId(superLongId);
+    crashlyticsWorkers.common.await();
+    assertEquals(longId, metadata.getUserId());
+
+    final String key1 = "key1";
+    final String value1 = "value1";
+    crashlyticsCore.setCustomKey(key1, value1);
+    crashlyticsWorkers.common.await();
+    assertEquals(value1, metadata.getCustomKeys(Map.of()).get(key1));
+
+    // Adding an existing key with the same value should return false
+    assertFalse(metadata.setCustomKey(key1, value1));
+    assertTrue(metadata.setCustomKey(key1, "someOtherValue"));
+    assertTrue(metadata.setCustomKey(key1, value1));
+    assertFalse(metadata.setCustomKey(key1, value1));
+
+    final String longValue = longId.replaceAll("0", "x");
+    final String superLongValue = longValue + "some more chars";
+
+    // test truncation of custom keys and attributes
+    crashlyticsCore.setCustomKey(superLongId, superLongValue);
+    crashlyticsWorkers.common.await();
+    assertNull(metadata.getCustomKeys(Map.of()).get(superLongId));
+    assertEquals(longValue, metadata.getCustomKeys().get(longId));
+
+    // test the max number of attributes. We've already set 2.
+    for (int i = 2; i < UserMetadata.MAX_ATTRIBUTES; ++i) {
+      final String key = "key" + i;
+      final String value = "value" + i;
+      crashlyticsCore.setCustomKey(key, value);
+      crashlyticsWorkers.common.await();
+      assertEquals(value, metadata.getCustomKeys(Map.of()).get(key));
+    }
+    // should be full now, extra key, value pairs will be dropped.
+    final String key = "new key";
+    crashlyticsCore.setCustomKey(key, "some value");
+    crashlyticsWorkers.common.await();
+    assertFalse(metadata.getCustomKeys(Map.of()).containsKey(key));
+
+    // should be able to update existing keys
+    crashlyticsCore.setCustomKey(key1, longValue);
+    crashlyticsWorkers.common.await();
+    assertEquals(longValue, metadata.getCustomKeys(Map.of()).get(key1));
+
+    // when we set a key to null, it should still exist with an empty value
+    crashlyticsCore.setCustomKey(key1, null);
+    crashlyticsWorkers.common.await();
+    assertEquals("", metadata.getCustomKeys(Map.of()).get(key1));
+
+    // keys and values are trimmed.
+    crashlyticsCore.setCustomKey(" " + key1 + " ", " " + longValue + " ");
+    crashlyticsWorkers.common.await();
+    assertTrue(metadata.getCustomKeys(Map.of()).containsKey(key1));
+    assertEquals(longValue, metadata.getCustomKeys(Map.of()).get(key1));
+  }
+
+  @Test
+  public void testCustomKeysMergedWithEventKeys() throws Exception {
+    UserMetadata metadata = crashlyticsCore.getController().getUserMetadata();
+
+    Map<String, String> keysAndValues = new HashMap<>();
+    keysAndValues.put("1", "value");
+    keysAndValues.put("2", "value");
+    keysAndValues.put("3", "value");
+
+    metadata.setCustomKeys(keysAndValues);
+    crashlyticsWorkers.common.await();
+
+    Map<String, String> eventKeysAndValues = new HashMap<>();
+    eventKeysAndValues.put("4", "eventValue");
+    eventKeysAndValues.put("5", "eventValue");
+
+    // Tests reading custom keys with event keys.
+    assertEquals(keysAndValues.size(), metadata.getCustomKeys().size());
+    assertEquals(keysAndValues.size(), metadata.getCustomKeys(Map.of()).size());
+    assertEquals(
+        keysAndValues.size() + eventKeysAndValues.size(),
+        metadata.getCustomKeys(eventKeysAndValues).size());
+
+    // Tests event keys don't add to custom keys in future reads.
+    assertEquals(keysAndValues.size(), metadata.getCustomKeys().size());
+    assertEquals(keysAndValues.size(), metadata.getCustomKeys(Map.of()).size());
+
+    // Tests additional event keys.
+    eventKeysAndValues.put("6", "eventValue");
+    eventKeysAndValues.put("7", "eventValue");
+    assertEquals(
+        keysAndValues.size() + eventKeysAndValues.size(),
+        metadata.getCustomKeys(eventKeysAndValues).size());
+
+    // Tests overriding custom key with event keys.
+    keysAndValues.put("7", "value");
+    metadata.setCustomKeys(keysAndValues);
+    crashlyticsWorkers.common.await();
+
+    assertEquals("value", metadata.getCustomKeys().get("7"));
+    assertEquals("value", metadata.getCustomKeys(Map.of()).get("7"));
+    assertEquals("eventValue", metadata.getCustomKeys(eventKeysAndValues).get("7"));
+  }
+
+  @Test
   public void testBulkCustomKeys() throws Exception {
     final double DELTA = 1e-15;
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinatorTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinatorTest.java
@@ -60,7 +60,7 @@ import org.mockito.MockitoAnnotations;
 
 public class SessionReportingCoordinatorTest extends CrashlyticsTestCase {
 
-  private static String TEST_SESSION_ID = "testSession1";
+  private static final String TEST_SESSION_ID = "testSessionId";
 
   @Mock private CrashlyticsReportDataCapture dataCapture;
   @Mock private CrashlyticsReportPersistence reportPersistence;
@@ -269,7 +269,8 @@ public class SessionReportingCoordinatorTest extends CrashlyticsTestCase {
     expectedCustomAttributes.add(customAttribute1);
     expectedCustomAttributes.add(customAttribute2);
 
-    addKeysToUserMetadata(attributes);
+    addCustomKeysToUserMetadata(attributes);
+    addInternalKeysToUserMetadata(attributes);
 
     reportingCoordinator.onBeginSession(sessionId, timestamp);
     reportingCoordinator.persistNonFatalEvent(
@@ -357,7 +358,7 @@ public class SessionReportingCoordinatorTest extends CrashlyticsTestCase {
     attributes.put(testKey1, testValue1);
     attributes.put(testKey2, testValue2);
 
-    addKeysToUserMetadata(attributes);
+    addCustomKeysToUserMetadata(attributes);
 
     final String testValue1UserInfo = "testValue1";
     final String testKey3 = "testKey3";
@@ -441,7 +442,7 @@ public class SessionReportingCoordinatorTest extends CrashlyticsTestCase {
     expectedCustomAttributes.add(customAttribute1);
     expectedCustomAttributes.add(customAttribute2);
 
-    addKeysToUserMetadata(attributes);
+    addCustomKeysToUserMetadata(attributes);
 
     reportingCoordinator.onBeginSession(sessionId, timestamp);
     reportingCoordinator.persistFatalEvent(mockException, mockThread, sessionId, timestamp);
@@ -479,7 +480,7 @@ public class SessionReportingCoordinatorTest extends CrashlyticsTestCase {
     expectedCustomAttributes.add(customAttribute1);
     expectedCustomAttributes.add(customAttribute2);
 
-    addKeysToUserMetadata(attributes);
+    addInternalKeysToUserMetadata(attributes);
 
     reportingCoordinator.onBeginSession(sessionId, timestamp);
     reportingCoordinator.persistFatalEvent(mockException, mockThread, sessionId, timestamp);
@@ -611,9 +612,16 @@ public class SessionReportingCoordinatorTest extends CrashlyticsTestCase {
     verify(reportPersistence).deleteAllReports();
   }
 
-  private void addKeysToUserMetadata(Map<String, String> customKeys) throws Exception {
+  private void addCustomKeysToUserMetadata(Map<String, String> customKeys) throws Exception {
     reportMetadata.setCustomKeys(customKeys);
     for (Map.Entry<String, String> entry : customKeys.entrySet()) {
+      reportMetadata.setInternalKey(entry.getKey(), entry.getValue());
+    }
+    crashlyticsWorkers.diskWrite.await();
+  }
+
+  private void addInternalKeysToUserMetadata(Map<String, String> internalKeys) throws Exception {
+    for (Map.Entry<String, String> entry : internalKeys.entrySet()) {
       reportMetadata.setInternalKey(entry.getKey(), entry.getValue());
     }
     crashlyticsWorkers.diskWrite.await();

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinatorTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinatorTest.java
@@ -35,6 +35,7 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.concurrent.TestOnlyExecutors;
 import com.google.firebase.crashlytics.internal.concurrency.CrashlyticsWorkers;
+import com.google.firebase.crashlytics.internal.metadata.EventMetadata;
 import com.google.firebase.crashlytics.internal.metadata.LogFileManager;
 import com.google.firebase.crashlytics.internal.metadata.UserMetadata;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport;
@@ -138,7 +139,8 @@ public class SessionReportingCoordinatorTest {
     mockEventInteractions();
 
     reportingCoordinator.onBeginSession(sessionId, timestamp);
-    reportingCoordinator.persistNonFatalEvent(mockException, mockThread, sessionId, timestamp);
+    reportingCoordinator.persistNonFatalEvent(
+        mockException, mockThread, new EventMetadata(sessionId, timestamp, Map.of()));
 
     crashlyticsWorkers.diskWrite.await();
 
@@ -163,7 +165,8 @@ public class SessionReportingCoordinatorTest {
     when(logFileManager.getLogString()).thenReturn(testLog);
 
     reportingCoordinator.onBeginSession(sessionId, timestamp);
-    reportingCoordinator.persistNonFatalEvent(mockException, mockThread, sessionId, timestamp);
+    reportingCoordinator.persistNonFatalEvent(
+        mockException, mockThread, new EventMetadata(sessionId, timestamp, Map.of()));
 
     crashlyticsWorkers.diskWrite.await();
 
@@ -184,7 +187,8 @@ public class SessionReportingCoordinatorTest {
     when(logFileManager.getLogString()).thenReturn(null);
 
     reportingCoordinator.onBeginSession(sessionId, timestamp);
-    reportingCoordinator.persistNonFatalEvent(mockException, mockThread, sessionId, timestamp);
+    reportingCoordinator.persistNonFatalEvent(
+        mockException, mockThread, new EventMetadata(sessionId, timestamp, Map.of()));
 
     crashlyticsWorkers.diskWrite.await();
 
@@ -261,7 +265,8 @@ public class SessionReportingCoordinatorTest {
     when(reportMetadata.getInternalKeys()).thenReturn(attributes);
 
     reportingCoordinator.onBeginSession(sessionId, timestamp);
-    reportingCoordinator.persistNonFatalEvent(mockException, mockThread, sessionId, timestamp);
+    reportingCoordinator.persistNonFatalEvent(
+        mockException, mockThread, new EventMetadata(sessionId, timestamp, Map.of()));
 
     crashlyticsWorkers.diskWrite.await();
 
@@ -286,7 +291,8 @@ public class SessionReportingCoordinatorTest {
     when(reportMetadata.getCustomKeys()).thenReturn(attributes);
 
     reportingCoordinator.onBeginSession(sessionId, timestamp);
-    reportingCoordinator.persistNonFatalEvent(mockException, mockThread, sessionId, timestamp);
+    reportingCoordinator.persistNonFatalEvent(
+        mockException, mockThread, new EventMetadata(sessionId, timestamp, Map.of()));
 
     crashlyticsWorkers.diskWrite.await();
 
@@ -309,7 +315,8 @@ public class SessionReportingCoordinatorTest {
     when(reportMetadata.getRolloutsState()).thenReturn(rolloutsState);
 
     reportingCoordinator.onBeginSession(sessionId, timestamp);
-    reportingCoordinator.persistNonFatalEvent(mockException, mockThread, sessionId, timestamp);
+    reportingCoordinator.persistNonFatalEvent(
+        mockException, mockThread, new EventMetadata(sessionId, timestamp, Map.of()));
 
     crashlyticsWorkers.diskWrite.await();
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -211,20 +211,28 @@ public class FirebaseCrashlytics {
   /**
    * Records a non-fatal report to send to Crashlytics.
    *
+   * <p>Combined with app level custom keys, the event is restricted to a maximum of 64 key/value
+   * pairs. New keys beyond that limit are ignored. Keys or values that exceed 1024 characters are
+   * truncated.
+   *
+   * <p>The values of event keys override the values of app level custom keys if they're identical.
+   *
    * @param throwable a {@link Throwable} to be recorded as a non-fatal event.
-   * @param userInfo a {@link Map} to add key value pairs to be recorded with the non fatal exception.
+   * @param customKeys a {@link Map<String, String>} containing key value pairs to be associated
+   *                   with the non fatal exception, in addition to the global custom keys.
    */
-  public void recordException(@NonNull Throwable throwable, @NonNull Map<String, String> userInfo) {
+  public void recordException(
+      @NonNull Throwable throwable, @NonNull Map<String, String> customKeys) {
     if (throwable == null) { // Users could call this with null despite the annotation.
       Logger.getLogger().w("A null value was passed to recordException. Ignoring.");
       return;
     }
 
-    if (userInfo == null) { // It's possible to set this to null even with the annotation.
-      userInfo = Map.of();
+    if (customKeys == null) { // It's possible to set this to null even with the annotation.
+      customKeys = Map.of();
     }
 
-    core.logException(throwable, userInfo);
+    core.logException(throwable, customKeys);
   }
 
   /**

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -205,6 +205,11 @@ public class FirebaseCrashlytics {
    * @param throwable a {@link Throwable} to be recorded as a non-fatal event.
    */
   public void recordException(@NonNull Throwable throwable) {
+    if (throwable == null) { // Users could call this with null despite the annotation.
+      Logger.getLogger().w("A null value was passed to recordException. Ignoring.");
+      return;
+    }
+
     core.logException(throwable, Map.of());
   }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -228,7 +228,7 @@ public class FirebaseCrashlytics {
       return;
     }
 
-    if (customKeys == null) { // It's possible to set this to null even with the annotation.
+    if (customKeys == null) { // Users could call this with null despite the annotation.
       customKeys = Map.of();
     }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -43,6 +43,7 @@ import com.google.firebase.installations.FirebaseInstallationsApi;
 import com.google.firebase.remoteconfig.interop.FirebaseRemoteConfigInterop;
 import com.google.firebase.sessions.api.FirebaseSessionsDependencies;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -202,11 +203,26 @@ public class FirebaseCrashlytics {
    * @param throwable a {@link Throwable} to be recorded as a non-fatal event.
    */
   public void recordException(@NonNull Throwable throwable) {
+    recordException(throwable, Map.of());
+  }
+
+  /**
+   * Records a non-fatal report to send to Crashlytics.
+   *
+   * @param throwable a {@link Throwable} to be recorded as a non-fatal event.
+   * @param userInfo a {@link Map} to add key value pairs to be recorded with the non fatal exception.
+   */
+  public void recordException(@NonNull Throwable throwable, @NonNull Map<String, String> userInfo) {
     if (throwable == null) { // Users could call this with null despite the annotation.
       Logger.getLogger().w("A null value was passed to recordException. Ignoring.");
       return;
     }
-    core.logException(throwable);
+
+    if (userInfo == null) { // It's possible to set this to null even with the annotation.
+      userInfo = Map.of();
+    }
+
+    core.logException(throwable, userInfo);
   }
 
   /**

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -205,7 +205,7 @@ public class FirebaseCrashlytics {
    * @param throwable a {@link Throwable} to be recorded as a non-fatal event.
    */
   public void recordException(@NonNull Throwable throwable) {
-    recordException(throwable, Map.of());
+    core.logException(throwable, Map.of());
   }
 
   /**
@@ -218,21 +218,17 @@ public class FirebaseCrashlytics {
    * <p>The values of event keys override the values of app level custom keys if they're identical.
    *
    * @param throwable a {@link Throwable} to be recorded as a non-fatal event.
-   * @param customKeys a {@link Map<String, String>} containing key value pairs to be associated
-   *                   with the non fatal exception, in addition to the app level custom keys.
+   * @param keysAndValues A dictionary of keys and the values to associate with the non fatal
+   *                      exception, in addition to the app level custom keys.
    */
   public void recordException(
-      @NonNull Throwable throwable, @NonNull Map<String, String> customKeys) {
+      @NonNull Throwable throwable, @NonNull CustomKeysAndValues keysAndValues) {
     if (throwable == null) { // Users could call this with null despite the annotation.
       Logger.getLogger().w("A null value was passed to recordException. Ignoring.");
       return;
     }
 
-    if (customKeys == null) { // Users could call this with null despite the annotation.
-      customKeys = Map.of();
-    }
-
-    core.logException(throwable, customKeys);
+    core.logException(throwable, keysAndValues.keysAndValues);
   }
 
   /**

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -219,7 +219,7 @@ public class FirebaseCrashlytics {
    *
    * @param throwable a {@link Throwable} to be recorded as a non-fatal event.
    * @param customKeys a {@link Map<String, String>} containing key value pairs to be associated
-   *                   with the non fatal exception, in addition to the global custom keys.
+   *                   with the non fatal exception, in addition to the app level custom keys.
    */
   public void recordException(
       @NonNull Throwable throwable, @NonNull Map<String, String> customKeys) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -35,6 +35,7 @@ import com.google.firebase.crashlytics.internal.NativeSessionFileProvider;
 import com.google.firebase.crashlytics.internal.analytics.AnalyticsEventLogger;
 import com.google.firebase.crashlytics.internal.concurrency.CrashlyticsTasks;
 import com.google.firebase.crashlytics.internal.concurrency.CrashlyticsWorkers;
+import com.google.firebase.crashlytics.internal.metadata.EventMetadata;
 import com.google.firebase.crashlytics.internal.metadata.LogFileManager;
 import com.google.firebase.crashlytics.internal.metadata.UserMetadata;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport;
@@ -405,7 +406,10 @@ class CrashlyticsController {
   }
 
   /** Log a caught exception - write out Throwable as event section of protobuf */
-  void writeNonFatalException(@NonNull final Thread thread, @NonNull final Throwable ex) {
+  void writeNonFatalException(
+      @NonNull final Thread thread,
+      @NonNull final Throwable ex,
+      @NonNull Map<String, String> userInfo) {
     // Capture and close over the current time, so that we get the exact call time,
     // rather than the time at which the task executes.
     final long timestampMillis = System.currentTimeMillis();
@@ -417,7 +421,8 @@ class CrashlyticsController {
         Logger.getLogger().w("Tried to write a non-fatal exception while no session was open.");
         return;
       }
-      reportingCoordinator.persistNonFatalEvent(ex, thread, currentSessionId, timestampSeconds);
+      EventMetadata eventMetadata = new EventMetadata(currentSessionId, timestampSeconds, userInfo);
+      reportingCoordinator.persistNonFatalEvent(ex, thread, eventMetadata);
     }
   }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -409,7 +409,7 @@ class CrashlyticsController {
   void writeNonFatalException(
       @NonNull final Thread thread,
       @NonNull final Throwable ex,
-      @NonNull Map<String, String> userInfo) {
+      @NonNull Map<String, String> eventKeys) {
     // Capture and close over the current time, so that we get the exact call time,
     // rather than the time at which the task executes.
     final long timestampMillis = System.currentTimeMillis();
@@ -421,7 +421,8 @@ class CrashlyticsController {
         Logger.getLogger().w("Tried to write a non-fatal exception while no session was open.");
         return;
       }
-      EventMetadata eventMetadata = new EventMetadata(currentSessionId, timestampSeconds, userInfo);
+      EventMetadata eventMetadata =
+          new EventMetadata(currentSessionId, timestampSeconds, eventKeys);
       reportingCoordinator.persistNonFatalEvent(ex, thread, eventMetadata);
     }
   }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -313,9 +313,9 @@ public class CrashlyticsCore {
    * Throwable was thrown. The Throwable will always be processed on a background thread, so it is
    * safe to invoke this method from the main thread.
    */
-  public void logException(@NonNull Throwable throwable, @NonNull Map<String, String> userInfo) {
+  public void logException(@NonNull Throwable throwable, @NonNull Map<String, String> eventKeys) {
     crashlyticsWorkers.common.submit(
-        () -> controller.writeNonFatalException(Thread.currentThread(), throwable, userInfo));
+        () -> controller.writeNonFatalException(Thread.currentThread(), throwable, eventKeys));
   }
 
   /**

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -313,9 +313,9 @@ public class CrashlyticsCore {
    * Throwable was thrown. The Throwable will always be processed on a background thread, so it is
    * safe to invoke this method from the main thread.
    */
-  public void logException(@NonNull Throwable throwable) {
+  public void logException(@NonNull Throwable throwable, @NonNull Map<String, String> userInfo) {
     crashlyticsWorkers.common.submit(
-        () -> controller.writeNonFatalException(Thread.currentThread(), throwable));
+        () -> controller.writeNonFatalException(Thread.currentThread(), throwable, userInfo));
   }
 
   /**

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
@@ -283,13 +283,12 @@ public class SessionReportingCoordinator {
     // TODO: Put this back once support for reports endpoint is removed.
     // logFileManager.clearLog(); // Clear log to prepare for next event.
 
-    // Merges the app level custom keys, with the event specific custom keys.
-    Map<String, String> customKeysMergedWithEventKeys =
-        new HashMap<>(reportMetadata.getCustomKeys());
-    customKeysMergedWithEventKeys.putAll(eventKeys);
+    // Merges the app level custom keys and the event specific custom keys.
+    Map<String, String> customKeysForEvent =
+        mergeEventKeysIntoCustomKeys(reportMetadata.getCustomKeys(), eventKeys);
 
     final List<CustomAttribute> sortedCustomAttributes =
-        getSortedCustomAttributes(customKeysMergedWithEventKeys);
+        getSortedCustomAttributes(customKeysForEvent);
     final List<CustomAttribute> sortedInternalKeys =
         getSortedCustomAttributes(reportMetadata.getInternalKeys());
 
@@ -380,6 +379,17 @@ public class SessionReportingCoordinator {
     Logger.getLogger()
         .w("Crashlytics report could not be enqueued to DataTransport", task.getException());
     return false;
+  }
+
+  @NonNull
+  private static Map<String, String> mergeEventKeysIntoCustomKeys(
+      Map<String, String> globalCustomKeys, Map<String, String> eventKeys) {
+    Map<String, String> result = new HashMap<>(globalCustomKeys);
+    result.putAll(eventKeys);
+
+    // TODO: Add 64 key restriction.
+    // TODO: Add 1024 character restriction.
+    return result;
   }
 
   @NonNull

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
@@ -43,7 +43,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
@@ -283,12 +282,8 @@ public class SessionReportingCoordinator {
     // TODO: Put this back once support for reports endpoint is removed.
     // logFileManager.clearLog(); // Clear log to prepare for next event.
 
-    // Merges the app level custom keys and the event specific custom keys.
-    Map<String, String> customKeysForEvent =
-        mergeEventKeysIntoCustomKeys(reportMetadata.getCustomKeys(), eventKeys);
-
     final List<CustomAttribute> sortedCustomAttributes =
-        getSortedCustomAttributes(customKeysForEvent);
+        getSortedCustomAttributes(reportMetadata.getCustomKeys(eventKeys));
     final List<CustomAttribute> sortedInternalKeys =
         getSortedCustomAttributes(reportMetadata.getInternalKeys());
 
@@ -379,17 +374,6 @@ public class SessionReportingCoordinator {
     Logger.getLogger()
         .w("Crashlytics report could not be enqueued to DataTransport", task.getException());
     return false;
-  }
-
-  @NonNull
-  private static Map<String, String> mergeEventKeysIntoCustomKeys(
-      Map<String, String> globalCustomKeys, Map<String, String> eventKeys) {
-    Map<String, String> result = new HashMap<>(globalCustomKeys);
-    result.putAll(eventKeys);
-
-    // TODO: Add 64 key restriction.
-    // TODO: Add 1024 character restriction.
-    return result;
   }
 
   @NonNull

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
@@ -25,6 +25,7 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.crashlytics.internal.Logger;
 import com.google.firebase.crashlytics.internal.concurrency.CrashlyticsWorkers;
+import com.google.firebase.crashlytics.internal.metadata.EventMetadata;
 import com.google.firebase.crashlytics.internal.metadata.LogFileManager;
 import com.google.firebase.crashlytics.internal.metadata.UserMetadata;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport;
@@ -42,6 +43,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
@@ -124,13 +126,14 @@ public class SessionReportingCoordinator {
   public void persistFatalEvent(
       @NonNull Throwable event, @NonNull Thread thread, @NonNull String sessionId, long timestamp) {
     Logger.getLogger().v("Persisting fatal event for session " + sessionId);
-    persistEvent(event, thread, sessionId, EVENT_TYPE_CRASH, timestamp, true);
+    EventMetadata eventMetadata = new EventMetadata(sessionId, timestamp, Map.of());
+    persistEvent(event, thread, EVENT_TYPE_CRASH, eventMetadata, true);
   }
 
   public void persistNonFatalEvent(
-      @NonNull Throwable event, @NonNull Thread thread, @NonNull String sessionId, long timestamp) {
-    Logger.getLogger().v("Persisting non-fatal event for session " + sessionId);
-    persistEvent(event, thread, sessionId, EVENT_TYPE_LOGGED, timestamp, false);
+      @NonNull Throwable event, @NonNull Thread thread, @NonNull EventMetadata eventMetadata) {
+    Logger.getLogger().v("Persisting non-fatal event for session " + eventMetadata.getSessionId());
+    persistEvent(event, thread, EVENT_TYPE_LOGGED, eventMetadata, false);
   }
 
   @RequiresApi(api = Build.VERSION_CODES.R)
@@ -253,23 +256,20 @@ public class SessionReportingCoordinator {
   }
 
   private CrashlyticsReport.Session.Event addMetaDataToEvent(
-      CrashlyticsReport.Session.Event capturedEvent) {
+      CrashlyticsReport.Session.Event capturedEvent, Map<String, String> eventCustomKeys) {
     CrashlyticsReport.Session.Event eventWithLogsAndCustomKeys =
-        addLogsAndCustomKeysToEvent(capturedEvent, logFileManager, reportMetadata);
+        addLogsCustomKeysAndEventKeysToEvent(
+            capturedEvent, logFileManager, reportMetadata, eventCustomKeys);
     CrashlyticsReport.Session.Event eventWithRollouts =
         addRolloutsStateToEvent(eventWithLogsAndCustomKeys, reportMetadata);
     return eventWithRollouts;
   }
 
-  private CrashlyticsReport.Session.Event addLogsAndCustomKeysToEvent(
-      CrashlyticsReport.Session.Event capturedEvent) {
-    return addLogsAndCustomKeysToEvent(capturedEvent, logFileManager, reportMetadata);
-  }
-
-  private CrashlyticsReport.Session.Event addLogsAndCustomKeysToEvent(
+  private CrashlyticsReport.Session.Event addLogsCustomKeysAndEventKeysToEvent(
       CrashlyticsReport.Session.Event capturedEvent,
       LogFileManager logFileManager,
-      UserMetadata reportMetadata) {
+      UserMetadata reportMetadata,
+      Map<String, String> eventKeys) {
     final CrashlyticsReport.Session.Event.Builder eventBuilder = capturedEvent.toBuilder();
     final String content = logFileManager.getLogString();
 
@@ -283,12 +283,18 @@ public class SessionReportingCoordinator {
     // TODO: Put this back once support for reports endpoint is removed.
     // logFileManager.clearLog(); // Clear log to prepare for next event.
 
+    // Merges the app level custom keys, with the event specific custom keys.
+    Map<String, String> customKeysMergedWithEventKeys =
+        new HashMap<>(reportMetadata.getCustomKeys());
+    customKeysMergedWithEventKeys.putAll(eventKeys);
+
     final List<CustomAttribute> sortedCustomAttributes =
-        getSortedCustomAttributes(reportMetadata.getCustomKeys());
+        getSortedCustomAttributes(customKeysMergedWithEventKeys);
     final List<CustomAttribute> sortedInternalKeys =
         getSortedCustomAttributes(reportMetadata.getInternalKeys());
 
     if (!sortedCustomAttributes.isEmpty() || !sortedInternalKeys.isEmpty()) {
+      // TODO(b/380072776): Change implementation to *not* override existing custom attributes.
       eventBuilder.setApp(
           capturedEvent.getApp().toBuilder()
               .setCustomAttributes(sortedCustomAttributes)
@@ -297,6 +303,14 @@ public class SessionReportingCoordinator {
     }
 
     return eventBuilder.build();
+  }
+
+  private CrashlyticsReport.Session.Event addLogsAndCustomKeysToEvent(
+      CrashlyticsReport.Session.Event capturedEvent,
+      LogFileManager logFileManager,
+      UserMetadata reportMetadata) {
+    return addLogsCustomKeysAndEventKeysToEvent(
+        capturedEvent, logFileManager, reportMetadata, Map.of());
   }
 
   private CrashlyticsReport.Session.Event addRolloutsStateToEvent(
@@ -319,9 +333,8 @@ public class SessionReportingCoordinator {
   private void persistEvent(
       @NonNull Throwable event,
       @NonNull Thread thread,
-      @NonNull String sessionId,
       @NonNull String eventType,
-      long timestamp,
+      @NonNull EventMetadata eventMetadata,
       boolean isFatal) {
 
     final boolean isHighPriority = eventType.equals(EVENT_TYPE_CRASH);
@@ -331,23 +344,25 @@ public class SessionReportingCoordinator {
             event,
             thread,
             eventType,
-            timestamp,
+            eventMetadata.getTimestamp(),
             EVENT_THREAD_IMPORTANCE,
             MAX_CHAINED_EXCEPTION_DEPTH,
             isFatal);
-    CrashlyticsReport.Session.Event finallizedEvent = addMetaDataToEvent(capturedEvent);
+    CrashlyticsReport.Session.Event finallizedEvent =
+        addMetaDataToEvent(capturedEvent, eventMetadata.getUserInfo());
 
     // Non-fatal, persistence write task we move to diskWriteWorker
     if (!isFatal) {
       crashlyticsWorkers.diskWrite.submit(
           () -> {
             Logger.getLogger().d("disk worker: log non-fatal event to persistence");
-            reportPersistence.persistEvent(finallizedEvent, sessionId, isHighPriority);
+            reportPersistence.persistEvent(
+                finallizedEvent, eventMetadata.getSessionId(), isHighPriority);
           });
       return;
     }
 
-    reportPersistence.persistEvent(finallizedEvent, sessionId, isHighPriority);
+    reportPersistence.persistEvent(finallizedEvent, eventMetadata.getSessionId(), isHighPriority);
   }
 
   private boolean onReportSendComplete(@NonNull Task<CrashlyticsReportWithSessionId> task) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
@@ -294,7 +294,6 @@ public class SessionReportingCoordinator {
         getSortedCustomAttributes(reportMetadata.getInternalKeys());
 
     if (!sortedCustomAttributes.isEmpty() || !sortedInternalKeys.isEmpty()) {
-      // TODO(b/380072776): Change implementation to *not* override existing custom attributes.
       eventBuilder.setApp(
           capturedEvent.getApp().toBuilder()
               .setCustomAttributes(sortedCustomAttributes)

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
@@ -126,7 +126,7 @@ public class SessionReportingCoordinator {
   public void persistFatalEvent(
       @NonNull Throwable event, @NonNull Thread thread, @NonNull String sessionId, long timestamp) {
     Logger.getLogger().v("Persisting fatal event for session " + sessionId);
-    EventMetadata eventMetadata = new EventMetadata(sessionId, timestamp, Map.of());
+    EventMetadata eventMetadata = new EventMetadata(sessionId, timestamp);
     persistEvent(event, thread, EVENT_TYPE_CRASH, eventMetadata, true);
   }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
@@ -342,7 +342,7 @@ public class SessionReportingCoordinator {
             MAX_CHAINED_EXCEPTION_DEPTH,
             isFatal);
     CrashlyticsReport.Session.Event finallizedEvent =
-        addMetaDataToEvent(capturedEvent, eventMetadata.getUserInfo());
+        addMetaDataToEvent(capturedEvent, eventMetadata.getAdditionalCustomKeys());
 
     // Non-fatal, persistence write task we move to diskWriteWorker
     if (!isFatal) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/EventMetadata.kt
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/EventMetadata.kt
@@ -1,0 +1,8 @@
+package com.google.firebase.crashlytics.internal.metadata
+
+/** A class that represents information to attach to a specific event. */
+data class EventMetadata(
+  val sessionId: String,
+  val timestamp: Long,
+  val userInfo: Map<String, String> = mapOf()
+)

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/EventMetadata.kt
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/EventMetadata.kt
@@ -15,7 +15,9 @@
 package com.google.firebase.crashlytics.internal.metadata
 
 /** A class that represents information to attach to a specific event. */
-data class EventMetadata(
+data class EventMetadata
+@JvmOverloads
+constructor(
   val sessionId: String,
   val timestamp: Long,
   val userInfo: Map<String, String> = mapOf()

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/EventMetadata.kt
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/EventMetadata.kt
@@ -19,13 +19,13 @@ package com.google.firebase.crashlytics.internal.metadata
  *
  * @property sessionId the sessionId to attach to the event.
  * @property timestamp the timestamp to attach to the event.
- * @property userInfo a [Map<String, String>] of key value pairs to attach to the event, in addition
- * to the global custom keys.
+ * @property additionalCustomKeys a [Map<String, String>] of key value pairs to attach to the event,
+ * in addition to the global custom keys.
  */
 data class EventMetadata
 @JvmOverloads
 constructor(
   val sessionId: String,
   val timestamp: Long,
-  val userInfo: Map<String, String> = mapOf()
+  val additionalCustomKeys: Map<String, String> = mapOf()
 )

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/EventMetadata.kt
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/EventMetadata.kt
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.firebase.crashlytics.internal.metadata
 
 /** A class that represents information to attach to a specific event. */

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/EventMetadata.kt
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/EventMetadata.kt
@@ -19,7 +19,8 @@ package com.google.firebase.crashlytics.internal.metadata
  *
  * @property sessionId the sessionId to attach to the event.
  * @property timestamp the timestamp to attach to the event.
- * @property userInfo a [Map<String, String>] of key value pairs to attach to the event.
+ * @property userInfo a [Map<String, String>] of key value pairs to attach to the event, in addition
+ * to the global custom keys.
  */
 data class EventMetadata
 @JvmOverloads

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/EventMetadata.kt
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/EventMetadata.kt
@@ -22,7 +22,7 @@ package com.google.firebase.crashlytics.internal.metadata
  * @property additionalCustomKeys a [Map<String, String>] of key value pairs to attach to the event,
  * in addition to the global custom keys.
  */
-data class EventMetadata
+internal data class EventMetadata
 @JvmOverloads
 constructor(
   val sessionId: String,

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/EventMetadata.kt
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/EventMetadata.kt
@@ -14,7 +14,13 @@
 
 package com.google.firebase.crashlytics.internal.metadata
 
-/** A class that represents information to attach to a specific event. */
+/**
+ * A class that represents information to attach to a specific event.
+ *
+ * @property sessionId the sessionId to attach to the event.
+ * @property timestamp the timestamp to attach to the event.
+ * @property userInfo a [Map<String, String>] of key value pairs to attach to the event.
+ */
 data class EventMetadata
 @JvmOverloads
 constructor(

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/KeysMap.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/KeysMap.java
@@ -54,7 +54,6 @@ class KeysMap {
       keys.put(sanitizedKey, value == null ? "" : sanitizedAttribute);
       return true;
     }
-    // TODO: Explore using a LinkedHashMap to overwrite keys in this case.
     Logger.getLogger()
         .w(
             "Ignored entry \""

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/KeysMap.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/KeysMap.java
@@ -48,11 +48,11 @@ class KeysMap {
     String sanitizedKey = sanitizeKey(key);
     // The entry can be added if we're under the size limit or we're updating an existing entry
     if (keys.size() < maxEntries || keys.containsKey(sanitizedKey)) {
-      String santitizedAttribute = sanitizeString(value, maxEntryLength);
-      if (CommonUtils.nullSafeEquals(keys.get(sanitizedKey), santitizedAttribute)) {
+      String sanitizedAttribute = sanitizeString(value, maxEntryLength);
+      if (CommonUtils.nullSafeEquals(keys.get(sanitizedKey), sanitizedAttribute)) {
         return false;
       }
-      keys.put(sanitizedKey, value == null ? "" : santitizedAttribute);
+      keys.put(sanitizedKey, value == null ? "" : sanitizedAttribute);
       return true;
     }
     // TODO: Explore using a LinkedHashMap to overwrite keys in this case.

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/KeysMap.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/KeysMap.java
@@ -19,7 +19,6 @@ import com.google.firebase.crashlytics.internal.Logger;
 import com.google.firebase.crashlytics.internal.common.CommonUtils;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 /** Handles any key/values for metadata. */

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/KeysMap.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/KeysMap.java
@@ -19,6 +19,7 @@ import com.google.firebase.crashlytics.internal.Logger;
 import com.google.firebase.crashlytics.internal.common.CommonUtils;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /** Handles any key/values for metadata. */
@@ -54,6 +55,7 @@ class KeysMap {
       keys.put(sanitizedKey, value == null ? "" : santitizedAttribute);
       return true;
     }
+    // TODO: Explore using a LinkedHashMap to overwrite keys in this case.
     Logger.getLogger()
         .w(
             "Ignored entry \""

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
@@ -152,6 +152,8 @@ public class UserMetadata {
         String key = KeysMap.sanitizeString(entry.getKey(), MAX_ATTRIBUTE_SIZE);
         String value = KeysMap.sanitizeString(entry.getValue(), MAX_ATTRIBUTE_SIZE);
         result.put(key, value);
+        
+        continue;
       }
 
       // TODO: Explore using a LinkedHashMap to overwrite keys in this case.

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
@@ -170,7 +170,7 @@ public class UserMetadata {
     if (eventKeysOverLimit > 0) {
       Logger.getLogger()
           .w(
-              "Ignored"
+              "Ignored "
                   + eventKeysOverLimit
                   + " keys when adding event specific keys. Maximum allowable: "
                   + MAX_ATTRIBUTE_SIZE);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
@@ -149,26 +149,33 @@ public class UserMetadata {
    */
   public Map<String, String> getCustomKeys(Map<String, String> eventKeys) {
     // In case of empty event keys, preserve existing behavior.
-    if (eventKeys.isEmpty()) { return customKeys.getKeys(); }
+    if (eventKeys.isEmpty()) {
+      return customKeys.getKeys();
+    }
 
     // Otherwise merge the event keys with custom keys as appropriate.
     Map<String, String> globalKeys = customKeys.getKeys();
     HashMap<String, String> result = new HashMap<>(globalKeys);
+    int eventKeysOverLimit = 0;
     for (Map.Entry<String, String> entry : eventKeys.entrySet()) {
       String sanitizedKey = KeysMap.sanitizeString(entry.getKey(), MAX_ATTRIBUTE_SIZE);
       if (result.size() < MAX_ATTRIBUTES || result.containsKey(sanitizedKey)) {
         String sanitizedValue = KeysMap.sanitizeString(entry.getValue(), MAX_ATTRIBUTE_SIZE);
         result.put(sanitizedKey, sanitizedValue);
-        continue;
+      } else {
+        eventKeysOverLimit++;
       }
+    }
 
+    if (eventKeysOverLimit > 0) {
       Logger.getLogger()
           .w(
-              "Ignored entry \""
-                  + entry.getKey()
-                  + "\" when adding event specific keys. Maximum allowable: "
+              "Ignored"
+                  + eventKeysOverLimit
+                  + " keys when adding event specific keys. Maximum allowable: "
                   + MAX_ATTRIBUTE_SIZE);
     }
+
     return Collections.unmodifiableMap(result);
   }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
@@ -149,7 +149,7 @@ public class UserMetadata {
    */
   public Map<String, String> getCustomKeys(Map<String, String> eventKeys) {
     // In case of empty event keys, preserve existing behavior.
-    if (eventKeys.isEmpty()) return customKeys.getKeys();
+    if (eventKeys.isEmpty()) { return customKeys.getKeys(); }
 
     // Otherwise merge the event keys with custom keys as appropriate.
     Map<String, String> globalKeys = customKeys.getKeys();

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
@@ -145,6 +145,10 @@ public class UserMetadata {
    * @return the {Map<String, String>} respecting the custom key constraints.
    */
   public Map<String, String> getCustomKeys(Map<String, String> eventKeys) {
+    // In case of empty event keys, preserve existing behavior.
+    if (eventKeys.isEmpty()) return customKeys.getKeys();
+
+    // Otherwise merge the event keys with custom keys as appropriate.
     Map<String, String> globalKeys = customKeys.getKeys();
     HashMap<String, String> result = new HashMap<>(globalKeys);
     for (Map.Entry<String, String> entry : eventKeys.entrySet()) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
@@ -138,11 +138,14 @@ public class UserMetadata {
     crashlyticsWorkers.diskWrite.submit(this::serializeUserDataIfNeeded);
   }
 
-  /** Creates a {Map<String, String>} with all the custom keys to attach to the event.
+  /**
+   * Returns a {@link Map<String, String>} containing all the custom keys to attach to the event.
+   * It overrides the values of app level custom keys with the values of event level custom keys if
+   * they're identical, and event keys or values that exceed 1024 characters are truncated.
+   * Combined with app level custom keys, the map is restricted to 64 key value pairs.
    *
-   * @param eventKeys a {Map<String, String>} representing event specific keys.
-   *
-   * @return the {Map<String, String>} respecting the custom key constraints.
+   * @param eventKeys a {@link Map<String, String>} representing event specific keys.
+   * @return a {@link Map<String, String>} containing all the custom keys to attach to the event.
    */
   public Map<String, String> getCustomKeys(Map<String, String> eventKeys) {
     // In case of empty event keys, preserve existing behavior.

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
@@ -22,6 +22,8 @@ import com.google.firebase.crashlytics.internal.common.CommonUtils;
 import com.google.firebase.crashlytics.internal.concurrency.CrashlyticsWorkers;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport;
 import com.google.firebase.crashlytics.internal.persistence.FileStore;
+
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -163,7 +165,7 @@ public class UserMetadata {
                   + MAX_ATTRIBUTES);
       break;
     }
-    return result;
+    return Collections.unmodifiableMap(result);
   }
 
   /**

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
@@ -148,15 +148,13 @@ public class UserMetadata {
     Map<String, String> globalKeys = customKeys.getKeys();
     HashMap<String, String> result = new HashMap<>(globalKeys);
     for (Map.Entry<String, String> entry : eventKeys.entrySet()) {
-      if (result.size() < MAX_ATTRIBUTES) {
-        String key = KeysMap.sanitizeString(entry.getKey(), MAX_ATTRIBUTE_SIZE);
-        String value = KeysMap.sanitizeString(entry.getValue(), MAX_ATTRIBUTE_SIZE);
-        result.put(key, value);
-        
+      String sanitizedKey = KeysMap.sanitizeString(entry.getKey(), MAX_ATTRIBUTE_SIZE);
+      if (result.size() < MAX_ATTRIBUTES || result.containsKey(sanitizedKey)) {
+        String sanitizedValue = KeysMap.sanitizeString(entry.getValue(), MAX_ATTRIBUTE_SIZE);
+        result.put(sanitizedKey, sanitizedValue);
         continue;
       }
 
-      // TODO: Explore using a LinkedHashMap to overwrite keys in this case.
       long ignoredEventKeysCount = eventKeys.size() - (MAX_ATTRIBUTES - globalKeys.size());
       Logger.getLogger()
           .w(

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
@@ -22,7 +22,6 @@ import com.google.firebase.crashlytics.internal.common.CommonUtils;
 import com.google.firebase.crashlytics.internal.concurrency.CrashlyticsWorkers;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport;
 import com.google.firebase.crashlytics.internal.persistence.FileStore;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -169,7 +168,6 @@ public class UserMetadata {
   }
 
   /**
-   *
    * @return defensive copy of the custom keys.
    */
   public Map<String, String> getCustomKeys() {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
@@ -159,14 +159,12 @@ public class UserMetadata {
         continue;
       }
 
-      long ignoredEventKeysCount = eventKeys.size() - (MAX_ATTRIBUTES - globalKeys.size());
       Logger.getLogger()
           .w(
-              "Ignored "
-                  + ignoredEventKeysCount
-                  + " event specific keys. Maximum key count is "
-                  + MAX_ATTRIBUTES);
-      break;
+              "Ignored entry \""
+                  + entry.getKey()
+                  + "\" when adding event specific keys. Maximum allowable: "
+                  + MAX_ATTRIBUTE_SIZE);
     }
     return Collections.unmodifiableMap(result);
   }


### PR DESCRIPTION
This PR adds a method `public void recordException(@NonNull Throwable throwable, CustomKeysAndValues keysAndValues)` as an overload to the existing `recordException` method in Crashlytics to allow attaching additional custom keys to the specific event.

Details:
- The total number of custom key/value pairs are still restricted to 64
- App level custom keys take precedence over event specific custom keys for the 64 key/value pair limit
- The values of event keys override the value of global custom keys if they're identical

Additionally:
- Creates a new EventMetadata class to represent `sessionId` and `timestamp` attached to non fatal events.