### PR TITLE
Fix data-collection-tests

### DIFF
--- a/firebase-common/data-collection-tests/data-collection-tests.gradle.kts
+++ b/firebase-common/data-collection-tests/data-collection-tests.gradle.kts
@@ -36,6 +36,7 @@ android {
 dependencies {
   implementation("com.google.firebase:firebase-common:21.0.0")
   implementation("com.google.firebase:firebase-components:18.0.0")
+  implementation(platform(libs.kotlin.bom))
 
   testImplementation(libs.androidx.core)
   testImplementation(libs.androidx.test.junit)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,6 +62,7 @@ grpc-protoc-gen-kotlin = { module = "io.grpc:protoc-gen-grpc-kotlin", version.re
 grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpc" }
 javax-annotation-jsr250 = { module = "javax.annotation:jsr250-api", version = "1.0" }
 javax-inject = { module = "javax.inject:javax.inject", version = "1" }
+kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlin-coroutines-tasks = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "coroutines" }


### PR DESCRIPTION
The dependencies were pulling kotlin stdlib versions that were breaking version alignment. 

The solution is to depend on the BOM as decribed in https://kotlinlang.org/docs/whatsnew18.html#usage-of-the-latest-kotlin-stdlib-version-in-transitive-dependencies