### PR TITLE
Bump AGP version to 8.3.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # javalite, protoc and protobufjavautil versions should be in sync while updating and
 # it needs to match the protobuf version which grpc has transitive dependency on, which
 # needs to match the version of grpc that grpc-kotlin has a transitive dependency on.
-androidGradlePlugin = "8.2.1"
+androidGradlePlugin = "8.3.2"
 android-lint = "31.3.2"
 autovalue = "1.10.1"
 coroutines = "1.7.3"


### PR DESCRIPTION
This is the latest version of AGP we can bump to without requiring us to bump gradle too.