### PR TITLE
chore(functions): export reactive-streams as a transitive dependency

### DIFF
--- a/firebase-functions/firebase-functions.gradle.kts
+++ b/firebase-functions/firebase-functions.gradle.kts
@@ -112,7 +112,7 @@ dependencies {
   implementation(libs.okhttp)
   implementation(libs.playservices.base)
   implementation(libs.playservices.basement)
-  implementation(libs.reactive.streams)
+  api(libs.reactive.streams)
 
   api(libs.playservices.tasks)
 


### PR DESCRIPTION
Alternative to #6774 - we'll keep that PR for a follow-up release.

For now, we're exposing the `reactive-streams` dependency to make sure it works out of the box for Java developers.