### PR TITLE
Remove the logging of GaugeMetadata to allow using AQS

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformance.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformance.java
@@ -182,7 +182,6 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
         .initialize(firebaseApp, firebaseInstallationsApi, transportFactoryProvider);
 
     Context appContext = firebaseApp.getApplicationContext();
-    // TODO(b/110178816): Explore moving off of main thread.
     mMetadataBundle = extractMetadata(appContext);
 
     remoteConfigManager.setFirebaseRemoteConfigProvider(firebaseRemoteConfigProvider);

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
@@ -79,9 +79,6 @@ public class SessionManager extends AppStateUpdateHandler {
    * (currently that is before onResume finishes) to ensure gauge collection starts on time.
    */
   public void setApplicationContext(final Context appContext) {
-    // Get PerfSession in main thread first, because it is possible that app changes fg/bg state
-    // which creates a new perfSession, before the following is executed in background thread
-    final PerfSession appStartSession = perfSession;
     // TODO(b/258263016): Migrate to go/firebase-android-executors
     @SuppressLint("ThreadPoolCreation")
     ExecutorService executorService = Executors.newSingleThreadExecutor();
@@ -89,10 +86,6 @@ public class SessionManager extends AppStateUpdateHandler {
         executorService.submit(
             () -> {
               gaugeManager.initializeGaugeMetadataManager(appContext);
-              if (appStartSession.isGaugeAndEventCollectionEnabled()) {
-                gaugeManager.logGaugeMetadata(
-                    appStartSession.sessionId(), ApplicationProcessState.FOREGROUND);
-              }
             });
   }
 
@@ -164,9 +157,6 @@ public class SessionManager extends AppStateUpdateHandler {
       }
     }
 
-    // Log the gauge metadata event if data collection is enabled.
-    logGaugeMetadataIfCollectionEnabled(appStateMonitor.getAppState());
-
     // Start of stop the gauge data collection.
     startOrStopCollectingGauges(appStateMonitor.getAppState());
   }
@@ -178,7 +168,6 @@ public class SessionManager extends AppStateUpdateHandler {
    * this does not reset the perfSession.
    */
   public void initializeGaugeCollection() {
-    logGaugeMetadataIfCollectionEnabled(ApplicationProcessState.FOREGROUND);
     startOrStopCollectingGauges(ApplicationProcessState.FOREGROUND);
   }
 
@@ -203,12 +192,6 @@ public class SessionManager extends AppStateUpdateHandler {
   public void unregisterForSessionUpdates(WeakReference<SessionAwareObject> client) {
     synchronized (clients) {
       clients.remove(client);
-    }
-  }
-
-  private void logGaugeMetadataIfCollectionEnabled(ApplicationProcessState appState) {
-    if (perfSession.isGaugeAndEventCollectionEnabled()) {
-      gaugeManager.logGaugeMetadata(perfSession.sessionId(), appState);
     }
   }
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/CpuGaugeCollector.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/CpuGaugeCollector.java
@@ -17,8 +17,6 @@ package com.google.firebase.perf.session.gauges;
 import static android.system.Os.sysconf;
 
 import android.annotation.SuppressLint;
-import android.os.Build.VERSION;
-import android.os.Build.VERSION_CODES;
 import android.system.OsConstants;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -163,7 +161,7 @@ public class CpuGaugeCollector {
     this.cpuMetricCollectionRateMs = cpuMetricCollectionRate;
     try {
       cpuMetricCollectorJob =
-          cpuMetricCollectorExecutor.scheduleAtFixedRate(
+          cpuMetricCollectorExecutor.scheduleWithFixedDelay(
               () -> {
                 CpuMetricReading currCpuReading = syncCollectCpuMetric(referenceTime);
                 if (currCpuReading != null) {
@@ -181,7 +179,7 @@ public class CpuGaugeCollector {
   private synchronized void scheduleCpuMetricCollectionOnce(Timer referenceTime) {
     try {
       @SuppressWarnings("FutureReturnValueIgnored")
-      ScheduledFuture unusedFuture =
+      ScheduledFuture<?> unusedFuture =
           cpuMetricCollectorExecutor.schedule(
               () -> {
                 CpuMetricReading currCpuReading = syncCollectCpuMetric(referenceTime);
@@ -227,12 +225,7 @@ public class CpuGaugeCollector {
   }
 
   private long getClockTicksPerSecond() {
-    if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
-      return sysconf(OsConstants._SC_CLK_TCK);
-    } else {
-      // TODO(b/110779408): Figure out how to collect this info for Android API 20 and below.
-      return INVALID_SC_PER_CPU_CLOCK_TICK;
-    }
+    return sysconf(OsConstants._SC_CLK_TCK);
   }
 
   private long convertClockTicksToMicroseconds(long clockTicks) {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeManager.java
@@ -72,8 +72,8 @@ public class GaugeManager {
         TransportManager.getInstance(),
         ConfigResolver.getInstance(),
         null,
-        new Lazy<>(() -> new CpuGaugeCollector()),
-        new Lazy<>(() -> new MemoryGaugeCollector()));
+        new Lazy<>(CpuGaugeCollector::new),
+        new Lazy<>(MemoryGaugeCollector::new));
   }
 
   @VisibleForTesting
@@ -81,7 +81,7 @@ public class GaugeManager {
       Lazy<ScheduledExecutorService> gaugeManagerExecutor,
       TransportManager transportManager,
       ConfigResolver configResolver,
-      GaugeMetadataManager gaugeMetadataManager,
+      @Nullable GaugeMetadataManager gaugeMetadataManager,
       Lazy<CpuGaugeCollector> cpuGaugeCollector,
       Lazy<MemoryGaugeCollector> memoryGaugeCollector) {
 
@@ -140,7 +140,7 @@ public class GaugeManager {
       gaugeManagerDataCollectionJob =
           gaugeManagerExecutor
               .get()
-              .scheduleAtFixedRate(
+              .scheduleWithFixedDelay(
                   () -> {
                     syncFlush(sessionIdForScheduledTask, applicationProcessStateForScheduledTask);
                   },

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeManager.java
@@ -256,6 +256,7 @@ public class GaugeManager {
    * @return true if GaugeMetadata was logged, false otherwise.
    */
   public boolean logGaugeMetadata(String sessionId, ApplicationProcessState appState) {
+    // TODO(b/394127311): Re-introduce logging of metadata for AQS.
     if (gaugeMetadataManager != null) {
       GaugeMetric gaugeMetric =
           GaugeMetric.newBuilder()

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeMetadataManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeMetadataManager.java
@@ -17,8 +17,6 @@ package com.google.firebase.perf.session.gauges;
 import android.app.ActivityManager;
 import android.app.ActivityManager.MemoryInfo;
 import android.content.Context;
-import android.os.Build.VERSION;
-import android.os.Build.VERSION_CODES;
 import androidx.annotation.VisibleForTesting;
 import com.google.firebase.perf.logging.AndroidLogger;
 import com.google.firebase.perf.util.StorageUnit;
@@ -41,7 +39,6 @@ class GaugeMetadataManager {
   private final Runtime runtime;
   private final ActivityManager activityManager;
   private final MemoryInfo memoryInfo;
-  private final Context appContext;
 
   GaugeMetadataManager(Context appContext) {
     this(Runtime.getRuntime(), appContext);
@@ -50,7 +47,6 @@ class GaugeMetadataManager {
   @VisibleForTesting
   GaugeMetadataManager(Runtime runtime, Context appContext) {
     this.runtime = runtime;
-    this.appContext = appContext;
     this.activityManager = (ActivityManager) appContext.getSystemService(Context.ACTIVITY_SERVICE);
     memoryInfo = new ActivityManager.MemoryInfo();
     activityManager.getMemoryInfo(memoryInfo);
@@ -75,11 +71,7 @@ class GaugeMetadataManager {
 
   /** Returns the total memory (in kilobytes) accessible by the kernel (called the RAM size). */
   public int getDeviceRamSizeKb() {
-    if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN) {
-      return Utils.saturatedIntCast(StorageUnit.BYTES.toKilobytes(memoryInfo.totalMem));
-    }
-
-    return readTotalRAM(/* procFileName= */ "/proc/meminfo");
+    return Utils.saturatedIntCast(StorageUnit.BYTES.toKilobytes(memoryInfo.totalMem));
   }
 
   /** Returns the total ram size of the device (in kilobytes) by reading the "proc/meminfo" file. */

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeMetadataManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeMetadataManager.java
@@ -22,11 +22,6 @@ import com.google.firebase.perf.logging.AndroidLogger;
 import com.google.firebase.perf.util.StorageUnit;
 import com.google.firebase.perf.util.Utils;
 import com.google.firebase.perf.v1.GaugeMetadata;
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * The {@code GaugeMetadataManager} class is responsible for collecting {@link GaugeMetadata}
@@ -72,24 +67,5 @@ class GaugeMetadataManager {
   /** Returns the total memory (in kilobytes) accessible by the kernel (called the RAM size). */
   public int getDeviceRamSizeKb() {
     return Utils.saturatedIntCast(StorageUnit.BYTES.toKilobytes(memoryInfo.totalMem));
-  }
-
-  /** Returns the total ram size of the device (in kilobytes) by reading the "proc/meminfo" file. */
-  @VisibleForTesting
-  int readTotalRAM(String procFileName) {
-    try (BufferedReader br = new BufferedReader(new FileReader(procFileName))) {
-      for (String s = br.readLine(); s != null; s = br.readLine()) {
-        if (s.startsWith("MemTotal")) {
-          Matcher m = Pattern.compile("\\d+").matcher(s);
-          return m.find() ? Integer.parseInt(m.group()) : 0;
-        }
-      }
-    } catch (IOException ioe) {
-      logger.warn("Unable to read '" + procFileName + "' file: " + ioe.getMessage());
-    } catch (NumberFormatException nfe) {
-      logger.warn("Unable to parse '" + procFileName + "' file: " + nfe.getMessage());
-    }
-
-    return 0;
   }
 }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/MemoryGaugeCollector.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/MemoryGaugeCollector.java
@@ -50,7 +50,7 @@ public class MemoryGaugeCollector {
   public final ConcurrentLinkedQueue<AndroidMemoryReading> memoryMetricReadings;
   private final Runtime runtime;
 
-  @Nullable private ScheduledFuture memoryMetricCollectorJob = null;
+  @Nullable private ScheduledFuture<?> memoryMetricCollectorJob = null;
   private long memoryMetricCollectionRateMs = UNSET_MEMORY_METRIC_COLLECTION_RATE;
 
   // TODO(b/258263016): Migrate to go/firebase-android-executors
@@ -124,7 +124,7 @@ public class MemoryGaugeCollector {
 
     try {
       memoryMetricCollectorJob =
-          memoryMetricCollectorExecutor.scheduleAtFixedRate(
+          memoryMetricCollectorExecutor.scheduleWithFixedDelay(
               () -> {
                 AndroidMemoryReading memoryReading = syncCollectMemoryMetric(referenceTime);
                 if (memoryReading != null) {
@@ -142,7 +142,7 @@ public class MemoryGaugeCollector {
   private synchronized void scheduleMemoryMetricCollectionOnce(Timer referenceTime) {
     try {
       @SuppressWarnings("FutureReturnValueIgnored")
-      ScheduledFuture unusedFuture =
+      ScheduledFuture<?> unusedFuture =
           memoryMetricCollectorExecutor.schedule(
               () -> {
                 AndroidMemoryReading memoryReading = syncCollectMemoryMetric(referenceTime);

--- a/firebase-perf/src/test/java/com/google/firebase/perf/session/SessionManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/session/SessionManagerTest.java
@@ -138,20 +138,6 @@ public class SessionManagerTest extends FirebasePerformanceTestBase {
 
   @Test
   public void
-      testOnUpdateAppStateMakesGaugeManagerLogGaugeMetadataOnForegroundStateIfSessionIsVerbose() {
-    forceVerboseSession();
-
-    SessionManager testSessionManager =
-        new SessionManager(mockGaugeManager, mockPerfSession, mockAppStateMonitor);
-    testSessionManager.onUpdateAppState(ApplicationProcessState.FOREGROUND);
-
-    verify(mockGaugeManager)
-        .logGaugeMetadata(
-            anyString(), nullable(com.google.firebase.perf.v1.ApplicationProcessState.class));
-  }
-
-  @Test
-  public void
       testOnUpdateAppStateDoesntMakeGaugeManagerLogGaugeMetadataOnForegroundStateIfSessionIsNonVerbose() {
     forceNonVerboseSession();
 
@@ -174,21 +160,6 @@ public class SessionManagerTest extends FirebasePerformanceTestBase {
     testSessionManager.onUpdateAppState(ApplicationProcessState.BACKGROUND);
 
     verify(mockGaugeManager, never())
-        .logGaugeMetadata(
-            anyString(), nullable(com.google.firebase.perf.v1.ApplicationProcessState.class));
-  }
-
-  @Test
-  public void
-      testOnUpdateAppStateMakesGaugeManagerLogGaugeMetadataOnBackgroundAppStateIfSessionIsVerboseAndTimedOut() {
-    when(mockPerfSession.isSessionRunningTooLong()).thenReturn(true);
-    forceVerboseSession();
-
-    SessionManager testSessionManager =
-        new SessionManager(mockGaugeManager, mockPerfSession, mockAppStateMonitor);
-    testSessionManager.onUpdateAppState(ApplicationProcessState.BACKGROUND);
-
-    verify(mockGaugeManager)
         .logGaugeMetadata(
             anyString(), nullable(com.google.firebase.perf.v1.ApplicationProcessState.class));
   }
@@ -230,32 +201,6 @@ public class SessionManagerTest extends FirebasePerformanceTestBase {
     testSessionManager.updatePerfSession(PerfSession.createWithId("testSessionId2"));
 
     verify(mockGaugeManager).stopCollectingGauges();
-  }
-
-  @Test
-  public void testGaugeMetadataIsFlushedOnlyWhenNewVerboseSessionIsCreated() {
-    when(mockPerfSession.isSessionRunningTooLong()).thenReturn(false);
-
-    // Start with a non verbose session
-    forceNonVerboseSession();
-    SessionManager testSessionManager =
-        new SessionManager(
-            mockGaugeManager, PerfSession.createWithId("testSessionId1"), mockAppStateMonitor);
-
-    verify(mockGaugeManager, times(0))
-        .logGaugeMetadata(
-            eq("testSessionId1"),
-            eq(com.google.firebase.perf.v1.ApplicationProcessState.FOREGROUND));
-
-    // Forcing a verbose session will enable Gauge collection
-    forceVerboseSession();
-    testSessionManager.updatePerfSession(PerfSession.createWithId("testSessionId2"));
-    verify(mockGaugeManager, times(1)).logGaugeMetadata(eq("testSessionId2"), any());
-
-    // Force a non-verbose session and verify if we are not logging metadata
-    forceVerboseSession();
-    testSessionManager.updatePerfSession(PerfSession.createWithId("testSessionId3"));
-    verify(mockGaugeManager, times(1)).logGaugeMetadata(eq("testSessionId3"), any());
   }
 
   @Test

--- a/firebase-perf/src/test/java/com/google/firebase/perf/session/SessionManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/session/SessionManagerTest.java
@@ -74,7 +74,7 @@ public class SessionManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void setApplicationContext_logGaugeMetadata_afterGaugeMetadataManagerIsInitialized()
+  public void setApplicationContext_initializeGaugeMetadataManager()
       throws ExecutionException, InterruptedException {
     when(mockPerfSession.isGaugeAndEventCollectionEnabled()).thenReturn(true);
     InOrder inOrder = Mockito.inOrder(mockGaugeManager);
@@ -84,7 +84,6 @@ public class SessionManagerTest extends FirebasePerformanceTestBase {
 
     testSessionManager.getSyncInitFuture().get();
     inOrder.verify(mockGaugeManager).initializeGaugeMetadataManager(any());
-    inOrder.verify(mockGaugeManager).logGaugeMetadata(any(), any());
   }
 
   @Test

--- a/firebase-perf/src/test/java/com/google/firebase/perf/session/gauges/GaugeMetadataManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/session/gauges/GaugeMetadataManagerTest.java
@@ -15,26 +15,20 @@
 package com.google.firebase.perf.session.gauges;
 
 import static com.google.common.truth.Truth.assertThat;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.app.ActivityManager;
 import android.content.Context;
-import android.os.Environment;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.firebase.perf.FirebasePerformanceTestBase;
 import com.google.firebase.perf.util.StorageUnit;
-import java.io.File;
 import java.io.IOException;
-import java.io.Writer;
-import java.nio.file.Files;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.shadows.ShadowEnvironment;
 
 /** Unit tests for {@link com.google.firebase.perf.session.gauges.GaugeMetadataManager} */
 @RunWith(RobolectricTestRunner.class)
@@ -49,12 +43,11 @@ public class GaugeMetadataManagerTest extends FirebasePerformanceTestBase {
 
   @Mock private Runtime runtime;
   private ActivityManager activityManager;
-  private Context appContext;
 
   @Before
   public void setUp() {
     initMocks(this);
-    appContext = ApplicationProvider.getApplicationContext();
+    Context appContext = ApplicationProvider.getApplicationContext();
     activityManager = (ActivityManager) appContext.getSystemService(Context.ACTIVITY_SERVICE);
 
     mockMemory();
@@ -90,62 +83,5 @@ public class GaugeMetadataManagerTest extends FirebasePerformanceTestBase {
     int ramSize = testGaugeMetadataManager.getDeviceRamSizeKb();
 
     assertThat(ramSize).isEqualTo(StorageUnit.BYTES.toKilobytes(DEVICE_RAM_SIZE_BYTES));
-    assertThat(ramSize).isEqualTo(testGaugeMetadataManager.readTotalRAM(createFakeMemInfoFile()));
   }
-
-  /** @return The file path of this fake file which can be used to read the file. */
-  private String createFakeMemInfoFile() throws IOException {
-    // Due to file permission issues on forge, it's easiest to just write this file to the emulated
-    // robolectric external storage.
-    ShadowEnvironment.setExternalStorageState(Environment.MEDIA_MOUNTED);
-
-    File file = new File(Environment.getExternalStorageDirectory(), "FakeProcMemInfoFile");
-    Writer fileWriter;
-
-    fileWriter = Files.newBufferedWriter(file.toPath(), UTF_8);
-    fileWriter.write(MEM_INFO_CONTENTS);
-    fileWriter.close();
-
-    return file.getAbsolutePath();
-  }
-
-  private static final String MEM_INFO_CONTENTS =
-      "MemTotal:        "
-          + DEVICE_RAM_SIZE_KB
-          + " kB\n"
-          + "MemFree:          542404 kB\n"
-          + "MemAvailable:    1392324 kB\n"
-          + "Buffers:           64292 kB\n"
-          + "Cached:           826180 kB\n"
-          + "SwapCached:         4196 kB\n"
-          + "Active:           934768 kB\n"
-          + "Inactive:         743812 kB\n"
-          + "Active(anon):     582132 kB\n"
-          + "Inactive(anon):   241500 kB\n"
-          + "Active(file):     352636 kB\n"
-          + "Inactive(file):   502312 kB\n"
-          + "Unevictable:        5148 kB\n"
-          + "Mlocked:             256 kB\n"
-          + "SwapTotal:        524284 kB\n"
-          + "SwapFree:         484800 kB\n"
-          + "Dirty:                 4 kB\n"
-          + "Writeback:             0 kB\n"
-          + "AnonPages:        789404 kB\n"
-          + "Mapped:           241928 kB\n"
-          + "Shmem:             30632 kB\n"
-          + "Slab:             122320 kB\n"
-          + "SReclaimable:      42552 kB\n"
-          + "SUnreclaim:        79768 kB\n"
-          + "KernelStack:       22816 kB\n"
-          + "PageTables:        35344 kB\n"
-          + "NFS_Unstable:          0 kB\n"
-          + "Bounce:                0 kB\n"
-          + "WritebackTmp:          0 kB\n"
-          + "CommitLimit:     2042280 kB\n"
-          + "Committed_AS:   76623352 kB\n"
-          + "VmallocTotal:   251658176 kB\n"
-          + "VmallocUsed:      232060 kB\n"
-          + "VmallocChunk:   251347444 kB\n"
-          + "NvMapMemFree:      48640 kB\n"
-          + "NvMapMemUsed:     471460 kB\n";
 }


### PR DESCRIPTION
Based on the behaviour of AQS w/ Fireperf, an AQS session isn't available when (currently) logging gauge metadata.

Changes:
- Remove the current logging of gauge metadata - will be re-introduced in a future PR.
- Switch Gauge collection from `scheduleAtFixedRate` to `scheduleWithFixedDelay`. As [documented](https://stackoverflow.com/a/78405653), this *should* prevent a potentially large amounts of gauge collection if a process is cached, and then restored during a verbose session - which *should* make it work better w/ AQS.
- Remove API restricted behaviour which is no longer relevant.

