### PR TITLE
Update the vertex golden file version being pulled

### DIFF
--- a/firebase-vertexai/src/test/java/com/google/firebase/vertexai/UnarySnapshotTests.kt
+++ b/firebase-vertexai/src/test/java/com/google/firebase/vertexai/UnarySnapshotTests.kt
@@ -44,7 +44,7 @@ import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotBeEmpty
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.http.HttpStatusCode
-import io.ktor.util.date.toDate
+import java.util.Calendar
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.JsonPrimitive
@@ -52,8 +52,6 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.json.JSONArray
 import org.junit.Test
-import java.util.Calendar
-import java.util.Date
 
 internal class UnarySnapshotTests {
   private val testTimeout = 5.seconds

--- a/firebase-vertexai/update_responses.sh
+++ b/firebase-vertexai/update_responses.sh
@@ -17,7 +17,7 @@
 # This script replaces mock response files for Vertex AI unit tests with a fresh
 # clone of the shared repository of Vertex AI test data.
 
-RESPONSES_VERSION='v3.*' # The major version of mock responses to use
+RESPONSES_VERSION='v5.*' # The major version of mock responses to use
 REPO_NAME="vertexai-sdk-test-data"
 REPO_LINK="https://github.com/FirebaseExtended/$REPO_NAME.git"
 


### PR DESCRIPTION
We've updated from version 3.* to 5.*. Test were added were necessary to match the coverage in the iOS repo.

A few changes (v5.1 and v5.2) don't have tests covering the new files yet