### PR TITLE
Add custom signal limits link and fix Javadoc List Formatting

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -656,14 +656,16 @@ public class FirebaseRemoteConfig {
    * Asynchronously changes the custom signals for this {@link FirebaseRemoteConfig} instance.
    *
    * <p>Custom signals are subject to limits on the size of key/value pairs and the total
-   * number of signals. Any calls that exceed these limits will be discarded.
+   * number of signals. Any calls that exceed these limits will be discarded.  See the <a
+   * href="https://firebase.google.com/docs/remote-config/parameters?template_type=client#custom-signal-limits">Custom
+   * Signal Limits</a> to check them.
    *
    * @param customSignals The custom signals to set for this instance.
-   * <ol>
+   * <ul>
    *   <li>New keys will add new key-value pairs in the custom signals.
    *   <li>Existing keys with new values will update the corresponding signals.
    *   <li>Setting a key's value to {@code null} will remove the associated signal.
-   * </ol>
+   * </ul>
    */
   // TODO(b/385028620): Add link to documentation about custom signal limits.
   @NonNull


### PR DESCRIPTION
Add link to documentation about custom signal limits ([b/385028620](https://buganizer.corp.google.com/issues/385028620)) and Update setCustomSignals Javadoc List Formatting ([b/390054823](https://buganizer.corp.google.com/issues/390054823))
