### PR TITLE
Adjust Create Release

### DIFF
--- a/.github/workflows/create_releases.yml
+++ b/.github/workflows/create_releases.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   create-branches:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -25,6 +28,9 @@ jobs:
 
   create-pull-request:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4.1.1
         with:


### PR DESCRIPTION
We need explicit permissions to create PRs now, this adjusts our create release workflow to specify them.