### PR TITLE
Remove code style from deprecated message

### DIFF
--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/KeyValueBuilder.kt
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/KeyValueBuilder.kt
@@ -23,7 +23,7 @@ private constructor(
   private val builder: CustomKeysAndValues.Builder,
 ) {
   @Deprecated(
-    "Do not construct this directly. Use [setCustomKeys] instead. To be removed in the next major release."
+    "Do not construct this directly. Use setCustomKeys instead. To be removed in the next major release."
   )
   constructor(crashlytics: FirebaseCrashlytics) : this(crashlytics, CustomKeysAndValues.Builder())
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/KeyValueBuilder.kt
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/KeyValueBuilder.kt
@@ -23,7 +23,7 @@ private constructor(
   private val builder: CustomKeysAndValues.Builder,
 ) {
   @Deprecated(
-    "Do not construct this directly. Use setCustomKeys instead. To be removed in the next major release."
+    "Do not construct this directly. Use `setCustomKeys` instead. To be removed in the next major release."
   )
   constructor(crashlytics: FirebaseCrashlytics) : this(crashlytics, CustomKeysAndValues.Builder())
 


### PR DESCRIPTION
Remove code style from deprecated message since it does not render properly. I could not find any syntax that rendered properly in both the IDE and in the generated html. I found many examples of deprecated messages that just don't add any code style to method or class names, see https://source.corp.google.com/search?q=%22@Deprecated(message%22. The Kotlin doc for `@Deprecated` does not mention any style, see https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-deprecated/.