### PR TITLE
dataconnect.yaml: improve readability of the output of the "tool versions" step

### DIFF
--- a/.github/workflows/dataconnect.yml
+++ b/.github/workflows/dataconnect.yml
@@ -84,16 +84,22 @@ jobs:
       - name: tool versions
         continue-on-error: true
         run: |
-          set +e -v
-          uname -a
-          which java
-          java -version
-          which javac
-          javac -version
-          which node
-          node --version
-          ${{ env.FDC_FIREBASE_COMMAND }} --version
-          ./gradlew --version
+          function run_cmd {
+            echo "==============================================================================="
+            echo "Running Command: $*"
+            ("$@" 2>&1) || echo "WARNING: command failed with non-zero exit code $?: $*"
+            echo
+          }
+
+          run_cmd uname -a
+          run_cmd which java
+          run_cmd java -version
+          run_cmd which javac
+          run_cmd javac -version
+          run_cmd which node
+          run_cmd node --version
+          run_cmd ${{ env.FDC_FIREBASE_COMMAND }} --version
+          run_cmd ./gradlew --version
 
       - name: Gradle assembleDebugAndroidTest
         run: |

--- a/.github/workflows/dataconnect.yml
+++ b/.github/workflows/dataconnect.yml
@@ -88,7 +88,6 @@ jobs:
             echo "==============================================================================="
             echo "Running Command: $*"
             ("$@" 2>&1) || echo "WARNING: command failed with non-zero exit code $?: $*"
-            echo
           }
 
           run_cmd uname -a

--- a/.github/workflows/dataconnect_demo_app.yml
+++ b/.github/workflows/dataconnect_demo_app.yml
@@ -89,15 +89,20 @@ jobs:
       - name: tool versions
         continue-on-error: true
         run: |
-          set +e -v
-          which java
-          java -version
-          which javac
-          javac -version
-          which node
-          node --version
-          ${{ env.FDC_FIREBASE_COMMAND }} --version
-          ./gradlew --version
+          function run_cmd {
+            echo "==============================================================================="
+            echo "Running Command: $*"
+            ("$@" 2>&1) || echo "WARNING: command failed with non-zero exit code $?: $*"
+          }
+
+          run_cmd which java
+          run_cmd java -version
+          run_cmd which javac
+          run_cmd javac -version
+          run_cmd which node
+          run_cmd node --version
+          run_cmd ${{ env.FDC_FIREBASE_COMMAND }} --version
+          run_cmd ./gradlew --version
 
       - name: ./gradlew assemble test
         run: |


### PR DESCRIPTION
The output now looks like this, with nice separators:

```
===============================================================================
Running Command: uname -a
Linux fv-az1911-92 6.8.0-1020-azure #23-Ubuntu SMP Mon Dec  9 16:58:58 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
===============================================================================
Running Command: which java
/opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.14-7/x64/bin/java
===============================================================================
Running Command: java -version
openjdk version "17.0.14" 2025-01-21
OpenJDK Runtime Environment Temurin-17.0.14+7 (build 17.0.14+7)
OpenJDK 64-Bit Server VM Temurin-17.0.14+7 (build 17.0.14+7, mixed mode, sharing)
===============================================================================
Running Command: which javac
/opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.14-7/x64/bin/javac
===============================================================================
Running Command: javac -version
javac 17.0.14
===============================================================================
Running Command: which node
/opt/hostedtoolcache/node/20.18.2/x64/bin/node
===============================================================================
Running Command: node --version
v20.18.2
===============================================================================
Running Command: /tmp/firebase-tools/node_modules/.bin/firebase --version
13.[29](https://github.com/firebase/firebase-android-sdk/actions/runs/13144511196/job/36679371844?pr=6669#step:8:30).1
===============================================================================
Running Command: ./gradlew --version
Downloading https://services.gradle.org/distributions/gradle-8.4-bin.zip
............10%............20%.............[30](https://github.com/firebase/firebase-android-sdk/actions/runs/13144511196/job/36679371844?pr=6669#step:8:31)%............40%.............50%............60%.............70%............80%.............90%............100%

Welcome to Gradle 8.4!

Here are the highlights of this release:
 - Compiling and testing with Java 21
 - Faster Java compilation on Windows
 - Role focused dependency configurations creation

For more details see https://docs.gradle.org/8.4/release-notes.html


------------------------------------------------------------
Gradle 8.4
------------------------------------------------------------

Build time:   2023-10-04 20:52:13 UTC
Revision:     e9251e572c9bd1d01e503a0dfdf43aedaeecdc3f

Kotlin:       1.9.10
Groovy:       3.0.17
Ant:          Apache Ant(TM) version 1.10.13 compiled on January 4 2023
JVM:          17.0.14 (Eclipse Adoptium 17.0.14+7)
OS:           Linux 6.8.0-1020-azure amd64
```