### PR TITLE
Fix deprecated message in KeyValueBuilder to render properly

### DIFF
--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/KeyValueBuilder.kt
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/KeyValueBuilder.kt
@@ -23,7 +23,7 @@ private constructor(
   private val builder: CustomKeysAndValues.Builder,
 ) {
   @Deprecated(
-    "Do not construct this directly. Use `setCustomKeys` instead. To be removed in the next major release."
+    "Do not construct this directly. Use [setCustomKeys] instead. To be removed in the next major release."
   )
   constructor(crashlytics: FirebaseCrashlytics) : this(crashlytics, CustomKeysAndValues.Builder())
 


### PR DESCRIPTION
Fix deprecated message in KeyValueBuilder to render properly. The old syntax was showing the backtick marks on https://firebase.google.com/docs/reference/kotlin/com/google/firebase/crashlytics/KeyValueBuilder#KeyValueBuilder(com.google.firebase.crashlytics.FirebaseCrashlytics). See http://b/382483629.