### PR TITLE
[crashlytics] Specify the executor when calling onFailureListener

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+* [fixed] Execute failure listener outside the main thread  [#6535]
 
 # 19.2.1
 * [changed] Updated protobuf dependency to `3.25.5` to fix
@@ -634,4 +634,3 @@ The following release notes describe changes in the new SDK.
   from your `AndroidManifest.xml` file.
 * [removed] The `fabric.properties` and `crashlytics.properties` files are no
   longer supported. Remove them from your app.
-

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/CrashlyticsRegistrar.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/CrashlyticsRegistrar.java
@@ -18,6 +18,7 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.analytics.connector.AnalyticsConnector;
 import com.google.firebase.annotations.concurrent.Background;
 import com.google.firebase.annotations.concurrent.Blocking;
+import com.google.firebase.annotations.concurrent.Lightweight;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentContainer;
 import com.google.firebase.components.ComponentRegistrar;
@@ -42,6 +43,8 @@ public class CrashlyticsRegistrar implements ComponentRegistrar {
       Qualified.qualified(Background.class, ExecutorService.class);
   private final Qualified<ExecutorService> blockingExecutorService =
       Qualified.qualified(Blocking.class, ExecutorService.class);
+  private final Qualified<ExecutorService> lightweightExecutorService =
+      Qualified.qualified(Lightweight.class, ExecutorService.class);
 
   static {
     // Add Crashlytics as a dependency of Sessions when this class is loaded into memory.
@@ -57,6 +60,7 @@ public class CrashlyticsRegistrar implements ComponentRegistrar {
             .add(Dependency.required(FirebaseInstallationsApi.class))
             .add(Dependency.required(backgroundExecutorService))
             .add(Dependency.required(blockingExecutorService))
+            .add(Dependency.required(lightweightExecutorService))
             .add(Dependency.deferred(CrashlyticsNativeComponent.class))
             .add(Dependency.deferred(AnalyticsConnector.class))
             .add(Dependency.deferred(FirebaseRemoteConfigInterop.class))
@@ -79,7 +83,8 @@ public class CrashlyticsRegistrar implements ComponentRegistrar {
             container.getDeferred(AnalyticsConnector.class),
             container.getDeferred(FirebaseRemoteConfigInterop.class),
             container.get(backgroundExecutorService),
-            container.get(blockingExecutorService));
+            container.get(blockingExecutorService),
+            container.get(lightweightExecutorService));
 
     long duration = System.currentTimeMillis() - startTime;
     if (duration > 16) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -67,7 +67,8 @@ public class FirebaseCrashlytics {
       @NonNull Deferred<AnalyticsConnector> analyticsConnector,
       @NonNull Deferred<FirebaseRemoteConfigInterop> remoteConfigInteropDeferred,
       ExecutorService backgroundExecutorService,
-      ExecutorService blockingExecutorService) {
+      ExecutorService blockingExecutorService,
+      ExecutorService lightExecutorService) {
 
     Context context = app.getApplicationContext();
     final String appIdentifier = context.getPackageName();
@@ -160,7 +161,8 @@ public class FirebaseCrashlytics {
     // Kick off actually fetching the settings.
     settingsController
         .loadSettingsData(crashlyticsWorkers)
-        .addOnFailureListener(ex -> Logger.getLogger().e("Error fetching settings.", ex));
+        .addOnFailureListener(
+            lightExecutorService, ex -> Logger.getLogger().e("Error fetching settings.", ex));
 
     final boolean finishCoreInBackground = core.onPreExecute(appData, settingsController);
 


### PR DESCRIPTION
To prevent unwanted executions in the main thread, callbacks should specify the executor explicitly.