### PR TITLE
Remove unnecessary LooperMode annotations

### DIFF
--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/AabUpdaterTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/AabUpdaterTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.robolectric.Shadows.shadowOf;
-import static org.robolectric.annotation.LooperMode.Mode.PAUSED;
 
 import android.app.Activity;
 import android.net.Uri;
@@ -54,11 +53,9 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowActivity;
 
 @RunWith(RobolectricTestRunner.class)
-@LooperMode(PAUSED)
 public class AabUpdaterTest {
   private static final String TEST_URL = "https://test-url";
   private static final String REDIRECT_TO_PLAY = "https://redirect-to-play-url";

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/FirebaseMessagingRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/FirebaseMessagingRoboTest.java
@@ -72,8 +72,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
-import org.robolectric.annotation.LooperMode;
-import org.robolectric.annotation.LooperMode.Mode;
 import org.robolectric.shadows.ShadowLooper;
 
 /**
@@ -84,7 +82,6 @@ import org.robolectric.shadows.ShadowLooper;
  */
 @RunWith(RobolectricTestRunner.class)
 @Config(shadows = ShadowPreconditions.class)
-@LooperMode(Mode.PAUSED)
 public final class FirebaseMessagingRoboTest {
 
   private static final String INVALID_TOPIC = "@invalid";

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/FirebaseMessagingServiceRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/FirebaseMessagingServiceRoboTest.java
@@ -84,12 +84,9 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ServiceController;
-import org.robolectric.annotation.LooperMode;
-import org.robolectric.annotation.LooperMode.Mode;
 import org.robolectric.shadows.ShadowLooper;
 
 @RunWith(RobolectricTestRunner.class)
-@LooperMode(Mode.PAUSED)
 public class FirebaseMessagingServiceRoboTest {
 
   // Constants are copied so that tests will break if these change

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/AppStartTraceTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/AppStartTraceTest.java
@@ -57,12 +57,10 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
-import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowSystemClock;
 
 /** Unit tests for {@link AppStartTrace}. */
 @RunWith(RobolectricTestRunner.class)
-@LooperMode(LooperMode.Mode.PAUSED)
 public class AppStartTraceTest extends FirebasePerformanceTestBase {
 
   @Mock private Clock clock;

--- a/firebase-perf/src/test/java/com/google/firebase/perf/util/FirstDrawDoneListenerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/util/FirstDrawDoneListenerTest.java
@@ -38,11 +38,9 @@ import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
-import org.robolectric.annotation.LooperMode;
 
 /** Unit tests for {@link FirstDrawDoneListener}. */
 @RunWith(RobolectricTestRunner.class)
-@LooperMode(LooperMode.Mode.PAUSED)
 public class FirstDrawDoneListenerTest {
   private View testView;
 

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionLifecycleServiceTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionLifecycleServiceTest.kt
@@ -42,13 +42,10 @@ import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.android.controller.ServiceController
-import org.robolectric.annotation.LooperMode
-import org.robolectric.annotation.LooperMode.Mode.PAUSED
 import org.robolectric.shadows.ShadowSystemClock
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @MediumTest
-@LooperMode(PAUSED)
 @RunWith(RobolectricTestRunner::class)
 internal class SessionLifecycleServiceTest {
 


### PR DESCRIPTION
PAUSED LooperMode has been the default for many years, so it is unnecessary to specify it. Remove these annotations.