### PR TITLE
fix(functions): use notifyError() instead of throwing

### DIFF
--- a/firebase-functions/src/androidTest/java/com/google/firebase/functions/StreamTests.kt
+++ b/firebase-functions/src/androidTest/java/com/google/firebase/functions/StreamTests.kt
@@ -145,8 +145,8 @@ class StreamTests {
 
   @Test
   fun nonExistentFunction_receivesError() = runBlocking {
-    val function = functions.getHttpsCallable("nonexistentFunction")
-      .withTimeout(2000, TimeUnit.MILLISECONDS)
+    val function =
+      functions.getHttpsCallable("nonexistentFunction").withTimeout(2000, TimeUnit.MILLISECONDS)
     val subscriber = StreamSubscriber()
 
     function.stream().subscribe(subscriber)

--- a/firebase-functions/src/androidTest/java/com/google/firebase/functions/StreamTests.kt
+++ b/firebase-functions/src/androidTest/java/com/google/firebase/functions/StreamTests.kt
@@ -144,6 +144,26 @@ class StreamTests {
   }
 
   @Test
+  fun nonExistentFunction_receivesError() = runBlocking {
+    val function = functions.getHttpsCallable("nonexistentFunction")
+      .withTimeout(2000, TimeUnit.MILLISECONDS)
+    val subscriber = StreamSubscriber()
+
+    function.stream().subscribe(subscriber)
+
+    withTimeout(2000) {
+      while (subscriber.throwable == null) {
+        delay(100)
+      }
+    }
+
+    assertThat(subscriber.throwable).isNotNull()
+    assertThat(subscriber.throwable).isInstanceOf(FirebaseFunctionsException::class.java)
+    assertThat((subscriber.throwable as FirebaseFunctionsException).code)
+      .isEqualTo(FirebaseFunctionsException.Code.NOT_FOUND)
+  }
+
+  @Test
   fun genStreamWeather_receivesWeatherForecasts() = runBlocking {
     val inputData = listOf(mapOf("name" to "Toronto"), mapOf("name" to "London"))
     val input = mapOf("data" to inputData)

--- a/firebase-functions/src/main/java/com/google/firebase/functions/PublisherStream.kt
+++ b/firebase-functions/src/main/java/com/google/firebase/functions/PublisherStream.kt
@@ -325,11 +325,7 @@ internal class PublisherStream(
       return
     }
     notifyError(
-      FirebaseFunctionsException(
-        error.toString(),
-        FirebaseFunctionsException.Code.INTERNAL,
-        error
-      )
+      FirebaseFunctionsException(error.toString(), FirebaseFunctionsException.Code.INTERNAL, error)
     )
   }
 }

--- a/firebase-functions/src/main/java/com/google/firebase/functions/PublisherStream.kt
+++ b/firebase-functions/src/main/java/com/google/firebase/functions/PublisherStream.kt
@@ -300,10 +300,12 @@ internal class PublisherStream(
     val errorMessage: String
     if (response.code() == 404 && response.header("Content-Type") == htmlContentType) {
       errorMessage = """URL not found. Raw response: ${response.body()?.string()}""".trimMargin()
-      throw FirebaseFunctionsException(
-        errorMessage,
-        FirebaseFunctionsException.Code.fromHttpStatus(response.code()),
-        null
+      notifyError(
+        FirebaseFunctionsException(
+          errorMessage,
+          FirebaseFunctionsException.Code.fromHttpStatus(response.code()),
+          null
+        )
       )
     }
 
@@ -313,16 +315,21 @@ internal class PublisherStream(
       val json = JSONObject(text)
       error = serializer.decode(json.opt("error"))
     } catch (e: Throwable) {
-      throw FirebaseFunctionsException(
-        "${e.message} Unexpected Response:\n$text ",
-        FirebaseFunctionsException.Code.INTERNAL,
-        e
+      notifyError(
+        FirebaseFunctionsException(
+          "${e.message} Unexpected Response:\n$text ",
+          FirebaseFunctionsException.Code.INTERNAL,
+          e
+        )
       )
+      return
     }
-    throw FirebaseFunctionsException(
-      error.toString(),
-      FirebaseFunctionsException.Code.INTERNAL,
-      error
+    notifyError(
+      FirebaseFunctionsException(
+        error.toString(),
+        FirebaseFunctionsException.Code.INTERNAL,
+        error
+      )
     )
   }
 }


### PR DESCRIPTION
Throwing inside the `PublisherStream` causes a Runtime exception that can't be caught in the call site.
Instead, we should use `notifyError()` so that the error can be caught in the `Subscriber#onError()` function.

I tried to catch the exception using both of the code snippets below, but none of them worked. (they both work with the changes in this PR):

```kotlin
functions.getHttpsCallable("nonExistentFunction")
    .stream().asFlow()
    .catch {
        // Handle error for a 404 function
    }
    .collect {
        // ...
    }
```

```kotlin
try {
    functions.getHttpsCallable("nonExistentFunction")
        .stream().asFlow()
        .collect {
            // ...
        }
} catch(e: Exception) {
    // Handle error for a 404 function
}
```

Runtime exception thrown:

```
FATAL EXCEPTION: OkHttp Dispatcher
    Process: com.google.samples.quickstart.functions, PID: 13321
    com.google.firebase.functions.FirebaseFunctionsException: Value <html><head> of type java.lang.String cannot be converted to JSONObject Unexpected Response:
                                                                             
    <html><head>
    <meta http-equiv="content-type" content="text/html;charset=utf-8">
    <title>404 Page not found</title>
    </head>
        <body text=#000000 bgcolor=#ffffff>
            <h1>Error: Page not found</h1>
            <h2>The requested URL was not found on this server.</h2>
            <h2></h2>
        </body></html>
                                                                              
    at com.google.firebase.functions.PublisherStream.validateResponse(PublisherStream.kt:316)
    at com.google.firebase.functions.PublisherStream.access$validateResponse(PublisherStream.kt:41)
    at com.google.firebase.functions.PublisherStream$startStreaming$1$4.onResponse(PublisherStream.kt:161)
    at okhttp3.RealCall$AsyncCall.execute(RealCall.java:203)
    at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1156)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:651)
    at java.lang.Thread.run(Thread.java:1119)
```
