### PR TITLE
Fix inefficiency in the setCustomKeys Kotlin extension

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+* [fixed] Fixed inefficiency in the Kotlin `FirebaseCrashlytics.setCustomKeys` extension.
 
 # 19.2.1
 * [changed] Updated protobuf dependency to `3.25.5` to fix

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/CrashlyticsTests.kt
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/CrashlyticsTests.kt
@@ -68,13 +68,12 @@ class CrashlyticsTests {
 
     val result: Map<String, String> = keyValueBuilder.build().keysAndValues
 
-    // The result is not empty because we need to pass the CustomKeysAndValues around.
-    assertThat(result).isNotEmpty()
+    assertThat(result).containsExactly("hello", "world", "hello2", "23", "hello3", "0.1");
   }
 
   @Test
   fun keyValueBuilder_withCrashlyticsInstance() {
-    val keyValueBuilder = KeyValueBuilder(Firebase.crashlytics)
+    @Suppress("DEPRECATION") val keyValueBuilder = KeyValueBuilder(Firebase.crashlytics)
     keyValueBuilder.key("hello", "world")
     keyValueBuilder.key("hello2", 23)
     keyValueBuilder.key("hello3", 0.1)

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/CrashlyticsTests.kt
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/CrashlyticsTests.kt
@@ -68,8 +68,21 @@ class CrashlyticsTests {
 
     val result: Map<String, String> = keyValueBuilder.build().keysAndValues
 
-    // TODO(mrober): Make unit tests for this.
+    // The result is not empty because we need to pass the CustomKeysAndValues around.
     assertThat(result).isNotEmpty()
+  }
+
+  @Test
+  fun keyValueBuilder_withCrashlyticsInstance() {
+    val keyValueBuilder = KeyValueBuilder(Firebase.crashlytics)
+    keyValueBuilder.key("hello", "world")
+    keyValueBuilder.key("hello2", 23)
+    keyValueBuilder.key("hello3", 0.1)
+
+    val result: Map<String, String> = keyValueBuilder.build().keysAndValues
+
+    // The result is empty because it called crashlytics.setCustomKey for every key.
+    assertThat(result).isEmpty()
   }
 
   companion object {

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/CrashlyticsTests.kt
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/CrashlyticsTests.kt
@@ -59,6 +59,19 @@ class CrashlyticsTests {
     Firebase.app.get(UserAgentPublisher::class.java)
   }
 
+  @Test
+  fun keyValueBuilder() {
+    val keyValueBuilder = KeyValueBuilder()
+    keyValueBuilder.key("hello", "world")
+    keyValueBuilder.key("hello2", 23)
+    keyValueBuilder.key("hello3", 0.1)
+
+    val result: Map<String, String> = keyValueBuilder.build().keysAndValues
+
+    // TODO(mrober): Make unit tests for this.
+    assertThat(result).isNotEmpty()
+  }
+
   companion object {
     private const val APP_ID = "1:1:android:1a"
     private const val API_KEY = "API-KEY-API-KEY-API-KEY-API-KEY-API-KEY"

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/CrashlyticsTests.kt
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/CrashlyticsTests.kt
@@ -68,7 +68,7 @@ class CrashlyticsTests {
 
     val result: Map<String, String> = keyValueBuilder.build().keysAndValues
 
-    assertThat(result).containsExactly("hello", "world", "hello2", "23", "hello3", "0.1");
+    assertThat(result).containsExactly("hello", "world", "hello2", "23", "hello3", "0.1")
   }
 
   @Test

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/metadata/MetaDataStoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/metadata/MetaDataStoreTest.java
@@ -168,17 +168,15 @@ public class MetaDataStoreTest extends CrashlyticsTestCase {
   }
 
   @Test
-  // TODO(b/375437048): Let @daymxn know if this test fails. It's flaky and running away from me:(
   public void testWriteUserData_escaped() throws Exception {
     crashlyticsWorkers.diskWrite.submit(
-        () -> {
-          storeUnderTest.writeUserData(
-              SESSION_ID_1, metadataWithUserId(SESSION_ID_1, ESCAPED).getUserId());
-        });
+        () ->
+            storeUnderTest.writeUserData(
+                SESSION_ID_1, metadataWithUserId(SESSION_ID_1, ESCAPED).getUserId()));
     crashlyticsWorkers.diskWrite.await();
+    Thread.sleep(10);
     UserMetadata userData =
         UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, crashlyticsWorkers);
-    Thread.sleep(10);
     assertEquals(ESCAPED.trim(), userData.getUserId());
   }
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/metadata/MetaDataStoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/metadata/MetaDataStoreTest.java
@@ -118,13 +118,13 @@ public class MetaDataStoreTest extends CrashlyticsTestCase {
   }
 
   @Test
-  // TODO(b/375437048): Let @daymxn know if this test fails. It's flaky and running away from me:(
   public void testWriteUserData_singleField() throws Exception {
     crashlyticsWorkers.diskWrite.submit(
-        () -> {
-          storeUnderTest.writeUserData(SESSION_ID_1, metadataWithUserId(SESSION_ID_1).getUserId());
-        });
+        () ->
+            storeUnderTest.writeUserData(
+                SESSION_ID_1, metadataWithUserId(SESSION_ID_1).getUserId()));
     crashlyticsWorkers.diskWrite.await();
+    Thread.sleep(10);
     UserMetadata userData =
         UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, crashlyticsWorkers);
     assertEquals(USER_ID, userData.getUserId());

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.kt
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.kt
@@ -27,10 +27,8 @@ val Firebase.crashlytics: FirebaseCrashlytics
   get() = FirebaseCrashlytics.getInstance()
 
 /** Associates all key-value parameters with the reports */
-fun FirebaseCrashlytics.setCustomKeys(init: KeyValueBuilder.() -> Unit) {
-  val builder = KeyValueBuilder(this)
-  builder.init()
-}
+fun FirebaseCrashlytics.setCustomKeys(init: KeyValueBuilder.() -> Unit) =
+  setCustomKeys(KeyValueBuilder().apply(init).build())
 
 /** @suppress */
 @Keep

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/KeyValueBuilder.kt
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/KeyValueBuilder.kt
@@ -22,7 +22,9 @@ private constructor(
   private val crashlytics: FirebaseCrashlytics?,
   private val builder: CustomKeysAndValues.Builder,
 ) {
-  @Deprecated("Do not construct this directly. Use `setCustomKeys` instead. To be removed in 2025.")
+  @Deprecated(
+    "Do not construct this directly. Use `setCustomKeys` instead. To be removed in the next major release."
+  )
   constructor(crashlytics: FirebaseCrashlytics) : this(crashlytics, CustomKeysAndValues.Builder())
 
   internal constructor() : this(crashlytics = null, CustomKeysAndValues.Builder())

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/KeyValueBuilder.kt
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/KeyValueBuilder.kt
@@ -17,38 +17,43 @@
 package com.google.firebase.crashlytics
 
 /** Helper class to enable fluent syntax in [setCustomKeys] */
-class KeyValueBuilder internal constructor() {
+@Suppress("DEPRECATION")
+class KeyValueBuilder(
+  // TODO(mrober): Remove this param and make ctor internal in 2025.
+  @Deprecated(message = "The crashlytics instance is no longer needed and will be removed in 2025.")
+  private val crashlytics: FirebaseCrashlytics? = null
+) {
   private val builder = CustomKeysAndValues.Builder()
 
   internal fun build(): CustomKeysAndValues = builder.build()
 
   /** Sets a custom key and value that are associated with reports. */
   fun key(key: String, value: Boolean) {
-    builder.putBoolean(key, value)
+    crashlytics?.setCustomKey(key, value) ?: builder.putBoolean(key, value)
   }
 
   /** Sets a custom key and value that are associated with reports. */
   fun key(key: String, value: Double) {
-    builder.putDouble(key, value)
+    crashlytics?.setCustomKey(key, value) ?: builder.putDouble(key, value)
   }
 
   /** Sets a custom key and value that are associated with reports. */
   fun key(key: String, value: Float) {
-    builder.putFloat(key, value)
+    crashlytics?.setCustomKey(key, value) ?: builder.putFloat(key, value)
   }
 
   /** Sets a custom key and value that are associated with reports. */
   fun key(key: String, value: Int) {
-    builder.putInt(key, value)
+    crashlytics?.setCustomKey(key, value) ?: builder.putInt(key, value)
   }
 
   /** Sets a custom key and value that are associated with reports. */
   fun key(key: String, value: Long) {
-    builder.putLong(key, value)
+    crashlytics?.setCustomKey(key, value) ?: builder.putLong(key, value)
   }
 
   /** Sets a custom key and value that are associated with reports. */
   fun key(key: String, value: String) {
-    builder.putString(key, value)
+    crashlytics?.setCustomKey(key, value) ?: builder.putString(key, value)
   }
 }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/KeyValueBuilder.kt
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/KeyValueBuilder.kt
@@ -17,23 +17,38 @@
 package com.google.firebase.crashlytics
 
 /** Helper class to enable fluent syntax in [setCustomKeys] */
-class KeyValueBuilder(private val crashlytics: FirebaseCrashlytics) {
+class KeyValueBuilder internal constructor() {
+  private val builder = CustomKeysAndValues.Builder()
+
+  internal fun build(): CustomKeysAndValues = builder.build()
 
   /** Sets a custom key and value that are associated with reports. */
-  fun key(key: String, value: Boolean) = crashlytics.setCustomKey(key, value)
+  fun key(key: String, value: Boolean) {
+    builder.putBoolean(key, value)
+  }
 
   /** Sets a custom key and value that are associated with reports. */
-  fun key(key: String, value: Double) = crashlytics.setCustomKey(key, value)
+  fun key(key: String, value: Double) {
+    builder.putDouble(key, value)
+  }
 
   /** Sets a custom key and value that are associated with reports. */
-  fun key(key: String, value: Float) = crashlytics.setCustomKey(key, value)
+  fun key(key: String, value: Float) {
+    builder.putFloat(key, value)
+  }
 
   /** Sets a custom key and value that are associated with reports. */
-  fun key(key: String, value: Int) = crashlytics.setCustomKey(key, value)
+  fun key(key: String, value: Int) {
+    builder.putInt(key, value)
+  }
 
   /** Sets a custom key and value that are associated with reports. */
-  fun key(key: String, value: Long) = crashlytics.setCustomKey(key, value)
+  fun key(key: String, value: Long) {
+    builder.putLong(key, value)
+  }
 
   /** Sets a custom key and value that are associated with reports. */
-  fun key(key: String, value: String) = crashlytics.setCustomKey(key, value)
+  fun key(key: String, value: String) {
+    builder.putString(key, value)
+  }
 }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/KeyValueBuilder.kt
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/KeyValueBuilder.kt
@@ -16,14 +16,15 @@
 
 package com.google.firebase.crashlytics
 
-/** Helper class to enable fluent syntax in [setCustomKeys] */
-@Suppress("DEPRECATION")
-class KeyValueBuilder(
-  // TODO(mrober): Remove this param and make ctor internal in 2025.
-  @Deprecated(message = "The crashlytics instance is no longer needed and will be removed in 2025.")
-  private val crashlytics: FirebaseCrashlytics? = null
+/** Helper class to enable convenient syntax in [setCustomKeys] */
+class KeyValueBuilder private constructor(
+  private val crashlytics: FirebaseCrashlytics?,
+  private val builder: CustomKeysAndValues.Builder,
 ) {
-  private val builder = CustomKeysAndValues.Builder()
+  @Deprecated("Do not construct this directly. Use `setCustomKeys` instead. To be removed in 2025.")
+  constructor(crashlytics: FirebaseCrashlytics) : this(crashlytics, CustomKeysAndValues.Builder())
+
+  internal constructor() : this(crashlytics = null, CustomKeysAndValues.Builder())
 
   internal fun build(): CustomKeysAndValues = builder.build()
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/KeyValueBuilder.kt
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/KeyValueBuilder.kt
@@ -17,7 +17,8 @@
 package com.google.firebase.crashlytics
 
 /** Helper class to enable convenient syntax in [setCustomKeys] */
-class KeyValueBuilder private constructor(
+class KeyValueBuilder
+private constructor(
   private val crashlytics: FirebaseCrashlytics?,
   private val builder: CustomKeysAndValues.Builder,
 ) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -368,7 +368,9 @@ public class CrashlyticsCore {
    * @throws NullPointerException if any key in keysAndValues is null.
    */
   public void setCustomKeys(Map<String, String> keysAndValues) {
-    crashlyticsWorkers.common.submit(() -> controller.setCustomKeys(keysAndValues));
+    if (!keysAndValues.isEmpty()) {
+      crashlyticsWorkers.common.submit(() -> controller.setCustomKeys(keysAndValues));
+    }
   }
 
   // endregion


### PR DESCRIPTION
Fixed inefficiency in the Kotlin `FirebaseCrashlytics.setCustomKeys` extension.

The old implementation called `setCustomKey` for every key/value pair, which serializes to disk, and is not an intuitive behaviour for customers. This now calls `setCustomKeys` once with the entire built map.

This proxies to the existing Java `CustomKeysAndValues.Builder` but gives nice Kotlin syntax. The old class had a public ctor, I plan to make this internal since customers shouldn't instantiate this class directly. This is done in a way to not break the api, even though the api is internal.

pair=tejasd