### PR TITLE
Implement a SessionSubscriber for Firebase Performance

### DIFF
--- a/firebase-perf/firebase-perf.gradle
+++ b/firebase-perf/firebase-perf.gradle
@@ -118,7 +118,7 @@ dependencies {
     api("com.google.firebase:firebase-components:18.0.0")
     api("com.google.firebase:firebase-config:21.5.0")
     api("com.google.firebase:firebase-installations:17.2.0")
-    api("com.google.firebase:firebase-sessions:2.0.7") {
+    api(project(":firebase-sessions")) {
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-common-ktx'
         exclude group: 'com.google.firebase', module: 'firebase-components'

--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfRegistrar.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfRegistrar.java
@@ -32,7 +32,6 @@ import com.google.firebase.platforminfo.LibraryVersionComponent;
 import com.google.firebase.remoteconfig.RemoteConfigComponent;
 import com.google.firebase.sessions.api.FirebaseSessionsDependencies;
 import com.google.firebase.sessions.api.SessionSubscriber;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executor;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfRegistrar.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfRegistrar.java
@@ -30,6 +30,9 @@ import com.google.firebase.perf.injection.components.FirebasePerformanceComponen
 import com.google.firebase.perf.injection.modules.FirebasePerformanceModule;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import com.google.firebase.remoteconfig.RemoteConfigComponent;
+import com.google.firebase.sessions.api.FirebaseSessionsDependencies;
+import com.google.firebase.sessions.api.SessionSubscriber;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -46,6 +49,11 @@ import java.util.concurrent.Executor;
 public class FirebasePerfRegistrar implements ComponentRegistrar {
   private static final String LIBRARY_NAME = "fire-perf";
   private static final String EARLY_LIBRARY_NAME = "fire-perf-early";
+
+  static {
+    // Add Firebase Performance as a dependency of Sessions when this class is loaded into memory.
+    FirebaseSessionsDependencies.addDependency(SessionSubscriber.Name.PERFORMANCE);
+  }
 
   @Override
   @Keep

--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformance.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformance.java
@@ -36,12 +36,15 @@ import com.google.firebase.perf.logging.AndroidLogger;
 import com.google.firebase.perf.logging.ConsoleUrlGenerator;
 import com.google.firebase.perf.metrics.HttpMetric;
 import com.google.firebase.perf.metrics.Trace;
+import com.google.firebase.perf.session.FirebasePerformanceSessionSubscriber;
 import com.google.firebase.perf.session.SessionManager;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.util.Constants;
 import com.google.firebase.perf.util.ImmutableBundle;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.remoteconfig.RemoteConfigComponent;
+import com.google.firebase.sessions.api.FirebaseSessionsDependencies;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.net.URL;
@@ -51,6 +54,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+
 
 /**
  * The Firebase Performance Monitoring API.
@@ -92,7 +96,7 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
   // once during initialization and cache it.
   private final ImmutableBundle mMetadataBundle;
 
-  /** Valid HttpMethods for manual network APIs */
+    /** Valid HttpMethods for manual network APIs */
   @StringDef({
     HttpMethod.GET,
     HttpMethod.PUT,
@@ -136,12 +140,7 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
   // to false if it's been force disabled or it is set to null if neither.
   @Nullable private Boolean mPerformanceCollectionForceEnabledState = null;
 
-  private final FirebaseApp firebaseApp;
-  private final Provider<RemoteConfigComponent> firebaseRemoteConfigProvider;
-  private final FirebaseInstallationsApi firebaseInstallationsApi;
-  private final Provider<TransportFactory> transportFactoryProvider;
-
-  /**
+    /**
    * Constructs the FirebasePerformance class and allows injecting dependencies.
    *
    * <p>TODO(b/172007278): Initialize SDK components in a background thread to avoid cases of cyclic
@@ -166,11 +165,6 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
       ConfigResolver configResolver,
       SessionManager sessionManager) {
 
-    this.firebaseApp = firebaseApp;
-    this.firebaseRemoteConfigProvider = firebaseRemoteConfigProvider;
-    this.firebaseInstallationsApi = firebaseInstallationsApi;
-    this.transportFactoryProvider = transportFactoryProvider;
-
     if (firebaseApp == null) {
       this.mPerformanceCollectionForceEnabledState = false;
       this.configResolver = configResolver;
@@ -191,6 +185,8 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
     sessionManager.setApplicationContext(appContext);
 
     mPerformanceCollectionForceEnabledState = configResolver.getIsPerformanceCollectionEnabled();
+    FirebaseSessionsDependencies.register(new FirebasePerformanceSessionSubscriber(isPerformanceCollectionEnabled()));
+
     if (logger.isLogcatEnabled() && isPerformanceCollectionEnabled()) {
       logger.info(
           String.format(
@@ -281,7 +277,7 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
       return;
     }
 
-    if (configResolver.getIsPerformanceCollectionDeactivated()) {
+    if (Boolean.TRUE.equals(configResolver.getIsPerformanceCollectionDeactivated())) {
       logger.info("Firebase Performance is permanently disabled");
       return;
     }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformance.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformance.java
@@ -44,7 +44,6 @@ import com.google.firebase.perf.util.ImmutableBundle;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.remoteconfig.RemoteConfigComponent;
 import com.google.firebase.sessions.api.FirebaseSessionsDependencies;
-
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.net.URL;
@@ -54,7 +53,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-
 
 /**
  * The Firebase Performance Monitoring API.
@@ -96,7 +94,7 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
   // once during initialization and cache it.
   private final ImmutableBundle mMetadataBundle;
 
-    /** Valid HttpMethods for manual network APIs */
+  /** Valid HttpMethods for manual network APIs */
   @StringDef({
     HttpMethod.GET,
     HttpMethod.PUT,
@@ -140,7 +138,7 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
   // to false if it's been force disabled or it is set to null if neither.
   @Nullable private Boolean mPerformanceCollectionForceEnabledState = null;
 
-    /**
+  /**
    * Constructs the FirebasePerformance class and allows injecting dependencies.
    *
    * <p>TODO(b/172007278): Initialize SDK components in a background thread to avoid cases of cyclic
@@ -185,7 +183,8 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
     sessionManager.setApplicationContext(appContext);
 
     mPerformanceCollectionForceEnabledState = configResolver.getIsPerformanceCollectionEnabled();
-    FirebaseSessionsDependencies.register(new FirebasePerformanceSessionSubscriber(isPerformanceCollectionEnabled()));
+    FirebaseSessionsDependencies.register(
+        new FirebasePerformanceSessionSubscriber(isPerformanceCollectionEnabled()));
 
     if (logger.isLogcatEnabled() && isPerformanceCollectionEnabled()) {
       logger.info(

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
@@ -116,7 +116,7 @@ public class ConfigResolver {
   /** Default API to call for whether performance monitoring is currently silent. */
   public boolean isPerformanceMonitoringEnabled() {
     Boolean isPerformanceCollectionEnabled = getIsPerformanceCollectionEnabled();
-    return (isPerformanceCollectionEnabled == null || isPerformanceCollectionEnabled == true)
+    return (isPerformanceCollectionEnabled == null || isPerformanceCollectionEnabled)
         && getIsServiceCollectionEnabled();
   }
 
@@ -131,7 +131,7 @@ public class ConfigResolver {
     // return developer config.
     // 4. Else, return null. Because Firebase Performance will read highlevel Firebase flag in this
     // case.
-    if (getIsPerformanceCollectionDeactivated()) {
+    if (Boolean.TRUE.equals(getIsPerformanceCollectionDeactivated())) {
       // 1. If developer has deactivated Firebase Performance in Manifest, return false.
       return false;
     }
@@ -186,7 +186,7 @@ public class ConfigResolver {
     // 2. Otherwise, save this configuration in device cache.
 
     // If collection is deactivated, skip the action to save user configuration.
-    if (getIsPerformanceCollectionDeactivated()) {
+    if (Boolean.TRUE.equals(getIsPerformanceCollectionDeactivated())) {
       return;
     }
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
@@ -116,7 +116,7 @@ public class ConfigResolver {
   /** Default API to call for whether performance monitoring is currently silent. */
   public boolean isPerformanceMonitoringEnabled() {
     Boolean isPerformanceCollectionEnabled = getIsPerformanceCollectionEnabled();
-    return (isPerformanceCollectionEnabled == null || isPerformanceCollectionEnabled)
+    return (isPerformanceCollectionEnabled == null || isPerformanceCollectionEnabled == true)
         && getIsServiceCollectionEnabled();
   }
 
@@ -131,7 +131,7 @@ public class ConfigResolver {
     // return developer config.
     // 4. Else, return null. Because Firebase Performance will read highlevel Firebase flag in this
     // case.
-    if (Boolean.TRUE.equals(getIsPerformanceCollectionDeactivated())) {
+    if (getIsPerformanceCollectionDeactivated()) {
       // 1. If developer has deactivated Firebase Performance in Manifest, return false.
       return false;
     }
@@ -186,7 +186,7 @@ public class ConfigResolver {
     // 2. Otherwise, save this configuration in device cache.
 
     // If collection is deactivated, skip the action to save user configuration.
-    if (Boolean.TRUE.equals(getIsPerformanceCollectionDeactivated())) {
+    if (getIsPerformanceCollectionDeactivated()) {
       return;
     }
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/FirebasePerformanceSessionSubscriber.kt
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/FirebasePerformanceSessionSubscriber.kt
@@ -1,0 +1,31 @@
+package com.google.firebase.perf.session
+
+import com.google.firebase.perf.logging.AndroidLogger
+import com.google.firebase.perf.session.gauges.GaugeManager
+import com.google.firebase.perf.v1.ApplicationProcessState
+import com.google.firebase.sessions.api.SessionSubscriber
+import java.util.UUID
+
+class FirebasePerformanceSessionSubscriber(private val dataCollectionEnabled: Boolean) : SessionSubscriber {
+    override val isDataCollectionEnabled: Boolean
+        get() = dataCollectionEnabled
+
+    override val sessionSubscriberName: SessionSubscriber.Name
+        get() = SessionSubscriber.Name.PERFORMANCE
+
+    override fun onSessionChanged(sessionDetails: SessionSubscriber.SessionDetails) {
+        val currentPerfSession = SessionManager.getInstance().perfSession()
+
+        // A [PerfSession] was created before a session was started.
+        if (currentPerfSession.aqsSessionId() == null) {
+            currentPerfSession.setAQSId(sessionDetails)
+            GaugeManager.getInstance().logGaugeMetadata(currentPerfSession.aqsSessionId(), ApplicationProcessState.FOREGROUND)
+            return
+        }
+
+        val updatedSession = PerfSession.createWithId(UUID.randomUUID().toString());
+        updatedSession.setAQSId(sessionDetails)
+        SessionManager.getInstance().updatePerfSession(updatedSession)
+        GaugeManager.getInstance().logGaugeMetadata(updatedSession.aqsSessionId(), ApplicationProcessState.FOREGROUND)
+    }
+}

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/FirebasePerformanceSessionSubscriber.kt
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/FirebasePerformanceSessionSubscriber.kt
@@ -1,31 +1,33 @@
 package com.google.firebase.perf.session
 
-import com.google.firebase.perf.logging.AndroidLogger
 import com.google.firebase.perf.session.gauges.GaugeManager
 import com.google.firebase.perf.v1.ApplicationProcessState
 import com.google.firebase.sessions.api.SessionSubscriber
 import java.util.UUID
 
-class FirebasePerformanceSessionSubscriber(private val dataCollectionEnabled: Boolean) : SessionSubscriber {
-    override val isDataCollectionEnabled: Boolean
-        get() = dataCollectionEnabled
+class FirebasePerformanceSessionSubscriber(private val dataCollectionEnabled: Boolean) :
+  SessionSubscriber {
+  override val isDataCollectionEnabled: Boolean
+    get() = dataCollectionEnabled
 
-    override val sessionSubscriberName: SessionSubscriber.Name
-        get() = SessionSubscriber.Name.PERFORMANCE
+  override val sessionSubscriberName: SessionSubscriber.Name
+    get() = SessionSubscriber.Name.PERFORMANCE
 
-    override fun onSessionChanged(sessionDetails: SessionSubscriber.SessionDetails) {
-        val currentPerfSession = SessionManager.getInstance().perfSession()
+  override fun onSessionChanged(sessionDetails: SessionSubscriber.SessionDetails) {
+    val currentPerfSession = SessionManager.getInstance().perfSession()
 
-        // A [PerfSession] was created before a session was started.
-        if (currentPerfSession.aqsSessionId() == null) {
-            currentPerfSession.setAQSId(sessionDetails)
-            GaugeManager.getInstance().logGaugeMetadata(currentPerfSession.aqsSessionId(), ApplicationProcessState.FOREGROUND)
-            return
-        }
-
-        val updatedSession = PerfSession.createWithId(UUID.randomUUID().toString());
-        updatedSession.setAQSId(sessionDetails)
-        SessionManager.getInstance().updatePerfSession(updatedSession)
-        GaugeManager.getInstance().logGaugeMetadata(updatedSession.aqsSessionId(), ApplicationProcessState.FOREGROUND)
+    // A [PerfSession] was created before a session was started.
+    if (currentPerfSession.aqsSessionId() == null) {
+      currentPerfSession.setAQSId(sessionDetails)
+      GaugeManager.getInstance()
+        .logGaugeMetadata(currentPerfSession.aqsSessionId(), ApplicationProcessState.FOREGROUND)
+      return
     }
+
+    val updatedSession = PerfSession.createWithId(UUID.randomUUID().toString())
+    updatedSession.setAQSId(sessionDetails)
+    SessionManager.getInstance().updatePerfSession(updatedSession)
+    GaugeManager.getInstance()
+      .logGaugeMetadata(updatedSession.aqsSessionId(), ApplicationProcessState.FOREGROUND)
+  }
 }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/FirebasePerformanceSessionSubscriber.kt
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/FirebasePerformanceSessionSubscriber.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.firebase.perf.session
 
 import com.google.firebase.perf.session.gauges.GaugeManager

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/FirebasePerformanceSessionSubscriber.kt
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/FirebasePerformanceSessionSubscriber.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +21,10 @@ import com.google.firebase.perf.v1.ApplicationProcessState
 import com.google.firebase.sessions.api.SessionSubscriber
 import java.util.UUID
 
-class FirebasePerformanceSessionSubscriber(private val dataCollectionEnabled: Boolean) :
+class FirebasePerformanceSessionSubscriber(override val isDataCollectionEnabled: Boolean) :
   SessionSubscriber {
-  override val isDataCollectionEnabled: Boolean
-    get() = dataCollectionEnabled
 
-  override val sessionSubscriberName: SessionSubscriber.Name
-    get() = SessionSubscriber.Name.PERFORMANCE
+  override val sessionSubscriberName: SessionSubscriber.Name = SessionSubscriber.Name.PERFORMANCE
 
   override fun onSessionChanged(sessionDetails: SessionSubscriber.SessionDetails) {
     val currentPerfSession = SessionManager.getInstance().perfSession()

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
@@ -127,8 +127,9 @@ public class PerfSession implements Parcelable {
 
   /** Creates and returns the proto object for PerfSession object. */
   public com.google.firebase.perf.v1.PerfSession build() {
+    // TODO(b/394127311): Switch to using AQS.
     com.google.firebase.perf.v1.PerfSession.Builder sessionMetric =
-        com.google.firebase.perf.v1.PerfSession.newBuilder().setSessionId(aqsSessionId);
+        com.google.firebase.perf.v1.PerfSession.newBuilder().setSessionId(sessionId);
 
     // If gauge collection is enabled, enable gauge collection verbosity.
     if (isGaugeAndEventCollectionEnabled) {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
@@ -67,11 +67,12 @@ public class PerfSession implements Parcelable {
   }
 
   /** Returns the AQS sessionId for the given session. */
+  @Nullable
   public String aqsSessionId() {
     return aqsSessionId;
   }
 
-  /** Returns the AQS sessionId for the given session. */
+  /** Sets the AQS sessionId for the given session. */
   public void setAQSId(SessionSubscriber.SessionDetails aqs) {
     if (aqsSessionId == null) {
       aqsSessionId = aqs.getSessionId();

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
@@ -23,6 +23,8 @@ import com.google.firebase.perf.config.ConfigResolver;
 import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.perf.v1.SessionVerbosity;
+import com.google.firebase.sessions.api.SessionSubscriber;
+
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -31,6 +33,7 @@ public class PerfSession implements Parcelable {
 
   private final String sessionId;
   private final Timer creationTime;
+  @Nullable private String aqsSessionId;
 
   private boolean isGaugeAndEventCollectionEnabled = false;
 
@@ -59,9 +62,21 @@ public class PerfSession implements Parcelable {
     creationTime = in.readParcelable(Timer.class.getClassLoader());
   }
 
-  /** Returns the sessionId of the object. */
+  /** Returns the sessionId of the session. */
   public String sessionId() {
     return sessionId;
+  }
+
+  /** Returns the AQS sessionId for the given session. */
+  public String aqsSessionId() {
+    return aqsSessionId;
+  }
+
+  /** Returns the AQS sessionId for the given session. */
+  public void setAQSId(SessionSubscriber.SessionDetails aqs) {
+    if (aqsSessionId == null) {
+      aqsSessionId = aqs.getSessionId();
+    }
   }
 
   /**

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
@@ -128,7 +128,7 @@ public class PerfSession implements Parcelable {
   /** Creates and returns the proto object for PerfSession object. */
   public com.google.firebase.perf.v1.PerfSession build() {
     com.google.firebase.perf.v1.PerfSession.Builder sessionMetric =
-        com.google.firebase.perf.v1.PerfSession.newBuilder().setSessionId(sessionId);
+        com.google.firebase.perf.v1.PerfSession.newBuilder().setSessionId(aqsSessionId);
 
     // If gauge collection is enabled, enable gauge collection verbosity.
     if (isGaugeAndEventCollectionEnabled) {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
@@ -24,7 +24,6 @@ import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.perf.v1.SessionVerbosity;
 import com.google.firebase.sessions.api.SessionSubscriber;
-
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
@@ -19,7 +19,6 @@ import android.content.Context;
 import androidx.annotation.Keep;
 import androidx.annotation.VisibleForTesting;
 import com.google.firebase.perf.application.AppStateMonitor;
-import com.google.firebase.perf.application.AppStateUpdateHandler;
 import com.google.firebase.perf.session.gauges.GaugeManager;
 import com.google.firebase.perf.v1.ApplicationProcessState;
 import com.google.firebase.perf.v1.GaugeMetadata;
@@ -27,13 +26,14 @@ import com.google.firebase.perf.v1.GaugeMetric;
 import java.lang.ref.WeakReference;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Future;
 
 /** Session manager to generate sessionIDs and broadcast to the application. */
 @Keep // Needed because of b/117526359.
-public class SessionManager extends AppStateUpdateHandler {
+public class SessionManager {
 
   @SuppressLint("StaticFieldLeak")
   private static final SessionManager instance = new SessionManager();
@@ -69,7 +69,6 @@ public class SessionManager extends AppStateUpdateHandler {
     this.gaugeManager = gaugeManager;
     this.perfSession = perfSession;
     this.appStateMonitor = appStateMonitor;
-    registerForAppState();
   }
 
   /**
@@ -78,34 +77,6 @@ public class SessionManager extends AppStateUpdateHandler {
    */
   public void setApplicationContext(final Context appContext) {
     gaugeManager.initializeGaugeMetadataManager(appContext);
-  }
-
-  @Override
-  public void onUpdateAppState(ApplicationProcessState newAppState) {
-    super.onUpdateAppState(newAppState);
-
-    if (appStateMonitor.isColdStart()) {
-      // We want the Session to remain unchanged if this is a cold start of the app since we already
-      // update the PerfSession in FirebasePerfProvider#onAttachInfo().
-      return;
-    }
-
-    if (newAppState == ApplicationProcessState.FOREGROUND) {
-      // A new foregrounding of app will force a new sessionID generation.
-      PerfSession session = PerfSession.createWithId(UUID.randomUUID().toString());
-      updatePerfSession(session);
-    } else {
-      // If the session is running for too long, generate a new session and collect gauges as
-      // necessary.
-      if (perfSession.isSessionRunningTooLong()) {
-        PerfSession session = PerfSession.createWithId(UUID.randomUUID().toString());
-        updatePerfSession(session);
-      } else {
-        // For any other state change of the application, modify gauge collection state as
-        // necessary.
-        startOrStopCollectingGauges(newAppState);
-      }
-    }
   }
 
   /**
@@ -129,7 +100,7 @@ public class SessionManager extends AppStateUpdateHandler {
    */
   public void updatePerfSession(PerfSession perfSession) {
     // Do not update the perf session if it is the exact same sessionId.
-    if (perfSession.sessionId() == this.perfSession.sessionId()) {
+    if (Objects.equals(perfSession.sessionId(), this.perfSession.sessionId())) {
       return;
     }
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
@@ -79,14 +79,7 @@ public class SessionManager extends AppStateUpdateHandler {
    * (currently that is before onResume finishes) to ensure gauge collection starts on time.
    */
   public void setApplicationContext(final Context appContext) {
-    // TODO(b/258263016): Migrate to go/firebase-android-executors
-    @SuppressLint("ThreadPoolCreation")
-    ExecutorService executorService = Executors.newSingleThreadExecutor();
-    syncInitFuture =
-        executorService.submit(
-            () -> {
-              gaugeManager.initializeGaugeMetadataManager(appContext);
-            });
+    gaugeManager.initializeGaugeMetadataManager(appContext);
   }
 
   @Override

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
@@ -29,7 +29,6 @@ import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.Future;
 
 /** Session manager to generate sessionIDs and broadcast to the application. */
 @Keep // Needed because of b/117526359.
@@ -43,7 +42,6 @@ public class SessionManager {
   private final Set<WeakReference<SessionAwareObject>> clients = new HashSet<>();
 
   private PerfSession perfSession;
-  private Future syncInitFuture;
 
   /** Returns the singleton instance of SessionManager. */
   public static SessionManager getInstance() {
@@ -168,10 +166,5 @@ public class SessionManager {
   @VisibleForTesting
   public void setPerfSession(PerfSession perfSession) {
     this.perfSession = perfSession;
-  }
-
-  @VisibleForTesting
-  public Future getSyncInitFuture() {
-    return this.syncInitFuture;
   }
 }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
@@ -29,8 +29,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 /** Session manager to generate sessionIDs and broadcast to the application. */

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeManager.java
@@ -136,6 +136,7 @@ public class GaugeManager {
     final String sessionIdForScheduledTask = sessionId;
     final ApplicationProcessState applicationProcessStateForScheduledTask = applicationProcessState;
 
+    // TODO(b/394127311): Switch to using AQS.
     try {
       gaugeManagerDataCollectionJob =
           gaugeManagerExecutor

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeManager.java
@@ -205,6 +205,7 @@ public class GaugeManager {
       gaugeManagerDataCollectionJob.cancel(false);
     }
 
+    // TODO(b/394127311): Switch to using AQS.
     // Flush any data that was collected for this session one last time.
     @SuppressWarnings("FutureReturnValueIgnored")
     ScheduledFuture unusedFuture =

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeManager.java
@@ -242,6 +242,7 @@ public class GaugeManager {
     }
 
     // Adding Session ID info.
+    // TODO(b/394127311): Switch to using AQS.
     gaugeMetricBuilder.setSessionId(sessionId);
 
     transportManager.log(gaugeMetricBuilder.build(), appState);
@@ -250,17 +251,16 @@ public class GaugeManager {
   /**
    * Log the Gauge Metadata information to the transport.
    *
-   * @param sessionId The {@link PerfSession#sessionId()} to which the collected Gauge Metrics
+   * @param aqsSessionId The {@link PerfSession#aqsSessionId()} ()} to which the collected Gauge Metrics
    *     should be associated with.
    * @param appState The {@link ApplicationProcessState} for which these gauges are collected.
    * @return true if GaugeMetadata was logged, false otherwise.
    */
-  public boolean logGaugeMetadata(String sessionId, ApplicationProcessState appState) {
-    // TODO(b/394127311): Re-introduce logging of metadata for AQS.
+  public boolean logGaugeMetadata(String aqsSessionId, ApplicationProcessState appState) {
     if (gaugeMetadataManager != null) {
       GaugeMetric gaugeMetric =
           GaugeMetric.newBuilder()
-              .setSessionId(sessionId)
+              .setSessionId(aqsSessionId)
               .setGaugeMetadata(getGaugeMetadata())
               .build();
       transportManager.log(gaugeMetric, appState);

--- a/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
@@ -354,6 +354,7 @@ public class TransportManager implements AppStateCallback {
    * {@link #isAllowedToDispatch(PerfMetric)}).
    */
   public void log(final GaugeMetric gaugeMetric, final ApplicationProcessState appState) {
+    // TODO(b/394127311): This *might* potentially be the right place to get AQS.
     executorService.execute(
         () -> syncLog(PerfMetric.newBuilder().setGaugeMetric(gaugeMetric), appState));
   }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/session/SessionManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/session/SessionManagerTest.java
@@ -16,9 +16,6 @@ package com.google.firebase.perf.session;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -40,7 +37,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.AdditionalMatchers;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -86,101 +82,12 @@ public class SessionManagerTest extends FirebasePerformanceTestBase {
     inOrder.verify(mockGaugeManager).initializeGaugeMetadataManager(any());
   }
 
-  @Test
-  public void testOnUpdateAppStateDoesNothingDuringAppStart() {
-    String oldSessionId = SessionManager.getInstance().perfSession().sessionId();
-
-    assertThat(oldSessionId).isNotNull();
-    assertThat(oldSessionId).isEqualTo(SessionManager.getInstance().perfSession().sessionId());
-
-    AppStateMonitor.getInstance().setIsColdStart(true);
-
-    SessionManager.getInstance().onUpdateAppState(ApplicationProcessState.FOREGROUND);
-    assertThat(oldSessionId).isEqualTo(SessionManager.getInstance().perfSession().sessionId());
-  }
-
-  @Test
-  public void testOnUpdateAppStateGeneratesNewSessionIdOnForegroundState() {
-    String oldSessionId = SessionManager.getInstance().perfSession().sessionId();
-
-    assertThat(oldSessionId).isNotNull();
-    assertThat(oldSessionId).isEqualTo(SessionManager.getInstance().perfSession().sessionId());
-
-    SessionManager.getInstance().onUpdateAppState(ApplicationProcessState.FOREGROUND);
-    assertThat(oldSessionId).isNotEqualTo(SessionManager.getInstance().perfSession().sessionId());
-  }
-
-  @Test
-  public void testOnUpdateAppStateDoesntGenerateNewSessionIdOnBackgroundState() {
-    String oldSessionId = SessionManager.getInstance().perfSession().sessionId();
-
-    assertThat(oldSessionId).isNotNull();
-    assertThat(oldSessionId).isEqualTo(SessionManager.getInstance().perfSession().sessionId());
-
-    SessionManager.getInstance().onUpdateAppState(ApplicationProcessState.BACKGROUND);
-    assertThat(oldSessionId).isEqualTo(SessionManager.getInstance().perfSession().sessionId());
-  }
-
-  @Test
-  public void testOnUpdateAppStateGeneratesNewSessionIdOnBackgroundStateIfPerfSessionExpires() {
-    when(mockPerfSession.isSessionRunningTooLong()).thenReturn(true);
-    SessionManager testSessionManager =
-        new SessionManager(mockGaugeManager, mockPerfSession, mockAppStateMonitor);
-    String oldSessionId = testSessionManager.perfSession().sessionId();
-
-    assertThat(oldSessionId).isNotNull();
-    assertThat(oldSessionId).isEqualTo(testSessionManager.perfSession().sessionId());
-
-    testSessionManager.onUpdateAppState(ApplicationProcessState.BACKGROUND);
-    assertThat(oldSessionId).isNotEqualTo(testSessionManager.perfSession().sessionId());
-  }
-
-  @Test
-  public void
-      testOnUpdateAppStateDoesntMakeGaugeManagerLogGaugeMetadataOnForegroundStateIfSessionIsNonVerbose() {
-    forceNonVerboseSession();
-
-    SessionManager testSessionManager =
-        new SessionManager(mockGaugeManager, mockPerfSession, mockAppStateMonitor);
-    testSessionManager.onUpdateAppState(ApplicationProcessState.FOREGROUND);
-
-    verify(mockGaugeManager, never())
-        .logGaugeMetadata(
-            anyString(), nullable(com.google.firebase.perf.v1.ApplicationProcessState.class));
-  }
-
-  @Test
-  public void
-      testOnUpdateAppStateDoesntMakeGaugeManagerLogGaugeMetadataOnBackgroundStateEvenIfSessionIsVerbose() {
-    forceVerboseSession();
-
-    SessionManager testSessionManager =
-        new SessionManager(mockGaugeManager, mockPerfSession, mockAppStateMonitor);
-    testSessionManager.onUpdateAppState(ApplicationProcessState.BACKGROUND);
-
-    verify(mockGaugeManager, never())
-        .logGaugeMetadata(
-            anyString(), nullable(com.google.firebase.perf.v1.ApplicationProcessState.class));
-  }
-
-  @Test
-  public void testOnUpdateAppStateMakesGaugeManagerStartCollectingGaugesIfSessionIsVerbose() {
-    forceVerboseSession();
-
-    SessionManager testSessionManager =
-        new SessionManager(mockGaugeManager, mockPerfSession, mockAppStateMonitor);
-    testSessionManager.onUpdateAppState(ApplicationProcessState.FOREGROUND);
-
-    verify(mockGaugeManager)
-        .startCollectingGauges(AdditionalMatchers.not(eq(mockPerfSession)), any());
-  }
-
   // LogGaugeData on new perf session when Verbose
   // NotLogGaugeData on new perf session when not Verbose
   // Mark Session as expired after time limit.
 
   @Test
-  public void testOnUpdateAppStateMakesGaugeManagerStopCollectingGaugesIfSessionIsNonVerbose() {
+  public void testUpdatePerfSessionMakesGaugeManagerStopCollectingGaugesIfSessionIsNonVerbose() {
     forceNonVerboseSession();
 
     SessionManager testSessionManager =
@@ -191,7 +98,7 @@ public class SessionManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void testOnUpdateAppStateMakesGaugeManagerStopCollectingGaugesWhenSessionsDisabled() {
+  public void testUpdatePerfSessionMakesGaugeManagerStopCollectingGaugesWhenSessionsDisabled() {
     forceSessionsFeatureDisabled();
 
     SessionManager testSessionManager =
@@ -221,22 +128,25 @@ public class SessionManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void testPerfSessionExpiredMakesGaugeManagerStopsCollectingGaugesIfSessionIsVerbose() {
-    forceVerboseSession();
+  public void testUpdatePerfSessionStartsCollectingGaugesIfSessionIsVerbose() {
     Timer mockTimer = mock(Timer.class);
     when(mockClock.getTime()).thenReturn(mockTimer);
+    when(mockAppStateMonitor.getAppState()).thenReturn(ApplicationProcessState.FOREGROUND);
 
-    PerfSession session = new PerfSession("sessionId", mockClock);
+    PerfSession previousSession = new PerfSession("previousSession", mockClock);
+    previousSession.setGaugeAndEventCollectionEnabled(false);
+
+    PerfSession newSession = new PerfSession("newSession", mockClock);
+    newSession.setGaugeAndEventCollectionEnabled(true);
+
     SessionManager testSessionManager =
-        new SessionManager(mockGaugeManager, session, mockAppStateMonitor);
+        new SessionManager(mockGaugeManager, previousSession, mockAppStateMonitor);
+    testSessionManager.updatePerfSession(newSession);
+    testSessionManager.setApplicationContext(mockApplicationContext);
 
-    assertThat(session.isSessionRunningTooLong()).isFalse();
-
-    when(mockTimer.getDurationMicros())
-        .thenReturn(TimeUnit.HOURS.toMicros(5)); // Default Max Session Length is 4 hours
-
-    assertThat(session.isSessionRunningTooLong()).isTrue();
-    verify(mockGaugeManager, times(0)).logGaugeMetadata(any(), any());
+    verify(mockGaugeManager, times(1)).initializeGaugeMetadataManager(mockApplicationContext);
+    verify(mockGaugeManager, times(1))
+        .startCollectingGauges(newSession, ApplicationProcessState.FOREGROUND);
   }
 
   @Test

--- a/firebase-perf/src/test/java/com/google/firebase/perf/session/SessionManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/session/SessionManagerTest.java
@@ -78,7 +78,6 @@ public class SessionManagerTest extends FirebasePerformanceTestBase {
         new SessionManager(mockGaugeManager, mockPerfSession, mockAppStateMonitor);
     testSessionManager.setApplicationContext(mockApplicationContext);
 
-    testSessionManager.getSyncInitFuture().get();
     inOrder.verify(mockGaugeManager).initializeGaugeMetadataManager(any());
   }
 

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/api/FirebaseSessionsDependencies.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/api/FirebaseSessionsDependencies.kt
@@ -40,19 +40,6 @@ object FirebaseSessionsDependencies {
    */
   @JvmStatic
   fun addDependency(subscriberName: SessionSubscriber.Name) {
-    if (subscriberName == SessionSubscriber.Name.PERFORMANCE) {
-      throw IllegalArgumentException(
-        """
-          Incompatible versions of Firebase Perf and Firebase Sessions.
-          A safe combination would be:
-            firebase-sessions:1.1.0
-            firebase-crashlytics:18.5.0
-            firebase-perf:20.5.0
-          For more information contact Firebase Support.
-        """
-          .trimIndent()
-      )
-    }
     if (dependencies.containsKey(subscriberName)) {
       Log.d(TAG, "Dependency $subscriberName already added.")
       return


### PR DESCRIPTION
This is a follow up for: https://github.com/firebase/firebase-android-sdk/pull/6678

This PR doesn't change the use of session ID to AQS - except in GaugeMetadata. I've added TODOs to identify the missing locations.