### PR TITLE
Make token count details fields non-nullable

### DIFF
--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/CountTokensResponse.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/CountTokensResponse.kt
@@ -36,7 +36,7 @@ import kotlinx.serialization.Serializable
 public class CountTokensResponse(
   public val totalTokens: Int,
   public val totalBillableCharacters: Int? = null,
-  public val promptTokensDetails: List<ModalityTokenCount>? = null,
+  public val promptTokensDetails: List<ModalityTokenCount> = emptyList(),
 ) {
   public operator fun component1(): Int = totalTokens
 
@@ -55,7 +55,7 @@ public class CountTokensResponse(
       return CountTokensResponse(
         totalTokens,
         totalBillableCharacters ?: 0,
-        promptTokensDetails?.map { it.toPublic() }
+        promptTokensDetails?.map { it.toPublic() } ?: emptyList()
       )
     }
   }

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/UsageMetadata.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/UsageMetadata.kt
@@ -33,8 +33,8 @@ public class UsageMetadata(
   public val promptTokenCount: Int,
   public val candidatesTokenCount: Int?,
   public val totalTokenCount: Int,
-  public val promptTokensDetails: List<ModalityTokenCount>?,
-  public val candidatesTokensDetails: List<ModalityTokenCount>?,
+  public val promptTokensDetails: List<ModalityTokenCount>,
+  public val candidatesTokensDetails: List<ModalityTokenCount>,
 ) {
 
   @Serializable
@@ -51,8 +51,8 @@ public class UsageMetadata(
         promptTokenCount ?: 0,
         candidatesTokenCount ?: 0,
         totalTokenCount ?: 0,
-        promptTokensDetails = promptTokensDetails?.map { it.toPublic() },
-        candidatesTokensDetails = candidatesTokensDetails?.map { it.toPublic() }
+        promptTokensDetails = promptTokensDetails?.map { it.toPublic() } ?: emptyList(),
+        candidatesTokensDetails = candidatesTokensDetails?.map { it.toPublic() } ?: emptyList()
       )
   }
 }

--- a/firebase-vertexai/src/test/java/com/google/firebase/vertexai/UnarySnapshotTests.kt
+++ b/firebase-vertexai/src/test/java/com/google/firebase/vertexai/UnarySnapshotTests.kt
@@ -289,6 +289,7 @@ internal class UnarySnapshotTests {
         response.candidates.first().finishReason shouldBe FinishReason.STOP
         response.usageMetadata shouldNotBe null
         response.usageMetadata?.totalTokenCount shouldBe 363
+        response.usageMetadata?.promptTokensDetails?.isEmpty() shouldBe true
       }
     }
 
@@ -478,6 +479,7 @@ internal class UnarySnapshotTests {
 
         response.totalTokens shouldBe 6
         response.totalBillableCharacters shouldBe 16
+        response.promptTokensDetails.isEmpty() shouldBe true
       }
     }
 


### PR DESCRIPTION
If missing, they'll default to empty.