### PR TITLE
Update fetch to utilize latest custom signals

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
@@ -262,8 +262,7 @@ public class RemoteConfigComponent implements FirebaseRemoteConfigInterop {
         apiKey,
         namespace,
         /* connectTimeoutInSeconds= */ sharedPrefsClient.getFetchTimeoutInSeconds(),
-        /* readTimeoutInSeconds= */ sharedPrefsClient.getFetchTimeoutInSeconds(),
-        /* customSignals= */ sharedPrefsClient.getCustomSignals());
+        /* readTimeoutInSeconds= */ sharedPrefsClient.getFetchTimeoutInSeconds());
   }
 
   @VisibleForTesting

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java
@@ -384,7 +384,8 @@ public class ConfigFetchHandler {
               frcSharedPrefs.getLastFetchETag(),
               customFetchHeaders,
               getFirstOpenTime(),
-              currentTime);
+              currentTime,
+              frcSharedPrefs.getCustomSignals());
 
       if (response.getFetchedConfigs() != null) {
         // Set template version in metadata to be saved on disk.

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
@@ -94,7 +94,6 @@ public class ConfigFetchHttpClient {
   private final String apiKey;
   private final String projectNumber;
   private final String namespace;
-  Map<String, String> customSignalsMap;
   private final long connectTimeoutInSeconds;
   private final long readTimeoutInSeconds;
 
@@ -108,8 +107,7 @@ public class ConfigFetchHttpClient {
       String apiKey,
       String namespace,
       long connectTimeoutInSeconds,
-      long readTimeoutInSeconds,
-      Map<String, String> customSignalsMap) {
+      long readTimeoutInSeconds) {
     this.context = context;
     this.appId = appId;
     this.apiKey = apiKey;
@@ -117,7 +115,6 @@ public class ConfigFetchHttpClient {
     this.namespace = namespace;
     this.connectTimeoutInSeconds = connectTimeoutInSeconds;
     this.readTimeoutInSeconds = readTimeoutInSeconds;
-    this.customSignalsMap = customSignalsMap;
   }
 
   /** Used to verify that the timeout is being set correctly. */
@@ -187,7 +184,8 @@ public class ConfigFetchHttpClient {
       String lastFetchETag,
       Map<String, String> customHeaders,
       Long firstOpenTime,
-      Date currentTime)
+      Date currentTime,
+      Map<String, String> customSignalsMap)
       throws FirebaseRemoteConfigException {
     setUpUrlConnection(urlConnection, lastFetchETag, installationAuthToken, customHeaders);
 
@@ -196,7 +194,11 @@ public class ConfigFetchHttpClient {
     try {
       byte[] requestBody =
           createFetchRequestBody(
-                  installationId, installationAuthToken, analyticsUserProperties, firstOpenTime)
+                  installationId,
+                  installationAuthToken,
+                  analyticsUserProperties,
+                  firstOpenTime,
+                  customSignalsMap)
               .toString()
               .getBytes("utf-8");
       setFetchRequestBody(urlConnection, requestBody);
@@ -307,7 +309,8 @@ public class ConfigFetchHttpClient {
       String installationId,
       String installationAuthToken,
       Map<String, String> analyticsUserProperties,
-      Long firstOpenTime)
+      Long firstOpenTime,
+      Map<String, String> customSignalsMap)
       throws FirebaseRemoteConfigClientException {
     Map<String, Object> requestBodyMap = new HashMap<>();
 

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandlerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandlerTest.java
@@ -776,8 +776,7 @@ public class ConfigFetchHandlerTest {
             "age", "20");
     sharedPrefsClient.setCustomSignals(customSignals);
     fetchCallToHttpClientUpdatesClockAndReturnsConfig(firstFetchedContainer);
-
-    assertWithMessage("Fetch() failed!").that(fetchHandler.fetch().isSuccessful()).isTrue();
+    fetchHandler.fetch();
 
     verifyCustomSignals(customSignals);
   }
@@ -997,7 +996,7 @@ public class ConfigFetchHandlerTest {
             /* customHeaders= */ any(),
             /* firstOpenTime= */ any(),
             /* currentTime= */ any(),
-            /* customSignals= */ eq(customSignals));
+            /* customSignals= */ eq(sharedPrefsClient.getCustomSignals()));
     assertThat(sharedPrefsClient.getCustomSignals()).isEqualTo(customSignals);
   }
 

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandlerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandlerTest.java
@@ -202,7 +202,8 @@ public class ConfigFetchHandlerTest {
             /* lastFetchETag= */ any(),
             /* customHeaders= */ any(),
             /* firstOpenTime= */ any(),
-            /* currentTime= */ any());
+            /* currentTime= */ any(),
+            /* customSignals= */ any());
   }
 
   @Test
@@ -401,7 +402,8 @@ public class ConfigFetchHandlerTest {
 
   @Test
   public void fetch_fetchBackendCallFails_taskThrowsException() throws Exception {
-    when(mockBackendFetchApiClient.fetch(any(), any(), any(), any(), any(), any(), any(), any()))
+    when(mockBackendFetchApiClient.fetch(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenThrow(
             new FirebaseRemoteConfigClientException("Fetch failed due to an unexpected error."));
 
@@ -811,7 +813,8 @@ public class ConfigFetchHandlerTest {
             /* lastFetchETag= */ any(),
             /* customHeaders= */ any(),
             /* firstOpenTime= */ any(),
-            /* currentTime= */ any());
+            /* currentTime= */ any(),
+            /* customSignals= */ any());
   }
 
   private void setBackendResponseToNoChange(Date date) throws Exception {
@@ -823,7 +826,8 @@ public class ConfigFetchHandlerTest {
             /* lastFetchETag= */ any(),
             /* customHeaders= */ any(),
             /* firstOpenTime= */ any(),
-            /* currentTime= */ any()))
+            /* currentTime= */ any(),
+            /* customSignals= */ any()))
         .thenReturn(FetchResponse.forBackendHasNoUpdates(date, firstFetchedContainer));
   }
 
@@ -838,7 +842,8 @@ public class ConfigFetchHandlerTest {
             /* lastFetchETag= */ any(),
             /* customHeaders= */ any(),
             /* firstOpenTime= */ any(),
-            /* currentTime= */ any());
+            /* currentTime= */ any(),
+            /* customSignals= */ any());
   }
 
   /**
@@ -919,7 +924,8 @@ public class ConfigFetchHandlerTest {
             /* lastFetchETag= */ any(),
             /* customHeaders= */ any(),
             /* firstOpenTime= */ any(),
-            /* currentTime= */ any());
+            /* currentTime= */ any(),
+            /* customSignals= */ any());
   }
 
   private void verifyBackendIsCalled(Map<String, String> userProperties, Long firstOpenTime)
@@ -933,7 +939,8 @@ public class ConfigFetchHandlerTest {
             /* lastFetchETag= */ any(),
             /* customHeaders= */ any(),
             /* firstOpenTime= */ eq(firstOpenTime),
-            /* currentTime= */ any());
+            /* currentTime= */ any(),
+            /* customSignals= */ any());
   }
 
   private void verifyBackendIsNeverCalled() throws Exception {
@@ -946,7 +953,8 @@ public class ConfigFetchHandlerTest {
             /* lastFetchETag= */ any(),
             /* customHeaders= */ any(),
             /* firstOpenTime= */ any(),
-            /* currentTime= */ any());
+            /* currentTime= */ any(),
+            /* customSignals= */ any());
   }
 
   private void verifyETags(@Nullable String requestETag, String responseETag) throws Exception {
@@ -959,7 +967,8 @@ public class ConfigFetchHandlerTest {
             /* lastFetchETag= */ eq(requestETag),
             /* customHeaders= */ any(),
             /* firstOpenTime= */ any(),
-            /* currentTime= */ any());
+            /* currentTime= */ any(),
+            /* customSignals= */ any());
     assertThat(sharedPrefsClient.getLastFetchETag()).isEqualTo(responseETag);
   }
 

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandlerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandlerTest.java
@@ -778,7 +778,18 @@ public class ConfigFetchHandlerTest {
     fetchCallToHttpClientUpdatesClockAndReturnsConfig(firstFetchedContainer);
     fetchHandler.fetch();
 
-    verifyCustomSignals(customSignals);
+    verify(mockBackendFetchApiClient)
+        .fetch(
+            any(HttpURLConnection.class),
+            /* instanceId= */ any(),
+            /* instanceIdToken= */ any(),
+            /* analyticsUserProperties= */ any(),
+            /* lastFetchETag= */ any(),
+            /* customHeaders= */ any(),
+            /* firstOpenTime= */ any(),
+            /* currentTime= */ any(),
+            /* customSignals= */ eq(sharedPrefsClient.getCustomSignals()));
+    assertThat(sharedPrefsClient.getCustomSignals()).isEqualTo(customSignals);
   }
 
   private ConfigFetchHandler getNewFetchHandler(AnalyticsConnector analyticsConnector) {
@@ -983,21 +994,6 @@ public class ConfigFetchHandlerTest {
             /* currentTime= */ any(),
             /* customSignals= */ any());
     assertThat(sharedPrefsClient.getLastFetchETag()).isEqualTo(responseETag);
-  }
-
-  private void verifyCustomSignals(Map<String, String> customSignals) throws Exception {
-    verify(mockBackendFetchApiClient)
-        .fetch(
-            any(HttpURLConnection.class),
-            /* instanceId= */ any(),
-            /* instanceIdToken= */ any(),
-            /* analyticsUserProperties= */ any(),
-            /* lastFetchETag= */ any(),
-            /* customHeaders= */ any(),
-            /* firstOpenTime= */ any(),
-            /* currentTime= */ any(),
-            /* customSignals= */ eq(sharedPrefsClient.getCustomSignals()));
-    assertThat(sharedPrefsClient.getCustomSignals()).isEqualTo(customSignals);
   }
 
   private void loadBackendApiClient() throws Exception {

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandlerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandlerTest.java
@@ -769,7 +769,7 @@ public class ConfigFetchHandlerTest {
   }
 
   @Test
-  public void customSignals_updated_onSubsequentFetch() throws Exception {
+  public void fetch_usesLatestCustomSignals() throws Exception {
     Map<String, String> customSignals =
         ImmutableMap.of(
             "subscription", "premium",

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandlerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandlerTest.java
@@ -768,6 +768,20 @@ public class ConfigFetchHandlerTest {
         .isEqualTo(firstFetchedContainer.getFetchTime());
   }
 
+  @Test
+  public void customSignals_updated_onSubsequentFetch() throws Exception {
+    Map<String, String> customSignals =
+        ImmutableMap.of(
+            "subscription", "premium",
+            "age", "20");
+    sharedPrefsClient.setCustomSignals(customSignals);
+    fetchCallToHttpClientUpdatesClockAndReturnsConfig(firstFetchedContainer);
+
+    assertWithMessage("Fetch() failed!").that(fetchHandler.fetch().isSuccessful()).isTrue();
+
+    verifyCustomSignals(customSignals);
+  }
+
   private ConfigFetchHandler getNewFetchHandler(AnalyticsConnector analyticsConnector) {
     ConfigFetchHandler fetchHandler =
         spy(
@@ -970,6 +984,21 @@ public class ConfigFetchHandlerTest {
             /* currentTime= */ any(),
             /* customSignals= */ any());
     assertThat(sharedPrefsClient.getLastFetchETag()).isEqualTo(responseETag);
+  }
+
+  private void verifyCustomSignals(Map<String, String> customSignals) throws Exception {
+    verify(mockBackendFetchApiClient)
+        .fetch(
+            any(HttpURLConnection.class),
+            /* instanceId= */ any(),
+            /* instanceIdToken= */ any(),
+            /* analyticsUserProperties= */ any(),
+            /* lastFetchETag= */ any(),
+            /* customHeaders= */ any(),
+            /* firstOpenTime= */ any(),
+            /* currentTime= */ any(),
+            /* customSignals= */ eq(customSignals));
+    assertThat(sharedPrefsClient.getCustomSignals()).isEqualTo(customSignals);
   }
 
   private void loadBackendApiClient() throws Exception {

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
@@ -24,7 +24,6 @@ import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFiel
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.APP_ID;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.APP_VERSION;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.COUNTRY_CODE;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.CUSTOM_SIGNALS;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.FIRST_OPEN_TIME;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.INSTANCE_ID;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.INSTANCE_ID_TOKEN;
@@ -86,10 +85,6 @@ public class ConfigFetchHttpClientTest {
       "etag-" + PROJECT_NUMBER + "-" + DEFAULT_NAMESPACE + "-fetch-%d";
   private static final String FIRST_ETAG = String.format(ETAG_FORMAT, 1);
   private static final String SECOND_ETAG = String.format(ETAG_FORMAT, 2);
-  private static final Map<String, String> SAMPLE_CUSTOM_SIGNALS =
-      ImmutableMap.of(
-          "subscription", "premium",
-          "age", "20");
 
   private Context context;
   private ConfigFetchHttpClient configFetchHttpClient;
@@ -110,8 +105,7 @@ public class ConfigFetchHttpClientTest {
             API_KEY,
             DEFAULT_NAMESPACE,
             /* connectTimeoutInSeconds= */ 10L,
-            /* readTimeoutInSeconds= */ 10L,
-            /* customSignals= */ SAMPLE_CUSTOM_SIGNALS);
+            /* readTimeoutInSeconds= */ 10L);
 
     hasChangeResponseBody =
         new JSONObject()
@@ -244,8 +238,6 @@ public class ConfigFetchHttpClientTest {
     assertThat(requestBody.get(FIRST_OPEN_TIME)).isEqualTo(firstOpenTimeIsoString);
     assertThat(requestBody.getJSONObject(ANALYTICS_USER_PROPERTIES).toString())
         .isEqualTo(new JSONObject(customUserProperties).toString());
-    assertThat(requestBody.getJSONObject(CUSTOM_SIGNALS).toString())
-        .isEqualTo(new JSONObject(SAMPLE_CUSTOM_SIGNALS).toString());
   }
 
   @Test
@@ -324,8 +316,7 @@ public class ConfigFetchHttpClientTest {
             API_KEY,
             DEFAULT_NAMESPACE,
             /* connectTimeoutInSeconds= */ 15L,
-            /* readTimeoutInSeconds= */ 20L,
-            /* customSignals= */ SAMPLE_CUSTOM_SIGNALS);
+            /* readTimeoutInSeconds= */ 20L);
     setServerResponseTo(noChangeResponseBody, SECOND_ETAG);
 
     fetch(FIRST_ETAG);
@@ -353,7 +344,8 @@ public class ConfigFetchHttpClientTest {
         eTag,
         /* customHeaders= */ ImmutableMap.of(),
         /* firstOpenTime= */ null,
-        /* currentTime= */ new Date(mockClock.currentTimeMillis()));
+        /* currentTime= */ new Date(mockClock.currentTimeMillis()),
+        /* customSignals= */ ImmutableMap.of());
   }
 
   private FetchResponse fetch(String eTag, Map<String, String> userProperties, Long firstOpenTime)
@@ -366,7 +358,8 @@ public class ConfigFetchHttpClientTest {
         eTag,
         /* customHeaders= */ ImmutableMap.of(),
         firstOpenTime,
-        new Date(mockClock.currentTimeMillis()));
+        new Date(mockClock.currentTimeMillis()),
+        /* customSignals= */ ImmutableMap.of());
   }
 
   private FetchResponse fetch(String eTag, Map<String, String> customHeaders) throws Exception {
@@ -378,7 +371,8 @@ public class ConfigFetchHttpClientTest {
         eTag,
         customHeaders,
         /* firstOpenTime= */ null,
-        new Date(mockClock.currentTimeMillis()));
+        new Date(mockClock.currentTimeMillis()),
+        /* customSignals= */ ImmutableMap.of());
   }
 
   private FetchResponse fetchWithoutInstallationId() throws Exception {
@@ -390,7 +384,8 @@ public class ConfigFetchHttpClientTest {
         /* lastFetchETag= */ "bogus-etag",
         /* customHeaders= */ ImmutableMap.of(),
         /* firstOpenTime= */ null,
-        new Date(mockClock.currentTimeMillis()));
+        new Date(mockClock.currentTimeMillis()),
+        /* customSignals= */ ImmutableMap.of());
   }
 
   private FetchResponse fetchWithoutInstallationAuthToken() throws Exception {
@@ -402,7 +397,8 @@ public class ConfigFetchHttpClientTest {
         /* lastFetchETag= */ "bogus-etag",
         /* customHeaders= */ ImmutableMap.of(),
         /* firstOpenTime= */ null,
-        new Date(mockClock.currentTimeMillis()));
+        new Date(mockClock.currentTimeMillis()),
+        /* customSignals= */ ImmutableMap.of());
   }
 
   private void setServerResponseTo(JSONObject requestBody, String eTag) {


### PR DESCRIPTION
When we update custom signals using setCustomSignals, the latest custom signals are not retrieved in the subsequent fetch. Currently, we are required to reload the app to fetch them.

Link to the bug: [Fetch uses stale custom signal values](https://b.corp.google.com/issues/381353888)