### PR TITLE
Rename ConfigMetadataClient to ConfigSharedPrefsClient 

### DIFF
--- a/firebase-config/ktx/src/test/kotlin/com/google/firebase/remoteconfig/TestConstructorUtil.kt
+++ b/firebase-config/ktx/src/test/kotlin/com/google/firebase/remoteconfig/TestConstructorUtil.kt
@@ -23,8 +23,8 @@ import com.google.firebase.installations.FirebaseInstallationsApi
 import com.google.firebase.remoteconfig.internal.ConfigCacheClient
 import com.google.firebase.remoteconfig.internal.ConfigFetchHandler
 import com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler
-import com.google.firebase.remoteconfig.internal.ConfigMetadataClient
 import com.google.firebase.remoteconfig.internal.ConfigRealtimeHandler
+import com.google.firebase.remoteconfig.internal.ConfigSharedPrefsClient
 import com.google.firebase.remoteconfig.internal.rollouts.RolloutsStateSubscriptionsHandler
 import java.util.concurrent.Executor
 
@@ -41,7 +41,7 @@ fun createRemoteConfig(
   defaultConfigsCache: ConfigCacheClient,
   fetchHandler: ConfigFetchHandler,
   getHandler: ConfigGetParameterHandler,
-  frcMetadata: ConfigMetadataClient,
+  frcSharedPrefs: ConfigSharedPrefsClient,
   realtimeHandler: ConfigRealtimeHandler,
   rolloutsStateSubscriptionsHandler: RolloutsStateSubscriptionsHandler
 ): FirebaseRemoteConfig {
@@ -56,7 +56,7 @@ fun createRemoteConfig(
     defaultConfigsCache,
     fetchHandler,
     getHandler,
-    frcMetadata,
+    frcSharedPrefs,
     realtimeHandler,
     rolloutsStateSubscriptionsHandler
   )

--- a/firebase-config/ktx/src/test/kotlin/com/google/firebase/remoteconfig/ktx/RemoteConfigTests.kt
+++ b/firebase-config/ktx/src/test/kotlin/com/google/firebase/remoteconfig/ktx/RemoteConfigTests.kt
@@ -32,8 +32,8 @@ import com.google.firebase.remoteconfig.createRemoteConfig
 import com.google.firebase.remoteconfig.internal.ConfigCacheClient
 import com.google.firebase.remoteconfig.internal.ConfigFetchHandler
 import com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler
-import com.google.firebase.remoteconfig.internal.ConfigMetadataClient
 import com.google.firebase.remoteconfig.internal.ConfigRealtimeHandler
+import com.google.firebase.remoteconfig.internal.ConfigSharedPrefsClient
 import com.google.firebase.remoteconfig.internal.rollouts.RolloutsStateSubscriptionsHandler
 import org.junit.After
 import org.junit.Before
@@ -142,7 +142,7 @@ class ConfigTests : BaseTestCase() {
         defaultConfigsCache = mock(ConfigCacheClient::class.java),
         fetchHandler = mock(ConfigFetchHandler::class.java),
         getHandler = mockGetHandler,
-        frcMetadata = mock(ConfigMetadataClient::class.java),
+        frcSharedPrefs = mock(ConfigSharedPrefsClient::class.java),
         realtimeHandler = mock(ConfigRealtimeHandler::class.java),
         rolloutsStateSubscriptionsHandler = mock(RolloutsStateSubscriptionsHandler::class.java)
       )

--- a/firebase-config/src/androidTest/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigIntegrationTest.java
+++ b/firebase-config/src/androidTest/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigIntegrationTest.java
@@ -35,8 +35,8 @@ import com.google.firebase.remoteconfig.internal.ConfigCacheClient;
 import com.google.firebase.remoteconfig.internal.ConfigContainer;
 import com.google.firebase.remoteconfig.internal.ConfigFetchHandler;
 import com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler;
-import com.google.firebase.remoteconfig.internal.ConfigMetadataClient;
 import com.google.firebase.remoteconfig.internal.ConfigRealtimeHandler;
+import com.google.firebase.remoteconfig.internal.ConfigSharedPrefsClient;
 import com.google.firebase.remoteconfig.internal.rollouts.RolloutsStateSubscriptionsHandler;
 import java.util.Date;
 import java.util.HashMap;
@@ -60,7 +60,7 @@ public class FirebaseRemoteConfigIntegrationTest {
   @Mock private ConfigCacheClient mockDefaultsCache;
   @Mock private ConfigFetchHandler mockFetchHandler;
   @Mock private ConfigGetParameterHandler mockGetHandler;
-  @Mock private ConfigMetadataClient metadataClient;
+  @Mock private ConfigSharedPrefsClient sharedPrefsClient;
   @Mock private ConfigRealtimeHandler mockConfigRealtimeHandler;
   @Mock private RolloutsStateSubscriptionsHandler mockRolloutsStateSubscriptionHandler;
 
@@ -112,7 +112,7 @@ public class FirebaseRemoteConfigIntegrationTest {
             mockDefaultsCache,
             mockFetchHandler,
             mockGetHandler,
-            metadataClient,
+            sharedPrefsClient,
             mockConfigRealtimeHandler,
             mockRolloutsStateSubscriptionHandler);
   }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -33,8 +33,8 @@ import com.google.firebase.remoteconfig.internal.ConfigContainer;
 import com.google.firebase.remoteconfig.internal.ConfigFetchHandler;
 import com.google.firebase.remoteconfig.internal.ConfigFetchHandler.FetchResponse;
 import com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler;
-import com.google.firebase.remoteconfig.internal.ConfigMetadataClient;
 import com.google.firebase.remoteconfig.internal.ConfigRealtimeHandler;
+import com.google.firebase.remoteconfig.internal.ConfigSharedPrefsClient;
 import com.google.firebase.remoteconfig.internal.DefaultsXmlParser;
 import com.google.firebase.remoteconfig.internal.rollouts.RolloutsStateSubscriptionsHandler;
 import java.util.ArrayList;
@@ -160,7 +160,7 @@ public class FirebaseRemoteConfig {
   private final ConfigCacheClient defaultConfigsCache;
   private final ConfigFetchHandler fetchHandler;
   private final ConfigGetParameterHandler getHandler;
-  private final ConfigMetadataClient frcMetadata;
+  private final ConfigSharedPrefsClient frcSharedPrefs;
   private final FirebaseInstallationsApi firebaseInstallations;
   private final ConfigRealtimeHandler configRealtimeHandler;
   private final RolloutsStateSubscriptionsHandler rolloutsStateSubscriptionsHandler;
@@ -181,7 +181,7 @@ public class FirebaseRemoteConfig {
       ConfigCacheClient defaultConfigsCache,
       ConfigFetchHandler fetchHandler,
       ConfigGetParameterHandler getHandler,
-      ConfigMetadataClient frcMetadata,
+      ConfigSharedPrefsClient frcSharedPrefs,
       ConfigRealtimeHandler configRealtimeHandler,
       RolloutsStateSubscriptionsHandler rolloutsStateSubscriptionsHandler) {
     this.context = context;
@@ -194,7 +194,7 @@ public class FirebaseRemoteConfig {
     this.defaultConfigsCache = defaultConfigsCache;
     this.fetchHandler = fetchHandler;
     this.getHandler = getHandler;
-    this.frcMetadata = frcMetadata;
+    this.frcSharedPrefs = frcSharedPrefs;
     this.configRealtimeHandler = configRealtimeHandler;
     this.rolloutsStateSubscriptionsHandler = rolloutsStateSubscriptionsHandler;
   }
@@ -208,7 +208,7 @@ public class FirebaseRemoteConfig {
     Task<ConfigContainer> activatedConfigsTask = activatedConfigsCache.get();
     Task<ConfigContainer> defaultsConfigsTask = defaultConfigsCache.get();
     Task<ConfigContainer> fetchedConfigsTask = fetchedConfigsCache.get();
-    Task<FirebaseRemoteConfigInfo> metadataTask = Tasks.call(executor, this::getInfo);
+    Task<FirebaseRemoteConfigInfo> sharedPrefsTask = Tasks.call(executor, this::getInfo);
     Task<String> installationIdTask = firebaseInstallations.getId();
     Task<InstallationTokenResult> installationTokenTask = firebaseInstallations.getToken(false);
 
@@ -216,10 +216,10 @@ public class FirebaseRemoteConfig {
             activatedConfigsTask,
             defaultsConfigsTask,
             fetchedConfigsTask,
-            metadataTask,
+            sharedPrefsTask,
             installationIdTask,
             installationTokenTask)
-        .continueWith(executor, (unusedListOfCompletedTasks) -> metadataTask.getResult());
+        .continueWith(executor, (unusedListOfCompletedTasks) -> sharedPrefsTask.getResult());
   }
 
   /**
@@ -475,7 +475,7 @@ public class FirebaseRemoteConfig {
    */
   @NonNull
   public FirebaseRemoteConfigInfo getInfo() {
-    return frcMetadata.getInfo();
+    return frcSharedPrefs.getInfo();
   }
 
   /**
@@ -488,7 +488,7 @@ public class FirebaseRemoteConfig {
     return Tasks.call(
         executor,
         () -> {
-          frcMetadata.setConfigSettings(settings);
+          frcSharedPrefs.setConfigSettings(settings);
 
           // Return value required; return null for Void.
           return null;
@@ -548,14 +548,14 @@ public class FirebaseRemoteConfig {
   @NonNull
   public Task<Void> reset() {
     // Use a Task to avoid throwing potential file I/O errors to the caller and because
-    // frcMetadata's clear call is blocking.
+    // frcSharedPrefs's clear call is blocking.
     return Tasks.call(
         executor,
         () -> {
           activatedConfigsCache.clear();
           fetchedConfigsCache.clear();
           defaultConfigsCache.clear();
-          frcMetadata.clear();
+          frcSharedPrefs.clear();
           return null;
         });
   }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
@@ -36,8 +36,8 @@ import com.google.firebase.remoteconfig.internal.ConfigCacheClient;
 import com.google.firebase.remoteconfig.internal.ConfigFetchHandler;
 import com.google.firebase.remoteconfig.internal.ConfigFetchHttpClient;
 import com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler;
-import com.google.firebase.remoteconfig.internal.ConfigMetadataClient;
 import com.google.firebase.remoteconfig.internal.ConfigRealtimeHandler;
+import com.google.firebase.remoteconfig.internal.ConfigSharedPrefsClient;
 import com.google.firebase.remoteconfig.internal.ConfigStorageClient;
 import com.google.firebase.remoteconfig.internal.Personalization;
 import com.google.firebase.remoteconfig.internal.rollouts.RolloutsStateFactory;
@@ -166,7 +166,7 @@ public class RemoteConfigComponent implements FirebaseRemoteConfigInterop {
     ConfigCacheClient fetchedCacheClient = getCacheClient(namespace, FETCH_FILE_NAME);
     ConfigCacheClient activatedCacheClient = getCacheClient(namespace, ACTIVATE_FILE_NAME);
     ConfigCacheClient defaultsCacheClient = getCacheClient(namespace, DEFAULTS_FILE_NAME);
-    ConfigMetadataClient metadataClient = getMetadataClient(context, appId, namespace);
+    ConfigSharedPrefsClient sharedPrefsClient = getSharedPrefsClient(context, appId, namespace);
 
     ConfigGetParameterHandler getHandler = getGetHandler(activatedCacheClient, defaultsCacheClient);
     Personalization personalization =
@@ -187,9 +187,9 @@ public class RemoteConfigComponent implements FirebaseRemoteConfigInterop {
         fetchedCacheClient,
         activatedCacheClient,
         defaultsCacheClient,
-        getFetchHandler(namespace, fetchedCacheClient, metadataClient),
+        getFetchHandler(namespace, fetchedCacheClient, sharedPrefsClient),
         getHandler,
-        metadataClient,
+        sharedPrefsClient,
         rolloutsStateSubscriptionsHandler);
   }
 
@@ -206,7 +206,7 @@ public class RemoteConfigComponent implements FirebaseRemoteConfigInterop {
       ConfigCacheClient defaultsClient,
       ConfigFetchHandler fetchHandler,
       ConfigGetParameterHandler getHandler,
-      ConfigMetadataClient metadataClient,
+      ConfigSharedPrefsClient sharedPrefsClient,
       RolloutsStateSubscriptionsHandler rolloutsStateSubscriptionsHandler) {
     if (!frcNamespaceInstances.containsKey(namespace)) {
       FirebaseRemoteConfig in =
@@ -221,7 +221,7 @@ public class RemoteConfigComponent implements FirebaseRemoteConfigInterop {
               defaultsClient,
               fetchHandler,
               getHandler,
-              metadataClient,
+              sharedPrefsClient,
               getRealtime(
                   firebaseApp,
                   firebaseInstallations,
@@ -229,7 +229,7 @@ public class RemoteConfigComponent implements FirebaseRemoteConfigInterop {
                   activatedClient,
                   context,
                   namespace,
-                  metadataClient),
+                  sharedPrefsClient),
               rolloutsStateSubscriptionsHandler);
       in.startLoadingConfigsFromDisk();
       frcNamespaceInstances.put(namespace, in);
@@ -254,20 +254,22 @@ public class RemoteConfigComponent implements FirebaseRemoteConfigInterop {
 
   @VisibleForTesting
   ConfigFetchHttpClient getFrcBackendApiClient(
-      String apiKey, String namespace, ConfigMetadataClient metadataClient) {
+      String apiKey, String namespace, ConfigSharedPrefsClient sharedPrefsClient) {
     String appId = firebaseApp.getOptions().getApplicationId();
     return new ConfigFetchHttpClient(
         context,
         appId,
         apiKey,
         namespace,
-        /* connectTimeoutInSeconds= */ metadataClient.getFetchTimeoutInSeconds(),
-        /* readTimeoutInSeconds= */ metadataClient.getFetchTimeoutInSeconds());
+        /* connectTimeoutInSeconds= */ sharedPrefsClient.getFetchTimeoutInSeconds(),
+        /* readTimeoutInSeconds= */ sharedPrefsClient.getFetchTimeoutInSeconds());
   }
 
   @VisibleForTesting
   synchronized ConfigFetchHandler getFetchHandler(
-      String namespace, ConfigCacheClient fetchedCacheClient, ConfigMetadataClient metadataClient) {
+      String namespace,
+      ConfigCacheClient fetchedCacheClient,
+      ConfigSharedPrefsClient sharedPrefsClient) {
     return new ConfigFetchHandler(
         firebaseInstallations,
         isPrimaryApp(firebaseApp) ? analyticsConnector : () -> null,
@@ -275,8 +277,8 @@ public class RemoteConfigComponent implements FirebaseRemoteConfigInterop {
         DEFAULT_CLOCK,
         DEFAULT_RANDOM,
         fetchedCacheClient,
-        getFrcBackendApiClient(firebaseApp.getOptions().getApiKey(), namespace, metadataClient),
-        metadataClient,
+        getFrcBackendApiClient(firebaseApp.getOptions().getApiKey(), namespace, sharedPrefsClient),
+        sharedPrefsClient,
         this.customHeaders);
   }
 
@@ -287,7 +289,7 @@ public class RemoteConfigComponent implements FirebaseRemoteConfigInterop {
       ConfigCacheClient activatedCacheClient,
       Context context,
       String namespace,
-      ConfigMetadataClient metadataClient) {
+      ConfigSharedPrefsClient sharedPrefsClient) {
     return new ConfigRealtimeHandler(
         firebaseApp,
         firebaseInstallations,
@@ -295,7 +297,7 @@ public class RemoteConfigComponent implements FirebaseRemoteConfigInterop {
         activatedCacheClient,
         context,
         namespace,
-        metadataClient,
+        sharedPrefsClient,
         executor);
   }
 
@@ -305,13 +307,14 @@ public class RemoteConfigComponent implements FirebaseRemoteConfigInterop {
   }
 
   @VisibleForTesting
-  static ConfigMetadataClient getMetadataClient(Context context, String appId, String namespace) {
+  static ConfigSharedPrefsClient getSharedPrefsClient(
+      Context context, String appId, String namespace) {
     String fileName =
         String.format(
             "%s_%s_%s_%s",
             FIREBASE_REMOTE_CONFIG_FILE_NAME_PREFIX, appId, namespace, PREFERENCES_FILE_NAME);
     SharedPreferences preferences = context.getSharedPreferences(fileName, Context.MODE_PRIVATE);
-    return new ConfigMetadataClient(preferences);
+    return new ConfigSharedPrefsClient(preferences);
   }
 
   @Nullable

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
@@ -39,7 +39,7 @@ public class ConfigRealtimeHandler {
   private final ConfigCacheClient activatedCacheClient;
   private final Context context;
   private final String namespace;
-  private final ConfigMetadataClient metadataClient;
+  private final ConfigSharedPrefsClient sharedPrefsClient;
   private final ScheduledExecutorService scheduledExecutorService;
 
   public ConfigRealtimeHandler(
@@ -49,7 +49,7 @@ public class ConfigRealtimeHandler {
       ConfigCacheClient activatedCacheClient,
       Context context,
       String namespace,
-      ConfigMetadataClient metadataClient,
+      ConfigSharedPrefsClient sharedPrefsClient,
       ScheduledExecutorService scheduledExecutorService) {
 
     this.listeners = new LinkedHashSet<>();
@@ -62,7 +62,7 @@ public class ConfigRealtimeHandler {
             context,
             namespace,
             listeners,
-            metadataClient,
+            sharedPrefsClient,
             scheduledExecutorService);
 
     this.firebaseApp = firebaseApp;
@@ -71,7 +71,7 @@ public class ConfigRealtimeHandler {
     this.activatedCacheClient = activatedCacheClient;
     this.context = context;
     this.namespace = namespace;
-    this.metadataClient = metadataClient;
+    this.sharedPrefsClient = sharedPrefsClient;
     this.scheduledExecutorService = scheduledExecutorService;
   }
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigSharedPrefsClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigSharedPrefsClient.java
@@ -33,12 +33,12 @@ import java.lang.annotation.Retention;
 import java.util.Date;
 
 /**
- * Client for handling Firebase Remote Config (FRC) metadata that is saved to disk and persisted
- * across App life cycles.
+ * Client for handling Firebase Remote Config (FRC) metadata and custom signals that are saved to
+ * disk and persisted across App life cycles.
  *
  * @author Miraziz Yusupov
  */
-public class ConfigMetadataClient {
+public class ConfigSharedPrefsClient {
   @Retention(SOURCE)
   @IntDef({
     LAST_FETCH_STATUS_SUCCESS,
@@ -75,65 +75,66 @@ public class ConfigMetadataClient {
   private static final String REALTIME_BACKOFF_END_TIME_IN_MILLIS_KEY =
       "realtime_backoff_end_time_in_millis";
 
-  private final SharedPreferences frcMetadata;
+  private final SharedPreferences frcSharedPrefs;
 
   private final Object frcInfoLock;
   private final Object backoffMetadataLock;
   private final Object realtimeBackoffMetadataLock;
 
-  public ConfigMetadataClient(SharedPreferences frcMetadata) {
-    this.frcMetadata = frcMetadata;
+  public ConfigSharedPrefsClient(SharedPreferences frcSharedPrefs) {
+    this.frcSharedPrefs = frcSharedPrefs;
     this.frcInfoLock = new Object();
     this.backoffMetadataLock = new Object();
     this.realtimeBackoffMetadataLock = new Object();
   }
 
   public long getFetchTimeoutInSeconds() {
-    return frcMetadata.getLong(FETCH_TIMEOUT_IN_SECONDS_KEY, CONNECTION_TIMEOUT_IN_SECONDS);
+    return frcSharedPrefs.getLong(FETCH_TIMEOUT_IN_SECONDS_KEY, CONNECTION_TIMEOUT_IN_SECONDS);
   }
 
   public long getMinimumFetchIntervalInSeconds() {
-    return frcMetadata.getLong(
+    return frcSharedPrefs.getLong(
         MINIMUM_FETCH_INTERVAL_IN_SECONDS_KEY, DEFAULT_MINIMUM_FETCH_INTERVAL_IN_SECONDS);
   }
 
   @LastFetchStatus
   int getLastFetchStatus() {
-    return frcMetadata.getInt(LAST_FETCH_STATUS_KEY, LAST_FETCH_STATUS_NO_FETCH_YET);
+    return frcSharedPrefs.getInt(LAST_FETCH_STATUS_KEY, LAST_FETCH_STATUS_NO_FETCH_YET);
   }
 
   Date getLastSuccessfulFetchTime() {
     return new Date(
-        frcMetadata.getLong(
+        frcSharedPrefs.getLong(
             LAST_SUCCESSFUL_FETCH_TIME_IN_MILLIS_KEY, LAST_FETCH_TIME_IN_MILLIS_NO_FETCH_YET));
   }
 
   @Nullable
   String getLastFetchETag() {
-    return frcMetadata.getString(LAST_FETCH_ETAG_KEY, null);
+    return frcSharedPrefs.getString(LAST_FETCH_ETAG_KEY, null);
   }
 
   long getLastTemplateVersion() {
-    return frcMetadata.getLong(LAST_TEMPLATE_VERSION, 0);
+    return frcSharedPrefs.getLong(LAST_TEMPLATE_VERSION, 0);
   }
 
   public FirebaseRemoteConfigInfo getInfo() {
     // A lock is used here to prevent the setters in this class from changing the state of
-    // frcMetadata during a getInfo call.
+    // frcSharedPrefs during a getInfo call.
     synchronized (frcInfoLock) {
       long lastSuccessfulFetchTimeInMillis =
-          frcMetadata.getLong(
+          frcSharedPrefs.getLong(
               LAST_SUCCESSFUL_FETCH_TIME_IN_MILLIS_KEY, LAST_FETCH_TIME_IN_MILLIS_NO_FETCH_YET);
       @LastFetchStatus
       int lastFetchStatus =
-          frcMetadata.getInt(LAST_FETCH_STATUS_KEY, LAST_FETCH_STATUS_NO_FETCH_YET);
+          frcSharedPrefs.getInt(LAST_FETCH_STATUS_KEY, LAST_FETCH_STATUS_NO_FETCH_YET);
 
       FirebaseRemoteConfigSettings settings =
           new FirebaseRemoteConfigSettings.Builder()
               .setFetchTimeoutInSeconds(
-                  frcMetadata.getLong(FETCH_TIMEOUT_IN_SECONDS_KEY, CONNECTION_TIMEOUT_IN_SECONDS))
+                  frcSharedPrefs.getLong(
+                      FETCH_TIMEOUT_IN_SECONDS_KEY, CONNECTION_TIMEOUT_IN_SECONDS))
               .setMinimumFetchIntervalInSeconds(
-                  frcMetadata.getLong(
+                  frcSharedPrefs.getLong(
                       MINIMUM_FETCH_INTERVAL_IN_SECONDS_KEY,
                       DEFAULT_MINIMUM_FETCH_INTERVAL_IN_SECONDS))
               .build();
@@ -147,14 +148,14 @@ public class ConfigMetadataClient {
   }
 
   /**
-   * Clears all metadata values from memory and disk.
+   * Clears all metadata and custom signals values from memory and disk.
    *
    * <p>The method is blocking and returns only when the values in disk are also cleared.
    */
   @WorkerThread
   public void clear() {
     synchronized (frcInfoLock) {
-      frcMetadata.edit().clear().commit();
+      frcSharedPrefs.edit().clear().commit();
     }
   }
 
@@ -167,7 +168,7 @@ public class ConfigMetadataClient {
   @WorkerThread
   public void setConfigSettings(FirebaseRemoteConfigSettings settings) {
     synchronized (frcInfoLock) {
-      frcMetadata
+      frcSharedPrefs
           .edit()
           .putLong(FETCH_TIMEOUT_IN_SECONDS_KEY, settings.getFetchTimeoutInSeconds())
           .putLong(
@@ -184,7 +185,7 @@ public class ConfigMetadataClient {
    */
   public void setConfigSettingsWithoutWaitingOnDiskWrite(FirebaseRemoteConfigSettings settings) {
     synchronized (frcInfoLock) {
-      frcMetadata
+      frcSharedPrefs
           .edit()
           .putLong(FETCH_TIMEOUT_IN_SECONDS_KEY, settings.getFetchTimeoutInSeconds())
           .putLong(
@@ -195,7 +196,7 @@ public class ConfigMetadataClient {
 
   void updateLastFetchAsSuccessfulAt(Date fetchTime) {
     synchronized (frcInfoLock) {
-      frcMetadata
+      frcSharedPrefs
           .edit()
           .putInt(LAST_FETCH_STATUS_KEY, LAST_FETCH_STATUS_SUCCESS)
           .putLong(LAST_SUCCESSFUL_FETCH_TIME_IN_MILLIS_KEY, fetchTime.getTime())
@@ -205,25 +206,25 @@ public class ConfigMetadataClient {
 
   void updateLastFetchAsFailed() {
     synchronized (frcInfoLock) {
-      frcMetadata.edit().putInt(LAST_FETCH_STATUS_KEY, LAST_FETCH_STATUS_FAILURE).apply();
+      frcSharedPrefs.edit().putInt(LAST_FETCH_STATUS_KEY, LAST_FETCH_STATUS_FAILURE).apply();
     }
   }
 
   void updateLastFetchAsThrottled() {
     synchronized (frcInfoLock) {
-      frcMetadata.edit().putInt(LAST_FETCH_STATUS_KEY, LAST_FETCH_STATUS_THROTTLED).apply();
+      frcSharedPrefs.edit().putInt(LAST_FETCH_STATUS_KEY, LAST_FETCH_STATUS_THROTTLED).apply();
     }
   }
 
   void setLastFetchETag(String eTag) {
     synchronized (frcInfoLock) {
-      frcMetadata.edit().putString(LAST_FETCH_ETAG_KEY, eTag).apply();
+      frcSharedPrefs.edit().putString(LAST_FETCH_ETAG_KEY, eTag).apply();
     }
   }
 
   void setLastTemplateVersion(long templateVersion) {
     synchronized (frcInfoLock) {
-      frcMetadata.edit().putLong(LAST_TEMPLATE_VERSION, templateVersion).apply();
+      frcSharedPrefs.edit().putLong(LAST_TEMPLATE_VERSION, templateVersion).apply();
     }
   }
 
@@ -234,14 +235,15 @@ public class ConfigMetadataClient {
   BackoffMetadata getBackoffMetadata() {
     synchronized (backoffMetadataLock) {
       return new BackoffMetadata(
-          frcMetadata.getInt(NUM_FAILED_FETCHES_KEY, NO_FAILED_FETCHES),
-          new Date(frcMetadata.getLong(BACKOFF_END_TIME_IN_MILLIS_KEY, NO_BACKOFF_TIME_IN_MILLIS)));
+          frcSharedPrefs.getInt(NUM_FAILED_FETCHES_KEY, NO_FAILED_FETCHES),
+          new Date(
+              frcSharedPrefs.getLong(BACKOFF_END_TIME_IN_MILLIS_KEY, NO_BACKOFF_TIME_IN_MILLIS)));
     }
   }
 
   void setBackoffMetadata(int numFailedFetches, Date backoffEndTime) {
     synchronized (backoffMetadataLock) {
-      frcMetadata
+      frcSharedPrefs
           .edit()
           .putInt(NUM_FAILED_FETCHES_KEY, numFailedFetches)
           .putLong(BACKOFF_END_TIME_IN_MILLIS_KEY, backoffEndTime.getTime())
@@ -286,16 +288,16 @@ public class ConfigMetadataClient {
   public RealtimeBackoffMetadata getRealtimeBackoffMetadata() {
     synchronized (realtimeBackoffMetadataLock) {
       return new RealtimeBackoffMetadata(
-          frcMetadata.getInt(NUM_FAILED_REALTIME_STREAMS_KEY, NO_FAILED_REALTIME_STREAMS),
+          frcSharedPrefs.getInt(NUM_FAILED_REALTIME_STREAMS_KEY, NO_FAILED_REALTIME_STREAMS),
           new Date(
-              frcMetadata.getLong(
+              frcSharedPrefs.getLong(
                   REALTIME_BACKOFF_END_TIME_IN_MILLIS_KEY, NO_BACKOFF_TIME_IN_MILLIS)));
     }
   }
 
   void setRealtimeBackoffMetadata(int numFailedStreams, Date backoffEndTime) {
     synchronized (realtimeBackoffMetadataLock) {
-      frcMetadata
+      frcSharedPrefs
           .edit()
           .putInt(NUM_FAILED_REALTIME_STREAMS_KEY, numFailedStreams)
           .putLong(REALTIME_BACKOFF_END_TIME_IN_MILLIS_KEY, backoffEndTime.getTime())

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/FirebaseRemoteConfigInfoImpl.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/FirebaseRemoteConfigInfoImpl.java
@@ -16,7 +16,7 @@ package com.google.firebase.remoteconfig.internal;
 
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigInfo;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings;
-import com.google.firebase.remoteconfig.internal.ConfigMetadataClient.LastFetchStatus;
+import com.google.firebase.remoteconfig.internal.ConfigSharedPrefsClient.LastFetchStatus;
 
 /**
  * Impl class for FirebaseRemoteConfigInfo.

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -72,9 +72,9 @@ import com.google.firebase.remoteconfig.internal.ConfigContainer;
 import com.google.firebase.remoteconfig.internal.ConfigFetchHandler;
 import com.google.firebase.remoteconfig.internal.ConfigFetchHandler.FetchResponse;
 import com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler;
-import com.google.firebase.remoteconfig.internal.ConfigMetadataClient;
 import com.google.firebase.remoteconfig.internal.ConfigRealtimeHandler;
 import com.google.firebase.remoteconfig.internal.ConfigRealtimeHttpClient;
+import com.google.firebase.remoteconfig.internal.ConfigSharedPrefsClient;
 import com.google.firebase.remoteconfig.internal.FakeHttpURLConnection;
 import com.google.firebase.remoteconfig.internal.Personalization;
 import com.google.firebase.remoteconfig.internal.rollouts.RolloutsStateSubscriptionsHandler;
@@ -155,7 +155,7 @@ public final class FirebaseRemoteConfigTest {
   @Mock private ConfigCacheClient mockDefaultsCache;
   @Mock private ConfigFetchHandler mockFetchHandler;
   @Mock private ConfigGetParameterHandler mockGetHandler;
-  @Mock private ConfigMetadataClient metadataClient;
+  @Mock private ConfigSharedPrefsClient sharedPrefsClient;
 
   @Mock private ConfigRealtimeHandler mockConfigRealtimeHandler;
   @Mock private ConfigAutoFetch mockConfigAutoFetch;
@@ -192,7 +192,7 @@ public final class FirebaseRemoteConfigTest {
   private ConfigContainer realtimeFetchedContainer;
   private ConfigAutoFetch configAutoFetch;
   private ConfigRealtimeHttpClient configRealtimeHttpClient;
-  private ConfigMetadataClient realtimeMetadataClient;
+  private ConfigSharedPrefsClient realtimeSharedPrefsClient;
 
   private FetchResponse firstFetchedContainerResponse;
 
@@ -240,7 +240,7 @@ public final class FirebaseRemoteConfigTest {
             mockDefaultsCache,
             mockFetchHandler,
             mockGetHandler,
-            metadataClient,
+            sharedPrefsClient,
             mockConfigRealtimeHandler,
             mockRolloutsStateSubscriptionsHandler);
 
@@ -259,7 +259,7 @@ public final class FirebaseRemoteConfigTest {
                 mockFireperfDefaultsCache,
                 mockFireperfFetchHandler,
                 mockFireperfGetHandler,
-                RemoteConfigComponent.getMetadataClient(context, APP_ID, FIREPERF_NAMESPACE),
+                RemoteConfigComponent.getSharedPrefsClient(context, APP_ID, FIREPERF_NAMESPACE),
                 mockRolloutsStateSubscriptionsHandler);
 
     personalizationFrc =
@@ -276,7 +276,8 @@ public final class FirebaseRemoteConfigTest {
                 mockDefaultsCache,
                 mockFetchHandler,
                 parameterHandler,
-                RemoteConfigComponent.getMetadataClient(context, APP_ID, PERSONALIZATION_NAMESPACE),
+                RemoteConfigComponent.getSharedPrefsClient(
+                    context, APP_ID, PERSONALIZATION_NAMESPACE),
                 mockRolloutsStateSubscriptionsHandler);
 
     firstFetchedContainer =
@@ -349,8 +350,9 @@ public final class FirebaseRemoteConfigTest {
             listeners,
             mockRetryListener,
             scheduledExecutorService);
-    realtimeMetadataClient =
-        new ConfigMetadataClient(context.getSharedPreferences("test_file", Context.MODE_PRIVATE));
+    realtimeSharedPrefsClient =
+        new ConfigSharedPrefsClient(
+            context.getSharedPreferences("test_file", Context.MODE_PRIVATE));
     configRealtimeHttpClient =
         new ConfigRealtimeHttpClient(
             firebaseApp,
@@ -360,7 +362,7 @@ public final class FirebaseRemoteConfigTest {
             context,
             "firebase",
             listeners,
-            realtimeMetadataClient,
+            realtimeSharedPrefsClient,
             scheduledExecutorService);
   }
 
@@ -1024,7 +1026,7 @@ public final class FirebaseRemoteConfigTest {
 
   @Test
   public void getInfo_returnsInfo() {
-    when(metadataClient.getInfo()).thenReturn(mockFrcInfo);
+    when(sharedPrefsClient.getInfo()).thenReturn(mockFrcInfo);
 
     long fetchTimeInMillis = 100L;
     int lastFetchStatus = LAST_FETCH_STATUS_THROTTLED;
@@ -1071,11 +1073,11 @@ public final class FirebaseRemoteConfigTest {
     verify(mockActivatedCache).clear();
     verify(mockFetchedCache).clear();
     verify(mockDefaultsCache).clear();
-    verify(metadataClient).clear();
+    verify(sharedPrefsClient).clear();
   }
 
   @Test
-  public void setConfigSettingsAsync_updatesMetadata() {
+  public void setConfigSettingsAsync_updatesSharedPrefs() {
     long fetchTimeout = 13L;
     long minimumFetchInterval = 666L;
     FirebaseRemoteConfigSettings frcSettings =
@@ -1087,7 +1089,7 @@ public final class FirebaseRemoteConfigTest {
     Task<Void> setterTask = frc.setConfigSettingsAsync(frcSettings);
 
     assertThat(setterTask.isSuccessful()).isTrue();
-    verify(metadataClient).setConfigSettings(frcSettings);
+    verify(sharedPrefsClient).setConfigSettings(frcSettings);
   }
 
   @Test

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigComponentTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigComponentTest.java
@@ -39,7 +39,7 @@ import com.google.firebase.remoteconfig.internal.ConfigContainer;
 import com.google.firebase.remoteconfig.internal.ConfigFetchHandler;
 import com.google.firebase.remoteconfig.internal.ConfigFetchHttpClient;
 import com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler;
-import com.google.firebase.remoteconfig.internal.ConfigMetadataClient;
+import com.google.firebase.remoteconfig.internal.ConfigSharedPrefsClient;
 import com.google.firebase.remoteconfig.internal.rollouts.RolloutsStateSubscriptionsHandler;
 import com.google.firebase.remoteconfig.interop.rollouts.RolloutsStateSubscriber;
 import java.util.Date;
@@ -73,7 +73,7 @@ public class RemoteConfigComponentTest {
   @Mock private ConfigCacheClient mockDefaultsCache;
   @Mock private ConfigFetchHandler mockFetchHandler;
   @Mock private ConfigGetParameterHandler mockGetParameterHandler;
-  @Mock private ConfigMetadataClient mockMetadataClient;
+  @Mock private ConfigSharedPrefsClient mockSharedPrefsClient;
   @Mock private RolloutsStateSubscriptionsHandler mockRolloutsStateSubscriptionsHandler;
 
   @Mock private RolloutsStateSubscriber mockRolloutsStateSubscriber;
@@ -82,7 +82,7 @@ public class RemoteConfigComponentTest {
   private ExecutorService directExecutor;
   private ScheduledExecutorService scheduledExecutorService;
   private FirebaseApp defaultApp;
-  private ConfigMetadataClient metadataClient;
+  private ConfigSharedPrefsClient sharedPrefsClient;
 
   @Before
   public void setUp() {
@@ -94,7 +94,8 @@ public class RemoteConfigComponentTest {
 
     defaultApp = initializeFirebaseApp(context);
 
-    metadataClient = RemoteConfigComponent.getMetadataClient(context, APP_ID, "personalization");
+    sharedPrefsClient =
+        RemoteConfigComponent.getSharedPrefsClient(context, APP_ID, "personalization");
 
     when(mockFirebaseApp.getOptions())
         .thenReturn(new FirebaseOptions.Builder().setApplicationId(APP_ID).build());
@@ -106,7 +107,7 @@ public class RemoteConfigComponentTest {
   public void frc2p_doesNotCallAbt() throws Exception {
 
     FirebaseRemoteConfig fireperfFrc =
-        getFrcInstanceFromComponentWithMetadataClient(
+        getFrcInstanceFromComponentWithSharedPrefsClient(
             getNewFrcComponent(), /* namespace= */ "fireperf");
     loadConfigsWithExperimentsForActivate();
 
@@ -123,7 +124,7 @@ public class RemoteConfigComponentTest {
 
     when(mockFirebaseApp.getName()).thenReturn("secondary");
     FirebaseRemoteConfig frc =
-        getFrcInstanceFromComponentWithMetadataClient(
+        getFrcInstanceFromComponentWithSharedPrefsClient(
             getNewFrcComponentWithoutLoadingDefault(), DEFAULT_NAMESPACE);
     loadConfigsWithExperimentsForActivate();
 
@@ -139,7 +140,7 @@ public class RemoteConfigComponentTest {
 
     ConfigFetchHandler fetchHandler =
         getNewFrcComponent()
-            .getFetchHandler(DEFAULT_NAMESPACE, mockFetchedCache, mockMetadataClient);
+            .getFetchHandler(DEFAULT_NAMESPACE, mockFetchedCache, mockSharedPrefsClient);
 
     assertThat(fetchHandler.getAnalyticsConnector().get()).isNull();
   }
@@ -149,10 +150,12 @@ public class RemoteConfigComponentTest {
       getFrcBackendApiClient_fetchTimeoutIsNotSet_buildsConfigFetchHttpClientWithDefaultConnectionTimeout() {
 
     RemoteConfigComponent frcComponent = defaultApp.get(RemoteConfigComponent.class);
-    when(mockMetadataClient.getFetchTimeoutInSeconds()).thenReturn(CONNECTION_TIMEOUT_IN_SECONDS);
+    when(mockSharedPrefsClient.getFetchTimeoutInSeconds())
+        .thenReturn(CONNECTION_TIMEOUT_IN_SECONDS);
 
     ConfigFetchHttpClient frcBackendClient =
-        frcComponent.getFrcBackendApiClient(DUMMY_API_KEY, DEFAULT_NAMESPACE, mockMetadataClient);
+        frcComponent.getFrcBackendApiClient(
+            DUMMY_API_KEY, DEFAULT_NAMESPACE, mockSharedPrefsClient);
 
     int actualConnectTimeout = getConnectTimeoutInSeconds(frcBackendClient);
     int actualReadTimeout = getReadTimeoutInSeconds(frcBackendClient);
@@ -167,11 +170,12 @@ public class RemoteConfigComponentTest {
     RemoteConfigComponent frcComponent = defaultApp.get(RemoteConfigComponent.class);
 
     long customConnectionTimeoutInSeconds = 2 * CONNECTION_TIMEOUT_IN_SECONDS;
-    when(mockMetadataClient.getFetchTimeoutInSeconds())
+    when(mockSharedPrefsClient.getFetchTimeoutInSeconds())
         .thenReturn(customConnectionTimeoutInSeconds);
 
     ConfigFetchHttpClient frcBackendClient =
-        frcComponent.getFrcBackendApiClient(DUMMY_API_KEY, DEFAULT_NAMESPACE, mockMetadataClient);
+        frcComponent.getFrcBackendApiClient(
+            DUMMY_API_KEY, DEFAULT_NAMESPACE, mockSharedPrefsClient);
 
     int actualConnectTimeout = getConnectTimeoutInSeconds(frcBackendClient);
     int actualReadTimeout = getReadTimeoutInSeconds(frcBackendClient);
@@ -181,9 +185,9 @@ public class RemoteConfigComponentTest {
 
   @Test
   public void registerRolloutsStateSubscriber_firebaseNamespace_callsSubscriptionHandler() {
-    // Mock metadata client response since Realtime handler can't be mocked here.
-    when(mockMetadataClient.getRealtimeBackoffMetadata())
-        .thenReturn(new ConfigMetadataClient.RealtimeBackoffMetadata(0, new Date()));
+    // Mock shared preference client response since Realtime handler can't be mocked here.
+    when(mockSharedPrefsClient.getRealtimeBackoffMetadata())
+        .thenReturn(new ConfigSharedPrefsClient.RealtimeBackoffMetadata(0, new Date()));
 
     RemoteConfigComponent frcComponent = getNewFrcComponentWithoutLoadingDefault();
     FirebaseRemoteConfig instance = getFrcInstanceFromComponent(frcComponent, DEFAULT_NAMESPACE);
@@ -216,7 +220,7 @@ public class RemoteConfigComponentTest {
         /* loadGetDefault= */ false);
   }
 
-  private FirebaseRemoteConfig getFrcInstanceFromComponentWithMetadataClient(
+  private FirebaseRemoteConfig getFrcInstanceFromComponentWithSharedPrefsClient(
       RemoteConfigComponent frcComponent, String namespace) {
     return frcComponent.get(
         mockFirebaseApp,
@@ -229,7 +233,7 @@ public class RemoteConfigComponentTest {
         mockDefaultsCache,
         mockFetchHandler,
         mockGetParameterHandler,
-        metadataClient,
+        sharedPrefsClient,
         mockRolloutsStateSubscriptionsHandler);
   }
 
@@ -246,7 +250,7 @@ public class RemoteConfigComponentTest {
         mockDefaultsCache,
         mockFetchHandler,
         mockGetParameterHandler,
-        mockMetadataClient,
+        mockSharedPrefsClient,
         mockRolloutsStateSubscriptionsHandler);
   }
 

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigTests.kt
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigTests.kt
@@ -29,8 +29,8 @@ import com.google.firebase.platforminfo.UserAgentPublisher
 import com.google.firebase.remoteconfig.internal.ConfigCacheClient
 import com.google.firebase.remoteconfig.internal.ConfigFetchHandler
 import com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler
-import com.google.firebase.remoteconfig.internal.ConfigMetadataClient
 import com.google.firebase.remoteconfig.internal.ConfigRealtimeHandler
+import com.google.firebase.remoteconfig.internal.ConfigSharedPrefsClient
 import com.google.firebase.remoteconfig.internal.rollouts.RolloutsStateSubscriptionsHandler
 import org.junit.After
 import org.junit.Before
@@ -139,7 +139,7 @@ class ConfigTests : BaseTestCase() {
         defaultConfigsCache = mock(ConfigCacheClient::class.java),
         fetchHandler = mock(ConfigFetchHandler::class.java),
         getHandler = mockGetHandler,
-        frcMetadata = mock(ConfigMetadataClient::class.java),
+        frcSharedPrefs = mock(ConfigSharedPrefsClient::class.java),
         realtimeHandler = mock(ConfigRealtimeHandler::class.java),
         rolloutsStateSubscriptionsHandler = mock(RolloutsStateSubscriptionsHandler::class.java)
       )

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/TestConstructorUtil.kt
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/TestConstructorUtil.kt
@@ -23,8 +23,8 @@ import com.google.firebase.installations.FirebaseInstallationsApi
 import com.google.firebase.remoteconfig.internal.ConfigCacheClient
 import com.google.firebase.remoteconfig.internal.ConfigFetchHandler
 import com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler
-import com.google.firebase.remoteconfig.internal.ConfigMetadataClient
 import com.google.firebase.remoteconfig.internal.ConfigRealtimeHandler
+import com.google.firebase.remoteconfig.internal.ConfigSharedPrefsClient
 import com.google.firebase.remoteconfig.internal.rollouts.RolloutsStateSubscriptionsHandler
 import java.util.concurrent.Executor
 
@@ -41,7 +41,7 @@ fun createRemoteConfig(
   defaultConfigsCache: ConfigCacheClient,
   fetchHandler: ConfigFetchHandler,
   getHandler: ConfigGetParameterHandler,
-  frcMetadata: ConfigMetadataClient,
+  frcSharedPrefs: ConfigSharedPrefsClient,
   realtimeHandler: ConfigRealtimeHandler,
   rolloutsStateSubscriptionsHandler: RolloutsStateSubscriptionsHandler
 ): FirebaseRemoteConfig {
@@ -56,7 +56,7 @@ fun createRemoteConfig(
     defaultConfigsCache,
     fetchHandler,
     getHandler,
-    frcMetadata,
+    frcSharedPrefs,
     realtimeHandler,
     rolloutsStateSubscriptionsHandler
   )

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/ktx/RemoteConfigTests.kt
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/ktx/RemoteConfigTests.kt
@@ -32,8 +32,8 @@ import com.google.firebase.remoteconfig.createRemoteConfig
 import com.google.firebase.remoteconfig.internal.ConfigCacheClient
 import com.google.firebase.remoteconfig.internal.ConfigFetchHandler
 import com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler
-import com.google.firebase.remoteconfig.internal.ConfigMetadataClient
 import com.google.firebase.remoteconfig.internal.ConfigRealtimeHandler
+import com.google.firebase.remoteconfig.internal.ConfigSharedPrefsClient
 import com.google.firebase.remoteconfig.internal.rollouts.RolloutsStateSubscriptionsHandler
 import org.junit.After
 import org.junit.Before
@@ -142,7 +142,7 @@ class ConfigTests : BaseTestCase() {
         defaultConfigsCache = mock(ConfigCacheClient::class.java),
         fetchHandler = mock(ConfigFetchHandler::class.java),
         getHandler = mockGetHandler,
-        frcMetadata = mock(ConfigMetadataClient::class.java),
+        frcSharedPrefs = mock(ConfigSharedPrefsClient::class.java),
         realtimeHandler = mock(ConfigRealtimeHandler::class.java),
         rolloutsStateSubscriptionsHandler = mock(RolloutsStateSubscriptionsHandler::class.java)
       )


### PR DESCRIPTION
Reflects expanded functionality to store both metadata and custom signals in shared preferences.