### PR TITLE
Make AQS resilient to background init in multi-process apps

### DIFF
--- a/firebase-sessions/CHANGELOG.md
+++ b/firebase-sessions/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* [fixed] Make AQS resilient to background init in multi-process apps.
 
 # 2.0.7
 * [fixed] Removed extraneous logs that risk leaking internal identifiers.


### PR DESCRIPTION
Make AQS resilient to background init in multi-process apps. This deals with a case where a customer manually initializes Firebase in a background thread in a multi-process app. See #6599. There is a race condition and it becomes possible for AQS to access the `FirebaseApp` instance before Firebase has finished initializing in that process.

This just prevents the crash. A better solution would be to use Dagger for proper dependency injection instead of relying on the Firebase Components. See https://firebase.github.io/firebase-android-sdk/best_practices/dependency_injection.