### PR TITLE
Bump well known types

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* [changed] Updated `protolite-well-known-types` dependency to `18.0.1`. [#6716]
 
 
 # 25.1.2

--- a/firebase-inappmessaging-display/CHANGELOG.md
+++ b/firebase-inappmessaging-display/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* [changed] Updated `protolite-well-known-types` dependency to `18.0.1`. [#6716]
 
 
 # 21.0.1

--- a/firebase-inappmessaging/CHANGELOG.md
+++ b/firebase-inappmessaging/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* [changed] Updated `protolite-well-known-types` dependency to `18.0.1`. [#6716]
 
 
 # 21.0.1

--- a/firebase-perf/CHANGELOG.md
+++ b/firebase-perf/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* [changed] Updated `protolite-well-known-types` dependency to `18.0.1`. [#6716]
 
 
 # 21.0.4

--- a/firebase-perf/firebase-perf.gradle
+++ b/firebase-perf/firebase-perf.gradle
@@ -111,7 +111,7 @@ dependencies {
     implementation libs.dagger.dagger
     api 'com.google.firebase:firebase-annotations:16.2.0'
     api 'com.google.firebase:firebase-installations-interop:17.1.0'
-    api 'com.google.firebase:protolite-well-known-types:18.0.0'
+    api project(":protolite-well-known-types")
     implementation libs.okhttp
     api("com.google.firebase:firebase-common:21.0.0")
     api("com.google.firebase:firebase-common-ktx:21.0.0")

--- a/protolite-well-known-types/CHANGELOG.md
+++ b/protolite-well-known-types/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Unreleased
-
+* [changed] Updated protobuf dependency to `3.25.5` to fix [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8).
 

--- a/protolite-well-known-types/README.md
+++ b/protolite-well-known-types/README.md
@@ -73,7 +73,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.firebase:protolite-well-known-types:18.0.0'
+    implementation 'com.google.firebase:protolite-well-known-types:18.0.1'
     implementation "io.grpc:grpc-stub:$grpcVersion"
 
     // optionally override grpc's protobuf-lite runtime

--- a/protolite-well-known-types/gradle.properties
+++ b/protolite-well-known-types/gradle.properties
@@ -1,5 +1,5 @@
 # IMPORTANT (b/285892320) Keep version and latestReleasedVersion in sync 
 # unless you are releasing a new version of the library to prevent issues 
 # with transitive dependencies.
-version=18.0.0
+version=18.0.1
 latestReleasedVersion=18.0.0

--- a/protolite-well-known-types/protolite-well-known-types.gradle
+++ b/protolite-well-known-types/protolite-well-known-types.gradle
@@ -26,7 +26,7 @@ firebaseLibrary {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.21.11"
+        artifact = "com.google.protobuf:protoc:3.25.5"
     }
     generateProtoTasks {
         all().each { task ->
@@ -68,5 +68,5 @@ dependencies {
         exclude group: "com.google.protobuf", module: "protobuf-java"
     }
 
-    implementation "com.google.protobuf:protobuf-javalite:3.21.11"
+    implementation "com.google.protobuf:protobuf-javalite:3.25.5"
 }

--- a/protolite-well-known-types/protolite-well-known-types.gradle
+++ b/protolite-well-known-types/protolite-well-known-types.gradle
@@ -26,7 +26,7 @@ firebaseLibrary {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.25.5"
+        artifact = libs.protoc.get().toString()
     }
     generateProtoTasks {
         all().each { task ->
@@ -41,6 +41,7 @@ protobuf {
         }
     }
 }
+
 android {
     namespace "firebase.com.protolitewrapper"
     compileSdkVersion project.compileSdkVersion
@@ -64,9 +65,9 @@ android {
 
 
 dependencies {
-    protobuf("com.google.api.grpc:proto-google-common-protos:1.18.0"){
+    protobuf(libs.proto.google.common.protos){
         exclude group: "com.google.protobuf", module: "protobuf-java"
     }
 
-    implementation "com.google.protobuf:protobuf-javalite:3.25.5"
+    implementation libs.protobuf.java.lite
 }


### PR DESCRIPTION
Per [b/398840288](https://b.corp.google.com/issues/398840288),

This bumps `protolite-well-known-types` to properly utilize `3.25.5`. It seems as though this was an oversight in #6343, but since gradle uses the highest version when resolving dependency conflicts (and all the existing libraries already use `3.25.5`), this isn't a major issue. This is only really an issue if someone is using `protolite-well-known-types` in isolation (which isn't really a use-case we're shipping for). But the main reason for fixing this is that it causes a bit of confusion when trying to track dependency issues (see issue #6674 for an example of this).

Fixes #6674 