### PR TITLE
Update CHANGELOG for Crashlytics and NDK

### DIFF
--- a/firebase-crashlytics-ndk/CHANGELOG.md
+++ b/firebase-crashlytics-ndk/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+* [changed] Updated `firebase-crashlytics` dependency to v19.4.1
 
 # 19.3.0
 * [changed] Updated `firebase-crashlytics` dependency to v19.3.0

--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+* [changed] Updated `firebase-sessions` dependency to v2.0.9
 
 # 19.4.0
 * [feature] Added an overload for `recordException` that allows logging additional custom


### PR DESCRIPTION
There were changes to the Sessions SDK but not Crashlytics or Crashlytics NDK