### PR TITLE
WIP: Idea for exit cleanly on expected crash

### DIFF
--- a/firebase-sessions/test-app/src/main/AndroidManifest.xml
+++ b/firebase-sessions/test-app/src/main/AndroidManifest.xml
@@ -28,7 +28,6 @@
       android:exported="true"
       android:label="@string/app_name"
       android:name=".MainActivity"
-      android:process=":main"
       android:theme="@style/Theme.Widget_test_app.NoActionBar">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
@@ -51,6 +50,15 @@
       android:name="firebase_sessions_sessions_restart_timeout"
       android:value="5" />
 
+    <provider
+      android:authorities="${applicationId}.preFirebase"
+      android:directBootAware="true"
+      android:exported="false"
+      android:initOrder="101"
+      android:name="com.google.firebase.testing.sessions.PreFirebaseProvider" />
+
+    <receiver android:name=".CrashBroadcastReceiver" />
+
     <receiver
       android:exported="false"
       android:name="CrashWidgetProvider"
@@ -62,8 +70,6 @@
         android:name="android.appwidget.provider"
         android:resource="@xml/homescreen_widget" />
     </receiver>
-
-    <receiver android:name=".CrashBroadcastReceiver" />
 
     <service
       android:enabled="true"

--- a/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/FirstFragment.kt
+++ b/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/FirstFragment.kt
@@ -54,8 +54,9 @@ class FirstFragment : Fragment() {
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
+    PreFirebaseProvider.expectedMessage = "i am expected"
 
-    binding.buttonCrash.setOnClickListener { throw RuntimeException("CRASHED") }
+    binding.buttonCrash.setOnClickListener { throw RuntimeException("so i am expected 123") }
     binding.buttonNonFatal.setOnClickListener {
       crashlytics.recordException(IllegalStateException())
     }

--- a/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/PreFirebaseProvider.kt
+++ b/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/PreFirebaseProvider.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.testing.sessions
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import java.lang.Thread.UncaughtExceptionHandler
+import kotlin.system.exitProcess
+
+class PreFirebaseProvider : ContentProvider(), UncaughtExceptionHandler {
+  private var defaultUncaughtExceptionHandler: UncaughtExceptionHandler? = null
+
+  companion object {
+    /**
+     * Set an expected exception message. If the uncaught exception contains the given string, then
+     * the app will exit cleanly. Otherwise, it will propagate up to the default exception handler.
+     */
+    var expectedMessage: String? = null
+  }
+
+  override fun onCreate(): Boolean {
+    defaultUncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
+    Thread.setDefaultUncaughtExceptionHandler(this)
+
+    return false
+  }
+
+  /* Returns if the given exception contains the expectedMessage in its message. */
+  private fun isExpected(throwable: Throwable): Boolean =
+    expectedMessage?.run { throwable.message?.contains(this) } ?: false
+
+  override fun uncaughtException(thread: Thread, throwable: Throwable) {
+    if (isExpected(throwable)) {
+      // Exit cleanly
+      exitProcess(0)
+    } else {
+      // Propagate up to the default exception handler
+      defaultUncaughtExceptionHandler?.uncaughtException(thread, throwable)
+    }
+  }
+
+  override fun query(
+    uri: Uri,
+    projection: Array<out String>?,
+    selection: String?,
+    selectionArgs: Array<out String>?,
+    sortOrder: String?
+  ): Cursor? = null
+
+  override fun getType(uri: Uri): String? = null
+
+  override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+  override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int = 0
+
+  override fun update(
+    uri: Uri,
+    values: ContentValues?,
+    selection: String?,
+    selectionArgs: Array<out String>?
+  ): Int = 0
+}


### PR DESCRIPTION
The idea here is to exit cleanly on an expected crash. The point of `expectedMessage` is so we don't hide unexpected crashes. The `PreFirebaseProvider` will load before the real `FirebaseInitProvider`, causing Crashlytics to propagate uncaught exceptions to it.