### PR TITLE
[Vertex AI] Add `apiVersion` parameter to `RequestOptions`

### DIFF
--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/ApiVersion.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/ApiVersion.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.vertexai.type
+
+/** Versions of the Vertex AI in Firebase server API. */
+public class ApiVersion private constructor(internal val value: String) {
+  public companion object {
+    /** The stable channel for version 1 of the API. */
+    @JvmField public val V1: ApiVersion = ApiVersion("v1")
+
+    /** The beta channel for version 1 of the API. */
+    @JvmField public val V1BETA: ApiVersion = ApiVersion("v1beta")
+  }
+}

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/RequestOptions.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/RequestOptions.kt
@@ -26,17 +26,23 @@ public class RequestOptions
 internal constructor(
   internal val timeout: Duration,
   internal val endpoint: String = "https://firebasevertexai.googleapis.com",
-  internal val apiVersion: String = "v1beta",
+  internal val apiVersion: String,
 ) {
 
   /**
    * Constructor for RequestOptions.
    *
    * @param timeoutInMillis the maximum amount of time, in milliseconds, for a request to take, from
-   * the first request to first response.
+   *   the first request to first response.
+   * @param apiVersion the version of the Vertex AI in Firebase API; defaults to [ApiVersion.V1BETA]
+   *   if not specified.
    */
   @JvmOverloads
   public constructor(
-    timeoutInMillis: Long = 180.seconds.inWholeMilliseconds
-  ) : this(timeout = timeoutInMillis.toDuration(DurationUnit.MILLISECONDS))
+    timeoutInMillis: Long = 180.seconds.inWholeMilliseconds,
+    apiVersion: ApiVersion = ApiVersion.V1BETA,
+  ) : this(
+    timeout = timeoutInMillis.toDuration(DurationUnit.MILLISECONDS),
+    apiVersion = apiVersion.value,
+  )
 }

--- a/firebase-vertexai/src/test/java/com/google/firebase/vertexai/GenerativeModelTesting.kt
+++ b/firebase-vertexai/src/test/java/com/google/firebase/vertexai/GenerativeModelTesting.kt
@@ -60,7 +60,7 @@ internal class GenerativeModelTesting {
       APIController(
         "super_cool_test_key",
         "gemini-1.5-flash",
-        RequestOptions(timeout = 5.seconds, endpoint = "https://my.custom.endpoint"),
+        RequestOptions(5.seconds.inWholeMilliseconds),
         mockEngine,
         TEST_CLIENT_ID,
         null,


### PR DESCRIPTION
WIP - Needs API review

Added the ability to specify an API version (e.g., v1 or v1beta) when initializing `RequestOptions`. This is the Android-equivalent of https://github.com/firebase/firebase-ios-sdk/pull/14356.