### PR TITLE
Add missing optIn declarations to reduce compilation noise

### DIFF
--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/GenerativeModel.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/GenerativeModel.kt
@@ -40,6 +40,7 @@ import com.google.firebase.vertexai.type.content
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
+import kotlinx.serialization.ExperimentalSerializationApi
 
 /**
  * Represents a multimodal model (like Gemini), capable of generating content based on various input
@@ -199,6 +200,7 @@ internal constructor(
     return countTokens(content { image(prompt) })
   }
 
+  @OptIn(ExperimentalSerializationApi::class)
   private fun constructRequest(vararg prompt: Content) =
     GenerateContentRequest(
       modelName,

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/common/Request.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/common/Request.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+@file:OptIn(ExperimentalSerializationApi::class)
 package com.google.firebase.vertexai.common
 
 import com.google.firebase.vertexai.common.util.fullModelName
@@ -24,6 +24,7 @@ import com.google.firebase.vertexai.type.PublicPreviewAPI
 import com.google.firebase.vertexai.type.SafetySetting
 import com.google.firebase.vertexai.type.Tool
 import com.google.firebase.vertexai.type.ToolConfig
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -49,14 +50,6 @@ internal data class CountTokensRequest(
   @SerialName("system_instruction") val systemInstruction: Content.Internal? = null,
 ) : Request {
   companion object {
-    fun forGenAI(generateContentRequest: GenerateContentRequest) =
-      CountTokensRequest(
-        generateContentRequest =
-          generateContentRequest.model?.let {
-            generateContentRequest.copy(model = fullModelName(it))
-          }
-            ?: generateContentRequest
-      )
 
     fun forVertexAI(generateContentRequest: GenerateContentRequest) =
       CountTokensRequest(

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/Candidate.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/Candidate.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalSerializationApi::class)
+
 package com.google.firebase.vertexai.type
 
 import com.google.firebase.vertexai.common.util.FirstOrdinalSerializer

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/Content.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/Content.kt
@@ -80,6 +80,7 @@ constructor(public val role: String? = "user", public val parts: List<Part>) {
     public fun build(): Content = Content(role, parts)
   }
 
+  @OptIn(ExperimentalSerializationApi::class)
   internal fun toInternal() = Internal(this.role ?: "user", this.parts.map { it.toInternal() })
 
   @ExperimentalSerializationApi

--- a/firebase-vertexai/src/test/java/com/google/firebase/vertexai/GenerativeModelTesting.kt
+++ b/firebase-vertexai/src/test/java/com/google/firebase/vertexai/GenerativeModelTesting.kt
@@ -40,6 +40,7 @@ import io.ktor.http.content.TextContent
 import io.ktor.http.headersOf
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.encodeToString
 import org.junit.Test
 
@@ -127,6 +128,7 @@ internal class GenerativeModelTesting {
     exception.message shouldContain "location"
   }
 
+  @OptIn(ExperimentalSerializationApi::class)
   private fun generateContentResponseAsJsonString(text: String): String {
     return JSON.encodeToString(
       GenerateContentResponse.Internal(

--- a/firebase-vertexai/src/test/java/com/google/firebase/vertexai/common/APIControllerTests.kt
+++ b/firebase-vertexai/src/test/java/com/google/firebase/vertexai/common/APIControllerTests.kt
@@ -46,6 +46,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonObject
 import org.junit.Test
@@ -84,6 +85,7 @@ internal class APIControllerTests {
     }
 }
 
+@OptIn(ExperimentalSerializationApi::class)
 internal class RequestFormatTests {
   @Test
   fun `using default endpoint`() = doBlocking {

--- a/firebase-vertexai/src/test/java/com/google/firebase/vertexai/common/StreamingSnapshotTests.kt
+++ b/firebase-vertexai/src/test/java/com/google/firebase/vertexai/common/StreamingSnapshotTests.kt
@@ -30,8 +30,10 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.ExperimentalSerializationApi
 import org.junit.Test
 
+@OptIn(ExperimentalSerializationApi::class)
 internal class StreamingSnapshotTests {
   private val testTimeout = 5.seconds
 


### PR DESCRIPTION
Part of the serialization API we use requires optIn, and without the correct declarations we get warnings printed when compiling the code.