### PR TITLE
Added a new API to allow a custom debug secret 

### DIFF
--- a/appcheck/firebase-appcheck-debug/src/main/java/com/google/firebase/appcheck/debug/DebugAppCheckProviderFactory.java
+++ b/appcheck/firebase-appcheck-debug/src/main/java/com/google/firebase/appcheck/debug/DebugAppCheckProviderFactory.java
@@ -27,6 +27,7 @@ import com.google.firebase.appcheck.debug.internal.DebugAppCheckProvider;
 public class DebugAppCheckProviderFactory implements AppCheckProviderFactory {
 
   private static final DebugAppCheckProviderFactory instance = new DebugAppCheckProviderFactory();
+  private static String _debugSecret;
 
   private DebugAppCheckProviderFactory() {}
 
@@ -40,11 +41,20 @@ public class DebugAppCheckProviderFactory implements AppCheckProviderFactory {
   public static DebugAppCheckProviderFactory getInstance() {
     return instance;
   }
+  @NonNull
+  public static DebugAppCheckProviderFactory getInstance(String debugSecret) {
+    _debugSecret = debugSecret;
+    return instance;
+  }
 
   @NonNull
   @Override
   @SuppressWarnings("FirebaseUseExplicitDependencies")
   public AppCheckProvider create(@NonNull FirebaseApp firebaseApp) {
-    return firebaseApp.get(DebugAppCheckProvider.class);
+    DebugAppCheckProvider debugAppCheckProvider = firebaseApp.get(DebugAppCheckProvider.class);
+    if (_debugSecret != null && !_debugSecret.isEmpty()) {
+      debugAppCheckProvider.setDebugSecret(_debugSecret);
+    }
+    return debugAppCheckProvider;
   }
 }

--- a/appcheck/firebase-appcheck-debug/src/main/java/com/google/firebase/appcheck/debug/internal/DebugAppCheckProvider.java
+++ b/appcheck/firebase-appcheck-debug/src/main/java/com/google/firebase/appcheck/debug/internal/DebugAppCheckProvider.java
@@ -85,6 +85,16 @@ public class DebugAppCheckProvider implements AppCheckProvider {
 
   @VisibleForTesting
   @NonNull
+  void setDebugSecret(@NonNull String debugSecret) {
+
+    StorageHelper storageHelper =
+            new StorageHelper(
+                    firebaseApp.getApplicationContext(), firebaseApp.getPersistenceKey());
+    storageHelper.saveDebugSecret(debugSecret);
+  }
+
+  @VisibleForTesting
+  @NonNull
   static Task<String> determineDebugSecret(
       @NonNull FirebaseApp firebaseApp, @NonNull Executor executor) {
     TaskCompletionSource<String> taskCompletionSource = new TaskCompletionSource<>();


### PR DESCRIPTION
Added the ability to set a static custom debug secret, enabling developers to manage their debug secret tokens.