### PR TITLE
Update the CHANGELOG for Crashlytics to better document the changes.

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
-* [fixed] Added an overload for `recordException` that allows logging event specific custom keys [#3551]
+* [fixed] Added an overload for `recordException` that allows logging event specific custom keys. 
+  (GitHub [#3551](https://github.com/firebase/firebase-android-sdk/issues/3551){: .external})
 
 # 19.3.0
 * [fixed] Fixed inefficiency in the Kotlin `FirebaseCrashlytics.setCustomKeys` extension.

--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Unreleased
-* [feature] Added an overload for `recordException` that allows logging additional custom
-  keys to the non fatal event [#3551]
+* [fixed] Added an overload for `recordException` that allows logging event specific custom keys [#3551]
 
 # 19.3.0
 * [fixed] Fixed inefficiency in the Kotlin `FirebaseCrashlytics.setCustomKeys` extension.

--- a/firebase-crashlytics/gradle.properties
+++ b/firebase-crashlytics/gradle.properties
@@ -1,2 +1,2 @@
-version=19.4.0
+version=19.3.1
 latestReleasedVersion=19.3.0

--- a/firebase-crashlytics/gradle.properties
+++ b/firebase-crashlytics/gradle.properties
@@ -1,2 +1,2 @@
-version=19.3.1
+version=19.4.0
 latestReleasedVersion=19.3.0


### PR DESCRIPTION
The SDK contains a new API which was added in https://github.com/firebase/firebase-android-sdk/pull/6528.

Since it's a new API, this should be a minor version bump, and not a patch.

Edit: This is an API overload that's backwards compatible and so it's probably OK for it to be a patch release.