### PR TITLE
FIX: sort strings in UTF-8 encoded byte order

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+* [fixed] Fixed a server and sdk mismatch in unicode string sorting. [#6615](//github.com/firebase/firebase-android-sdk/pull/6615)
 
 # 25.1.1
 * [changed] Update Firestore proto definitions. [#6369](//github.com/firebase/firebase-android-sdk/pull/6369)

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FirestoreTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FirestoreTest.java
@@ -1689,7 +1689,6 @@ public class FirestoreTest {
       registration.remove();
     }
 
-    // Assert that get and snapshot listener requests sort docs in the same, expected order
     assertTrue(getSnapshotDocIds.equals(expectedDocIds));
     assertTrue(watchSnapshotDocIds.equals(expectedDocIds));
 
@@ -1697,7 +1696,7 @@ public class FirestoreTest {
   }
 
   @Test
-  public void snapshotListenerSortsUnicodeStringsInArrayFieldsAsServer() {
+  public void snapshotListenerSortsUnicodeStringsInArrayAsServer() {
     Map<String, Map<String, Object>> testDocs =
         map(
             "a", map("value", Arrays.asList("Łukasiewicz")),
@@ -1731,7 +1730,6 @@ public class FirestoreTest {
       registration.remove();
     }
 
-    // Assert that get and snapshot listener requests sort docs in the same, expected order
     assertTrue(getSnapshotDocIds.equals(expectedDocIds));
     assertTrue(watchSnapshotDocIds.equals(expectedDocIds));
 
@@ -1773,7 +1771,6 @@ public class FirestoreTest {
       registration.remove();
     }
 
-    // Assert that get and snapshot listener requests sort docs in the same, expected order
     assertTrue(getSnapshotDocIds.equals(expectedDocIds));
     assertTrue(watchSnapshotDocIds.equals(expectedDocIds));
 
@@ -1815,7 +1812,6 @@ public class FirestoreTest {
       registration.remove();
     }
 
-    // Assert that get and snapshot listener requests sort docs in the same, expected order
     assertTrue(getSnapshotDocIds.equals(expectedDocIds));
     assertTrue(watchSnapshotDocIds.equals(expectedDocIds));
 
@@ -1858,7 +1854,6 @@ public class FirestoreTest {
       registration.remove();
     }
 
-    // Assert that get and snapshot listener requests sort docs in the same, expected order
     assertTrue(getSnapshotDocIds.equals(expectedDocIds));
     assertTrue(watchSnapshotDocIds.equals(expectedDocIds));
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FirestoreTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FirestoreTest.java
@@ -1655,41 +1655,36 @@ public class FirestoreTest {
   }
 
   @Test
-  public void snapshotListenerSortsStringFieldsAsGetQuery() {
+  public void snapshotListenerSortsUnicodeStringsAsServer() {
     Map<String, Map<String, Object>> testDocs =
-            map(
-                    "a", map("value", "Łukasiewicz"),
-                    "b", map("value", "Sierpiński"),
-                    "c", map("value", "岩澤"),
-                    "d", map("value", "🄟"),
-                    "e", map("value", "Ｐ"),
-                    "f", map("value", "︒"),
-                    "g", map("value", "🐵")
-            );
+        map(
+            "a", map("value", "Łukasiewicz"),
+            "b", map("value", "Sierpiński"),
+            "c", map("value", "岩澤"),
+            "d", map("value", "🄟"),
+            "e", map("value", "Ｐ"),
+            "f", map("value", "︒"),
+            "g", map("value", "🐵"));
 
     CollectionReference colRef = testCollectionWithDocs(testDocs);
-    // Test query
     Query orderedQuery = colRef.orderBy("value");
-    List<String> expectedDocIds =
-            Arrays.asList(
-                    "b", "a", "c", "f", "e", "d", "g");
+    List<String> expectedDocIds = Arrays.asList("b", "a", "c", "f", "e", "d", "g");
 
     QuerySnapshot getSnapshot = waitFor(orderedQuery.get());
     List<String> getSnapshotDocIds =
-            getSnapshot.getDocuments().stream().map(ds -> ds.getId()).collect(Collectors.toList());
+        getSnapshot.getDocuments().stream().map(ds -> ds.getId()).collect(Collectors.toList());
 
-    // Run query with snapshot listener
     EventAccumulator<QuerySnapshot> eventAccumulator = new EventAccumulator<QuerySnapshot>();
     ListenerRegistration registration =
-            orderedQuery.addSnapshotListener(eventAccumulator.listener());
+        orderedQuery.addSnapshotListener(eventAccumulator.listener());
 
     List<String> watchSnapshotDocIds = new ArrayList<>();
     try {
       QuerySnapshot watchSnapshot = eventAccumulator.await();
       watchSnapshotDocIds =
-              watchSnapshot.getDocuments().stream()
-                      .map(documentSnapshot -> documentSnapshot.getId())
-                      .collect(Collectors.toList());
+          watchSnapshot.getDocuments().stream()
+              .map(documentSnapshot -> documentSnapshot.getId())
+              .collect(Collectors.toList());
     } finally {
       registration.remove();
     }
@@ -1697,6 +1692,171 @@ public class FirestoreTest {
     // Assert that get and snapshot listener requests sort docs in the same, expected order
     assertTrue(getSnapshotDocIds.equals(expectedDocIds));
     assertTrue(watchSnapshotDocIds.equals(expectedDocIds));
+
+    checkOnlineAndOfflineResultsMatch(orderedQuery, expectedDocIds.toArray(new String[0]));
   }
 
+  public void snapshotListenerSortsUnicodeStringsInArrayFieldsAsServer() {
+    Map<String, Map<String, Object>> testDocs =
+        map(
+            "a", map("value", Arrays.asList("Łukasiewicz")),
+            "b", map("value", Arrays.asList("Sierpiński")),
+            "c", map("value", Arrays.asList("岩澤")),
+            "d", map("value", Arrays.asList("🄟")),
+            "e", map("value", Arrays.asList("Ｐ")),
+            "f", map("value", Arrays.asList("︒")),
+            "g", map("value", Arrays.asList("🐵")));
+
+    CollectionReference colRef = testCollectionWithDocs(testDocs);
+    Query orderedQuery = colRef.orderBy("value");
+    List<String> expectedDocIds = Arrays.asList("b", "a", "c", "f", "e", "d", "g");
+
+    QuerySnapshot getSnapshot = waitFor(orderedQuery.get());
+    List<String> getSnapshotDocIds =
+        getSnapshot.getDocuments().stream().map(ds -> ds.getId()).collect(Collectors.toList());
+
+    EventAccumulator<QuerySnapshot> eventAccumulator = new EventAccumulator<QuerySnapshot>();
+    ListenerRegistration registration =
+        orderedQuery.addSnapshotListener(eventAccumulator.listener());
+
+    List<String> watchSnapshotDocIds = new ArrayList<>();
+    try {
+      QuerySnapshot watchSnapshot = eventAccumulator.await();
+      watchSnapshotDocIds =
+          watchSnapshot.getDocuments().stream()
+              .map(documentSnapshot -> documentSnapshot.getId())
+              .collect(Collectors.toList());
+    } finally {
+      registration.remove();
+    }
+
+    // Assert that get and snapshot listener requests sort docs in the same, expected order
+    assertTrue(getSnapshotDocIds.equals(expectedDocIds));
+    assertTrue(watchSnapshotDocIds.equals(expectedDocIds));
+
+    checkOnlineAndOfflineResultsMatch(orderedQuery, expectedDocIds.toArray(new String[0]));
+  }
+
+  public void snapshotListenerSortsUnicodeStringsInMapAsServer() {
+    Map<String, Map<String, Object>> testDocs =
+        map(
+            "a", map("value", map("foo", "Łukasiewicz")),
+            "b", map("value", map("foo", "Sierpiński")),
+            "c", map("value", map("foo", "岩澤")),
+            "d", map("value", map("foo", "🄟")),
+            "e", map("value", map("foo", "Ｐ")),
+            "f", map("value", map("foo", "︒")),
+            "g", map("value", map("foo", "🐵")));
+
+    CollectionReference colRef = testCollectionWithDocs(testDocs);
+    Query orderedQuery = colRef.orderBy("value");
+    List<String> expectedDocIds = Arrays.asList("b", "a", "c", "f", "e", "d", "g");
+
+    QuerySnapshot getSnapshot = waitFor(orderedQuery.get());
+    List<String> getSnapshotDocIds =
+        getSnapshot.getDocuments().stream().map(ds -> ds.getId()).collect(Collectors.toList());
+
+    EventAccumulator<QuerySnapshot> eventAccumulator = new EventAccumulator<QuerySnapshot>();
+    ListenerRegistration registration =
+        orderedQuery.addSnapshotListener(eventAccumulator.listener());
+
+    List<String> watchSnapshotDocIds = new ArrayList<>();
+    try {
+      QuerySnapshot watchSnapshot = eventAccumulator.await();
+      watchSnapshotDocIds =
+          watchSnapshot.getDocuments().stream()
+              .map(documentSnapshot -> documentSnapshot.getId())
+              .collect(Collectors.toList());
+    } finally {
+      registration.remove();
+    }
+
+    // Assert that get and snapshot listener requests sort docs in the same, expected order
+    assertTrue(getSnapshotDocIds.equals(expectedDocIds));
+    assertTrue(watchSnapshotDocIds.equals(expectedDocIds));
+
+    checkOnlineAndOfflineResultsMatch(orderedQuery, expectedDocIds.toArray(new String[0]));
+  }
+
+  public void snapshotListenerSortsUnicodeStringsInMapKeyAsServer() {
+    Map<String, Map<String, Object>> testDocs =
+        map(
+            "a", map("value", map("Łukasiewicz", "foo")),
+            "b", map("value", map("Sierpiński", "foo")),
+            "c", map("value", map("岩澤", "foo")),
+            "d", map("value", map("🄟", "foo")),
+            "e", map("value", map("Ｐ", "foo")),
+            "f", map("value", map("︒", "foo")),
+            "g", map("value", map("🐵", "foo")));
+
+    CollectionReference colRef = testCollectionWithDocs(testDocs);
+    Query orderedQuery = colRef.orderBy("value");
+    List<String> expectedDocIds = Arrays.asList("b", "a", "c", "f", "e", "d", "g");
+
+    QuerySnapshot getSnapshot = waitFor(orderedQuery.get());
+    List<String> getSnapshotDocIds =
+        getSnapshot.getDocuments().stream().map(ds -> ds.getId()).collect(Collectors.toList());
+
+    EventAccumulator<QuerySnapshot> eventAccumulator = new EventAccumulator<QuerySnapshot>();
+    ListenerRegistration registration =
+        orderedQuery.addSnapshotListener(eventAccumulator.listener());
+
+    List<String> watchSnapshotDocIds = new ArrayList<>();
+    try {
+      QuerySnapshot watchSnapshot = eventAccumulator.await();
+      watchSnapshotDocIds =
+          watchSnapshot.getDocuments().stream()
+              .map(documentSnapshot -> documentSnapshot.getId())
+              .collect(Collectors.toList());
+    } finally {
+      registration.remove();
+    }
+
+    // Assert that get and snapshot listener requests sort docs in the same, expected order
+    assertTrue(getSnapshotDocIds.equals(expectedDocIds));
+    assertTrue(watchSnapshotDocIds.equals(expectedDocIds));
+
+    checkOnlineAndOfflineResultsMatch(orderedQuery, expectedDocIds.toArray(new String[0]));
+  }
+
+  public void snapshotListenerSortsUnicodeStringsInDocumentKeyAsServer() {
+    Map<String, Map<String, Object>> testDocs =
+        map(
+            "Łukasiewicz", map("value", "foo"),
+            "Sierpiński", map("value", "foo"),
+            "岩澤", map("value", "foo"),
+            "🄟", map("value", "foo"),
+            "Ｐ", map("value", "foo"),
+            "︒", map("value", "foo"),
+            "🐵", map("value", "foo"));
+
+    CollectionReference colRef = testCollectionWithDocs(testDocs);
+    Query orderedQuery = colRef.orderBy(FieldPath.documentId());
+    List<String> expectedDocIds = Arrays.asList("b", "a", "c", "f", "e", "d", "g");
+
+    QuerySnapshot getSnapshot = waitFor(orderedQuery.get());
+    List<String> getSnapshotDocIds =
+        getSnapshot.getDocuments().stream().map(ds -> ds.getId()).collect(Collectors.toList());
+
+    EventAccumulator<QuerySnapshot> eventAccumulator = new EventAccumulator<QuerySnapshot>();
+    ListenerRegistration registration =
+        orderedQuery.addSnapshotListener(eventAccumulator.listener());
+
+    List<String> watchSnapshotDocIds = new ArrayList<>();
+    try {
+      QuerySnapshot watchSnapshot = eventAccumulator.await();
+      watchSnapshotDocIds =
+          watchSnapshot.getDocuments().stream()
+              .map(documentSnapshot -> documentSnapshot.getId())
+              .collect(Collectors.toList());
+    } finally {
+      registration.remove();
+    }
+
+    // Assert that get and snapshot listener requests sort docs in the same, expected order
+    assertTrue(getSnapshotDocIds.equals(expectedDocIds));
+    assertTrue(watchSnapshotDocIds.equals(expectedDocIds));
+
+    checkOnlineAndOfflineResultsMatch(orderedQuery, expectedDocIds.toArray(new String[0]));
+  }
 }

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FirestoreTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FirestoreTest.java
@@ -1696,6 +1696,7 @@ public class FirestoreTest {
     checkOnlineAndOfflineResultsMatch(orderedQuery, expectedDocIds.toArray(new String[0]));
   }
 
+  @Test
   public void snapshotListenerSortsUnicodeStringsInArrayFieldsAsServer() {
     Map<String, Map<String, Object>> testDocs =
         map(
@@ -1737,6 +1738,7 @@ public class FirestoreTest {
     checkOnlineAndOfflineResultsMatch(orderedQuery, expectedDocIds.toArray(new String[0]));
   }
 
+  @Test
   public void snapshotListenerSortsUnicodeStringsInMapAsServer() {
     Map<String, Map<String, Object>> testDocs =
         map(
@@ -1778,6 +1780,7 @@ public class FirestoreTest {
     checkOnlineAndOfflineResultsMatch(orderedQuery, expectedDocIds.toArray(new String[0]));
   }
 
+  @Test
   public void snapshotListenerSortsUnicodeStringsInMapKeyAsServer() {
     Map<String, Map<String, Object>> testDocs =
         map(
@@ -1819,6 +1822,7 @@ public class FirestoreTest {
     checkOnlineAndOfflineResultsMatch(orderedQuery, expectedDocIds.toArray(new String[0]));
   }
 
+  @Test
   public void snapshotListenerSortsUnicodeStringsInDocumentKeyAsServer() {
     Map<String, Map<String, Object>> testDocs =
         map(
@@ -1832,7 +1836,8 @@ public class FirestoreTest {
 
     CollectionReference colRef = testCollectionWithDocs(testDocs);
     Query orderedQuery = colRef.orderBy(FieldPath.documentId());
-    List<String> expectedDocIds = Arrays.asList("b", "a", "c", "f", "e", "d", "g");
+    List<String> expectedDocIds =
+        Arrays.asList("Sierpiński", "Łukasiewicz", "岩澤", "︒", "Ｐ", "🄟", "🐵");
 
     QuerySnapshot getSnapshot = waitFor(orderedQuery.get());
     List<String> getSnapshotDocIds =

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/BasePath.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/BasePath.java
@@ -114,7 +114,7 @@ public abstract class BasePath<B extends BasePath<B>> implements Comparable<B> {
     } else if (isLhsNumeric && isRhsNumeric) { // both numeric
       return Long.compare(extractNumericId(lhs), extractNumericId(rhs));
     } else { // both string
-      return lhs.compareTo(rhs);
+      return Util.compareUtf8Strings(lhs, rhs);
     }
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Values.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Values.java
@@ -230,8 +230,7 @@ public class Values {
       case TYPE_ORDER_SERVER_TIMESTAMP:
         return compareTimestamps(getLocalWriteTime(left), getLocalWriteTime(right));
       case TYPE_ORDER_STRING:
-        return Util.compareStrings(left.getStringValue(), right.getStringValue());
-//        return left.getStringValue().compareTo(right.getStringValue());
+        return Util.compareUtf8Strings(left.getStringValue(), right.getStringValue());
       case TYPE_ORDER_BLOB:
         return Util.compareByteStrings(left.getBytesValue(), right.getBytesValue());
       case TYPE_ORDER_REFERENCE:
@@ -350,7 +349,7 @@ public class Values {
     while (iterator1.hasNext() && iterator2.hasNext()) {
       Map.Entry<String, Value> entry1 = iterator1.next();
       Map.Entry<String, Value> entry2 = iterator2.next();
-      int keyCompare = entry1.getKey().compareTo(entry2.getKey());
+      int keyCompare = Util.compareUtf8Strings(entry1.getKey(), entry2.getKey());
       if (keyCompare != 0) {
         return keyCompare;
       }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Values.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Values.java
@@ -230,7 +230,8 @@ public class Values {
       case TYPE_ORDER_SERVER_TIMESTAMP:
         return compareTimestamps(getLocalWriteTime(left), getLocalWriteTime(right));
       case TYPE_ORDER_STRING:
-        return left.getStringValue().compareTo(right.getStringValue());
+        return Util.compareStrings(left.getStringValue(), right.getStringValue());
+//        return left.getStringValue().compareTo(right.getStringValue());
       case TYPE_ORDER_BLOB:
         return Util.compareByteStrings(left.getBytesValue(), right.getBytesValue());
       case TYPE_ORDER_REFERENCE:

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Util.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Util.java
@@ -27,6 +27,8 @@ import com.google.protobuf.ByteString;
 import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
+
+import java.nio.charset.Charset;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -83,6 +85,13 @@ public class Util {
     } else {
       return 0;
     }
+  }
+
+  public static int compareStrings(String left, String right) {
+    ByteString leftBytes = ByteString.copyFromUtf8(left);
+    ByteString rightBytes = ByteString.copyFromUtf8(right);
+    //    return left.getStringValue().compareTo(right.getStringValue());
+    return compareByteStrings(leftBytes, rightBytes);
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Util.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Util.java
@@ -27,8 +27,6 @@ import com.google.protobuf.ByteString;
 import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
-
-import java.nio.charset.Charset;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -87,10 +85,9 @@ public class Util {
     }
   }
 
-  public static int compareStrings(String left, String right) {
+  public static int compareUtf8Strings(String left, String right) {
     ByteString leftBytes = ByteString.copyFromUtf8(left);
     ByteString rightBytes = ByteString.copyFromUtf8(right);
-    //    return left.getStringValue().compareTo(right.getStringValue());
     return compareByteStrings(leftBytes, rightBytes);
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Util.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Util.java
@@ -85,6 +85,7 @@ public class Util {
     }
   }
 
+  /** Compare strings in UTF-8 encoded byte order */
   public static int compareUtf8Strings(String left, String right) {
     ByteString leftBytes = ByteString.copyFromUtf8(left);
     ByteString rightBytes = ByteString.copyFromUtf8(right);


### PR DESCRIPTION
Strings should be sorted in UTF-8 encoded byte order. Public document: https://cloud.google.com/firestore/docs/concepts/data-types#data_types

SDK sorts strings using built in comparator method, which sorts lexicographically, and leads to mismatch between server and sdk when special characters are present. This PR fixes the string order mismatches on document field, map key, and document key.