### PR TITLE
Read version control info from Android resource

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* [changed] Internal changes to read version control info more efficiently [6754]
 * [fixed] Fixed NoSuchMethodError when getting process info on Android 13 [#6720]
 
 # 19.4.1

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
@@ -69,6 +69,8 @@ public class CommonUtils {
       "com.google.firebase.crashlytics.build_ids_arch";
   static final String BUILD_IDS_BUILD_ID_RESOURCE_NAME =
       "com.google.firebase.crashlytics.build_ids_build_id";
+  static final String VERSION_CONTROL_INFO_RESOURCE_NAME =
+      "com.google.firebase.crashlytics.version_control_info";
 
   // TODO: Maybe move this method into a more appropriate class.
   public static SharedPreferences getSharedPrefs(Context context) {
@@ -523,6 +525,15 @@ public class CommonUtils {
     }
 
     return buildIdInfoList;
+  }
+
+  @Nullable
+  public static String getVersionControlInfo(Context context) {
+    int id = getResourcesIdentifier(context, VERSION_CONTROL_INFO_RESOURCE_NAME, "string");
+    if (id == 0) {
+      return null;
+    }
+    return context.getResources().getString(id);
   }
 
   public static void closeQuietly(Closeable closeable) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -48,6 +48,7 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -76,6 +77,8 @@ class CrashlyticsController {
   private static final String VERSION_CONTROL_INFO_KEY = "com.crashlytics.version-control-info";
   private static final String VERSION_CONTROL_INFO_FILE = "version-control-info.textproto";
   private static final String META_INF_FOLDER = "META-INF/";
+
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   private final Context context;
   private final DataCollectionArbiter dataCollectionArbiter;
@@ -628,13 +631,22 @@ class CrashlyticsController {
   }
 
   String getVersionControlInfo() throws IOException {
-    InputStream is = getResourceAsStream(META_INF_FOLDER + VERSION_CONTROL_INFO_FILE);
-    if (is == null) {
-      return null;
+    // Attempt to read from an Android string resource
+    String versionControlInfo = CommonUtils.getVersionControlInfo(context);
+    if (versionControlInfo != null) {
+      Logger.getLogger().d("Read version control info from string resource");
+      return Base64.encodeToString(versionControlInfo.getBytes(UTF_8), 0);
     }
 
-    Logger.getLogger().d("Read version control info");
-    return Base64.encodeToString(readResource(is), 0);
+    // Fallback to reading the file
+    InputStream is = getResourceAsStream(META_INF_FOLDER + VERSION_CONTROL_INFO_FILE);
+    if (is != null) {
+      Logger.getLogger().d("Read version control info from file");
+      return Base64.encodeToString(readResource(is), 0);
+    }
+
+    Logger.getLogger().i("No version control information found");
+    return null;
   }
 
   private InputStream getResourceAsStream(String resource) {
@@ -644,13 +656,7 @@ class CrashlyticsController {
       return null;
     }
 
-    InputStream is = classLoader.getResourceAsStream(resource);
-    if (is == null) {
-      Logger.getLogger().i("No version control information found");
-      return null;
-    }
-
-    return is;
+    return classLoader.getResourceAsStream(resource);
   }
 
   private static byte[] readResource(InputStream is) throws IOException {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -639,10 +639,11 @@ class CrashlyticsController {
     }
 
     // Fallback to reading the file
-    InputStream is = getResourceAsStream(META_INF_FOLDER + VERSION_CONTROL_INFO_FILE);
-    if (is != null) {
-      Logger.getLogger().d("Read version control info from file");
-      return Base64.encodeToString(readResource(is), 0);
+    try (InputStream is = getResourceAsStream(META_INF_FOLDER + VERSION_CONTROL_INFO_FILE)) {
+      if (is != null) {
+        Logger.getLogger().d("Read version control info from file");
+        return Base64.encodeToString(readResource(is), 0);
+      }
     }
 
     Logger.getLogger().i("No version control information found");


### PR DESCRIPTION
Read version control info from an Android string resource, then fall back to the old slower method.

The Crashlytics Gradle plugin will need to be updated to generate this string resource.