### PR TITLE
Update changelogs for m150

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-* [fixed] Fixed a server and sdk mismatch in unicode string sorting. [#6615](//github.com/firebase/firebase-android-sdk/pull/6615)
+* [fixed] Fixed a server and SDK mismatch in unicode string sorting. [#6615](//github.com/firebase/firebase-android-sdk/pull/6615)
 
 # 25.1.1
 * [changed] Update Firestore proto definitions. [#6369](//github.com/firebase/firebase-android-sdk/pull/6369)

--- a/firebase-vertexai/CHANGELOG.md
+++ b/firebase-vertexai/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [changed] Internal improvements to correctly handle empty model responses.
+* [changed] Internal improvements to correctly handle empty responses from models.
 
 
 # 16.0.2


### PR DESCRIPTION
This updates the changelog entries that had their contents changed in the m150 CL.

NO_RELEASE_CHANGE