### PR TITLE
Update code formatting command in vertex's README

### DIFF
--- a/firebase-vertexai/README.md
+++ b/firebase-vertexai/README.md
@@ -30,7 +30,7 @@ Integration tests, requiring a running and connected device (emulator or real):
 ## Code Formatting
 
 Format Kotlin code in this SDK in Android Studio using
-the [ktfmt plugin](https://plugins.jetbrains.com/plugin/14912-ktfmt) with code style to
-**Google (internal)**, or by running:
+the [spotless plugin]([https://plugins.jetbrains.com/plugin/14912-ktfmt](https://github.com/diffplug/spotless)
+by running:
 
-`./gradlew :firebase-vertexai:ktfmtFormat`
+`./gradlew firebase-vertexai:spotlessApply`


### PR DESCRIPTION
We have been using the spotless plugin for a while already.