### PR TITLE
dataconnect: demo: upgrade firebase-tools to v13.28.0

### DIFF
--- a/.github/workflows/dataconnect_demo_app.yml
+++ b/.github/workflows/dataconnect_demo_app.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   FDC_NODE_VERSION: ${{ inputs.nodeVersion || '20' }}
-  FDC_FIREBASE_TOOLS_VERSION: ${{ inputs.firebaseToolsVersion || '13.25.0' }}
+  FDC_FIREBASE_TOOLS_VERSION: ${{ inputs.firebaseToolsVersion || '13.28.0' }}
   FDC_JAVA_VERSION: ${{ inputs.javaVersion || '17' }}
   FDC_FIREBASE_TOOLS_DIR: ${{ github.workspace }}/firebase-tools
   FDC_FIREBASE_COMMAND: ${{ github.workspace }}/firebase-tools/node_modules/.bin/firebase

--- a/firebase-dataconnect/demo/firebase/dataconnect/connector/operations.gql
+++ b/firebase-dataconnect/demo/firebase/dataconnect/connector/operations.gql
@@ -48,3 +48,17 @@ query GetItemByKey(
     any
   }
 }
+
+# This mutation exists only as a workaround for b/382688278 where the following
+# compiler error will otherwise result when compiling the generated code:
+#   Serializer has not been found for type 'java.util.UUID'. To use context
+#   serializer as fallback, explicitly annotate type or property with @Contextual
+# This bug first appeared in v1.7.1 of the Data Connect Toolkit CLI, which
+# started to be used in firebase-tools v13.26.0
+# (https://github.com/firebase/firebase-tools/releases/tag/v13.26.0).
+# This mutation can be removed from this file once the fix is released, which will
+# likely be version 1.7.4 of the Data Connect Toolkit CLI (v13.28.1 of firebase-
+# tools).
+mutation WorkaroundForBug382688278( $id: UUID!) {
+  zwda6x9zyy_insert(data: { id: $id })
+}


### PR DESCRIPTION
This PR includes a workaround for b/382688278 where compiling the generated Kotlin code may result in the following error:

> `Serializer has not been found for type 'java.util.UUID'. To use context serializer as fallback, explicitly annotate type or property with @Contextual`