### PR TITLE
Swap external action to verify changed files for inline code

### DIFF
--- a/.github/workflows/release-note-changes.yml
+++ b/.github/workflows/release-note-changes.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 jobs:
-  build:
+  release-notes-changed:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
@@ -18,12 +18,16 @@ jobs:
 
       - name: Get changed changelog files
         id: changed-files
-        uses: tj-actions/changed-files@v41.0.0
-        with:
-          files_ignore: |
-            plugins/**
-          files: |
-            **/CHANGELOG.md
+        run: |
+          git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha}} | grep CHANGELOG.md > /tmp/changelog_file_list.txt
+          if [[ "$?" == "0" ]]
+          then
+            echo "any_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "any_changed=false" >> $GITHUB_OUTPUT
+          fi
+          echo "all_changed_files=$(cat /tmp/changelog_file_list.txt)" >> $GITHUB_OUTPUT
+          rm /tmp/changelog_file_list.txt
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4.1.0


### PR DESCRIPTION
In the light of recent security issues, we are choosing to use our own code to replace an external action.

See
https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised for context

b/403703743