### PR TITLE
Remove unneeded package declaration in transport runtime

### DIFF
--- a/transport/transport-runtime/src/main/AndroidManifest.xml
+++ b/transport/transport-runtime/src/main/AndroidManifest.xml
@@ -12,8 +12,7 @@
 <!-- See the License for the specific language governing permissions and -->
 <!-- limitations under the License. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.google.android.datatransport.runtime">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
     <!--<uses-sdk android:minSdkVersion="21"/>-->


### PR DESCRIPTION
The package declaration inside AndroidManifest.xml is no longer used, and the `namespace` declaration in the gradle file is the one that should be used.