### PR TITLE
Store registered context for sync task unregistrations

### DIFF
--- a/firebase-messaging/CHANGELOG.md
+++ b/firebase-messaging/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+* [changed] Bug fix in SyncTask to always unregister the receiver on the same
+  context on which it was registered.
 
 
 # 24.1.0

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/SyncTask.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/SyncTask.java
@@ -161,6 +161,7 @@ class SyncTask implements Runnable {
   static class ConnectivityChangeReceiver extends BroadcastReceiver {
 
     @Nullable private SyncTask task; // task is set to null after it has been fired.
+    @Nullable private Context receiverContext;
 
     public ConnectivityChangeReceiver(SyncTask task) {
       this.task = task;
@@ -171,7 +172,10 @@ class SyncTask implements Runnable {
         Log.d(TAG, "Connectivity change received registered");
       }
       IntentFilter intentFilter = new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION);
-      task.getContext().registerReceiver(this, intentFilter);
+      if (task != null) {
+        receiverContext = task.getContext();
+        receiverContext.registerReceiver(this, intentFilter);
+      }
     }
 
     @Override
@@ -191,7 +195,9 @@ class SyncTask implements Runnable {
         Log.d(TAG, "Connectivity changed. Starting background sync.");
       }
       task.firebaseMessaging.enqueueTaskWithDelaySeconds(task, 0);
-      task.getContext().unregisterReceiver(this);
+      if (receiverContext != null) {
+        receiverContext.unregisterReceiver(this);
+      }
       task = null;
     }
   }


### PR DESCRIPTION
For issue #6558, this is an attempt at fixing the IllegalArgumentException by ensuring that the context we use for registering the SyncTask is the same context we use to unregister the task. Race conditions dont seem like a culprit here since unregister is only triggered by the Receiver itself, which should be only executed synchronously on the main thread.

New PR needed to fix CLA issue