### PR TITLE
[github actions] Pin actions to hash commits

### DIFF
--- a/.github/workflows/api-information.yml
+++ b/.github/workflows/api-information.yml
@@ -7,18 +7,18 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
           submodules: true
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin
           cache: gradle
       - name: Set up Python 3.10
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.10'
       - name: Set up fireci

--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -12,10 +12,10 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin
@@ -26,21 +26,21 @@ jobs:
           ./gradlew firebasePublish
 
       - name: Upload m2 repo
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: m2repository
           path: build/m2repository/
           retention-days: 15
 
       - name: Upload release notes
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: release_notes
           path: build/release-notes/
           retention-days: 15
 
       - name: Upload kotlindocs
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: kotlindocs
           path: build/firebase-kotlindoc/

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       BUNDLE_GEMFILE: ./ci/danger/Gemfile
     steps:
-    - uses: actions/checkout@v4.1.1
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 100
         submodules: true

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         fetch-depth: 100
         submodules: true
-    - uses: ruby/setup-ruby@v1
+    - uses: ruby/setup-ruby@1a615958ad9d422dd932dc1d5823942ee002799f # v1.227.0
       with:
         ruby-version: '2.7'
     - name: Setup Bundler

--- a/.github/workflows/check-head-dependencies.yml
+++ b/.github/workflows/check-head-dependencies.yml
@@ -10,9 +10,9 @@ jobs:
   check-head-dependencies:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin

--- a/.github/workflows/check-vertexai-responses.yml
+++ b/.github/workflows/check-vertexai-responses.yml
@@ -17,24 +17,24 @@ jobs:
           echo "latest_tag=$LATEST" >> $GITHUB_ENV
         working-directory: firebase-vertexai/src/test/resources/vertexai-sdk-test-data
       - name: Find comment from previous run if exists
-        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         id: fc
         with:
           issue-number: ${{github.event.number}}
           body-includes: Vertex AI Mock Responses Check
       - name: Comment on PR if newer version is available
         if: ${{env.cloned_tag != env.latest_tag && !steps.fc.outputs.comment-id}}
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           issue-number: ${{github.event.number}}
           body: >
             ### Vertex AI Mock Responses Check :warning:
-            
+
             A newer major version of the mock responses for Vertex AI unit tests is available.
             [update_responses.sh](https://github.com/firebase/firebase-android-sdk/blob/main/firebase-vertexai/update_responses.sh)
             should be updated to clone the latest version of the responses: `${{env.latest_tag}}`
       - name: Delete comment when version gets updated
         if: ${{env.cloned_tag == env.latest_tag && steps.fc.outputs.comment-id}}
-        uses: detomarco/delete-comment@850734dd44d8b15fef55b45252613b903ceb06f0
+        uses: detomarco/delete-comment@dd37d1026c669ebfb0ffa5d23890010759ff05d5 # v1.1.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/check-vertexai-responses.yml
+++ b/.github/workflows/check-vertexai-responses.yml
@@ -6,7 +6,7 @@ jobs:
   check-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Clone mock responses
         run: firebase-vertexai/update_responses.sh
       - name: Find cloned and latest versions

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -16,13 +16,13 @@ jobs:
     outputs:
       modules: ${{ steps.changed-modules.outputs.modules }}
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
           submodules: true
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin
@@ -44,13 +44,13 @@ jobs:
         module: ${{ fromJSON(needs.determine_changed.outputs.modules) }}
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
           submodules: true
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -16,13 +16,13 @@ jobs:
     outputs:
       modules: ${{ steps.changed-modules.outputs.modules }}
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
           submodules: true
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin
@@ -44,13 +44,13 @@ jobs:
         module: ${{ fromJSON(needs.determine_changed.outputs.modules) }}
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
           submodules: true
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin
@@ -76,7 +76,7 @@ jobs:
           MODULE=${{matrix.module}}
           echo "ARTIFACT_NAME=${MODULE//:/_}" >> $GITHUB_ENV
       - name: Upload Test Results
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         if: always()
         with:
           name: unit-test-result-${{env.ARTIFACT_NAME}}
@@ -113,13 +113,13 @@ jobs:
           - module: :firebase-functions:ktx
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
           submodules: true
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin
@@ -130,10 +130,10 @@ jobs:
           INTEG_TESTS_GOOGLE_SERVICES: ${{ secrets.INTEG_TESTS_GOOGLE_SERVICES }}
         run: |
           echo $INTEG_TESTS_GOOGLE_SERVICES | base64 -d > google-services.json
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
         with:
           credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
       - name: ${{ matrix.module }} Integ Tests
         env:
           FIREBASE_CI: 1
@@ -159,7 +159,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e #v4.2.1
         with:
           path: artifacts
 

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -159,11 +159,11 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e #v4.2.1
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           path: artifacts
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@82082dac68ad6a19d980f8ce817e108b9f496c2a
+        uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b # v2.18.0
         with:
           files: "artifacts/**/*.xml"

--- a/.github/workflows/config-e2e.yml
+++ b/.github/workflows/config-e2e.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout firebase-config
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -31,10 +31,10 @@ jobs:
         run: |
           echo $REMOTE_CONFIG_E2E_GOOGLE_SERVICES | base64 -d > google-services.json
 
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
         with:
           credentials_json: ${{ secrets.GCP_service_account }}
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
       - name: Run Remote Config end-to-end tests
         env:
           FTL_RESULTS_BUCKET: fireescape

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -10,8 +10,8 @@ jobs:
   copyright-check:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4.1.1
-      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.9'
       - run: |

--- a/.github/workflows/create_releases.yml
+++ b/.github/workflows/create_releases.yml
@@ -32,11 +32,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin

--- a/.github/workflows/create_releases.yml
+++ b/.github/workflows/create_releases.yml
@@ -46,7 +46,7 @@ jobs:
           ./gradlew generateReleaseConfig -PcurrentRelease=${{ inputs.name }} -PpastRelease=${{ inputs.past-name }} -PprintOutput=true
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           base: 'releases/${{ inputs.name }}'
           branch: 'releases/${{ inputs.name }}.release'

--- a/.github/workflows/dataconnect.yml
+++ b/.github/workflows/dataconnect.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Create AVD
         if: github.event_name == 'schedule' || steps.restore-avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d #v2.33.0
         with:
           api-level: ${{ env.FDC_ANDROID_EMULATOR_API_LEVEL }}
           arch: x86_64
@@ -187,7 +187,7 @@ jobs:
 
       - name: Gradle connectedCheck
         id: connectedCheck
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d #v2.33.0
         # Allow this GitHub Actions "job" to continue even if the tests fail so that logs from a
         # failed test run get uploaded as "artifacts" and are available to investigate failed runs.
         # A later step in this "job" will fail the job if this step fails

--- a/.github/workflows/dataconnect.yml
+++ b/.github/workflows/dataconnect.yml
@@ -51,16 +51,16 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           show-progress: false
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: ${{ env.FDC_JAVA_VERSION }}
           distribution: temurin
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: ${{ env.FDC_NODEJS_VERSION }}
 
@@ -74,7 +74,7 @@ jobs:
 
       - name: Restore Gradle cache
         id: restore-gradle-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # 4.2.2
         if: github.event_name != 'schedule'
         with:
           path: |
@@ -118,7 +118,7 @@ jobs:
             :firebase-dataconnect:assembleDebugAndroidTest
 
       - name: Save Gradle cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # 4.2.2
         if: github.event_name == 'schedule'
         with:
           path: |
@@ -134,7 +134,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Restore AVD cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # 4.2.2
         if: github.event_name != 'schedule'
         id: restore-avd-cache
         with:
@@ -157,7 +157,7 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
 
       - name: Save AVD cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # 4.2.2
         if: github.event_name == 'schedule'
         with:
           path: |
@@ -202,7 +202,7 @@ jobs:
             set -eux && ./gradlew ${{ (inputs.gradleInfoLog && '--info') || '' }} :firebase-dataconnect:connectedCheck :firebase-dataconnect:connectors:connectedCheck
 
       - name: Upload log file artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: integration_test_logs
           path: "**/*.log"
@@ -210,7 +210,7 @@ jobs:
           compression-level: 9
 
       - name: Upload Gradle build report artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: integration_test_gradle_build_reports
           path: firebase-dataconnect/**/build/reports/
@@ -230,7 +230,7 @@ jobs:
     continue-on-error: false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           show-progress: false
       - uses: docker://rhysd/actionlint:1.7.7

--- a/.github/workflows/dataconnect_demo_app.yml
+++ b/.github/workflows/dataconnect_demo_app.yml
@@ -36,7 +36,7 @@ jobs:
     continue-on-error: false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           sparse-checkout: firebase-dataconnect/demo
 
@@ -45,7 +45,7 @@ jobs:
           echo "gmagjr2b9d" >github_actions_demo_test_cache_key.txt
           echo "${{ env.FDC_FIREBASE_TOOLS_VERSION }}" >github_actions_demo_assemble_firebase_tools_version.txt
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: ${{ env.FDC_NODE_VERSION }}
           cache: 'npm'
@@ -55,7 +55,7 @@ jobs:
 
       - name: cache package-lock.json
         id: package_json_lock
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # 4.2.2
         with:
           path: ${{ env.FDC_FIREBASE_TOOLS_DIR }}/package*.json
           key: firebase_tools_package_json-${{ env.FDC_FIREBASE_TOOLS_VERSION }}
@@ -73,9 +73,9 @@ jobs:
         if: steps.package_json_lock.outputs.cache-hit == 'true'
         run: |
           cd ${{ env.FDC_FIREBASE_TOOLS_DIR }}
-          npm ci --fund=false --audit=false 
+          npm ci --fund=false --audit=false
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: ${{ env.FDC_JAVA_VERSION }}
           distribution: temurin
@@ -114,14 +114,14 @@ jobs:
           -PdataConnect.minimalApp.firebaseCommand=${{ env.FDC_FIREBASE_COMMAND }} \
           assemble test
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: apks
           path: firebase-dataconnect/demo/build/**/*.apk
           if-no-files-found: warn
           compression-level: 0
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: gradle_build_reports
           path: firebase-dataconnect/demo/build/reports/
@@ -132,14 +132,14 @@ jobs:
     continue-on-error: false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           sparse-checkout: firebase-dataconnect/demo
 
       - name: Create Cache Key Files
         run: echo "h99ee4egfd" >github_actions_demo_spotless_cache_key.txt
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: ${{ env.FDC_JAVA_VERSION }}
           distribution: temurin

--- a/.github/workflows/diff-javadoc.yml
+++ b/.github/workflows/diff-javadoc.yml
@@ -13,13 +13,13 @@ jobs:
         run: mkdir ~/diff
 
       - name: Checkout PR branch
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
           submodules: true
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin
@@ -32,7 +32,7 @@ jobs:
         run: mv build ~/diff/modified
 
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.base_ref }}
 

--- a/.github/workflows/fireci.yml
+++ b/.github/workflows/fireci.yml
@@ -15,8 +15,8 @@ jobs:
     name: "fireci tests"
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4.1.1
-      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.8'
       - run: |

--- a/.github/workflows/fireperf-e2e.yml
+++ b/.github/workflows/fireperf-e2e.yml
@@ -20,29 +20,29 @@ jobs:
         environment: [ prod, autopush ]
     steps:
       - name: Checkout firebase-android-sdk
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Checkout firebase-android-buildtools
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: FirebasePrivate/firebase-android-buildtools
           token: ${{ secrets.GOOGLE_OSS_BOT_TOKEN }}
           path: firebase-android-buildtools
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin
           cache: gradle
       - name: Set up Python 3.10
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.10'
       - name: Set up fireci
         run: pip3 install -e ci/fireci
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
         with:
           credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
       - name: Add google-services.json
         run: echo $PERF_E2E_GOOGLE_SERVICES | base64 -d > google-services.json
       - name: Run fireperf end-to-end tests
@@ -52,7 +52,7 @@ jobs:
             --target_environment=${{ matrix.environment }}
       - name: Notify developers upon failures
         if: ${{ failure() }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const owner = context.repo.owner;
@@ -98,7 +98,7 @@ jobs:
             }
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: test-artifacts (${{ matrix.environment }})
           path: |

--- a/.github/workflows/firestore_ci_tests.yml
+++ b/.github/workflows/firestore_ci_tests.yml
@@ -72,7 +72,7 @@ jobs:
           credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       - uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
       - name: firebase-firestore Integ Tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d #v2.33.0
         env:
           FIREBASE_CI: 1
           FTL_RESULTS_BUCKET: android-ci
@@ -137,7 +137,7 @@ jobs:
 
       # create composite indexes with Terraform
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
       - name: Terraform Init
         run: |
           cd firebase-firestore
@@ -164,7 +164,7 @@ jobs:
 
       - name: Firestore Named DB Integ Tests
         timeout-minutes: 20
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d #v2.33.0
         env:
           FIREBASE_CI: 1
           FTL_RESULTS_BUCKET: android-ci
@@ -227,7 +227,7 @@ jobs:
       - uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
 
       - name: Firestore Nightly Integ Tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d #v2.33.0
         env:
           FIREBASE_CI: 1
           FTL_RESULTS_BUCKET: android-ci

--- a/.github/workflows/firestore_ci_tests.yml
+++ b/.github/workflows/firestore_ci_tests.yml
@@ -16,13 +16,13 @@ jobs:
     outputs:
       modules: ${{ steps.changed-modules.outputs.modules }}
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
           submodules: true
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
           submodules: true
@@ -53,10 +53,10 @@ jobs:
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm    
+          sudo udevadm trigger --name-match=kvm
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin
@@ -67,10 +67,10 @@ jobs:
           INTEG_TESTS_GOOGLE_SERVICES: ${{ secrets.INTEG_TESTS_GOOGLE_SERVICES }}
         run: |
           echo $INTEG_TESTS_GOOGLE_SERVICES | base64 -d > google-services.json
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
         with:
           credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
       - name: firebase-firestore Integ Tests
         uses: reactivecircus/android-emulator-runner@v2
         env:
@@ -88,7 +88,7 @@ jobs:
             ./gradlew firebase-firestore:connectedCheck withErrorProne -PtargetBackend="prod"
       - name: Upload logs
         if: failure()
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: logcat.txt
           path: logcat.txt
@@ -107,7 +107,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
           submodules: true
@@ -116,10 +116,10 @@ jobs:
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm    
+          sudo udevadm trigger --name-match=kvm
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin
@@ -130,10 +130,10 @@ jobs:
           INTEG_TESTS_GOOGLE_SERVICES: ${{ secrets.INTEG_TESTS_GOOGLE_SERVICES }}
         run: |
           echo $INTEG_TESTS_GOOGLE_SERVICES | base64 -d > google-services.json
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
         with:
           credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
 
       # create composite indexes with Terraform
       - name: Setup Terraform
@@ -180,7 +180,7 @@ jobs:
             ./gradlew firebase-firestore:connectedCheck withErrorProne -PtargetBackend="prod"
       - name: Upload logs
         if: failure()
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: named-db-logcat.txt
           path: logcat.txt
@@ -198,7 +198,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
           submodules: true
@@ -207,10 +207,10 @@ jobs:
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm    
+          sudo udevadm trigger --name-match=kvm
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin
@@ -221,10 +221,10 @@ jobs:
           INTEG_TESTS_GOOGLE_SERVICES: ${{ secrets.NIGHTLY_INTEG_TESTS_GOOGLE_SERVICES }}
         run: |
           echo $INTEG_TESTS_GOOGLE_SERVICES > google-services.json
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
         with:
           credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
 
       - name: Firestore Nightly Integ Tests
         uses: reactivecircus/android-emulator-runner@v2
@@ -243,7 +243,7 @@ jobs:
             ./gradlew firebase-firestore:connectedCheck withErrorProne -PtargetBackend="nightly"
       - name: Upload logs
         if: failure()
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: nightly-logcat.txt
           path: logcat.txt

--- a/.github/workflows/health-metrics.yml
+++ b/.github/workflows/health-metrics.yml
@@ -24,24 +24,24 @@ jobs:
               && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
           submodules: true
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin
           cache: gradle
       - name: Set up Python 3.10
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.10'
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
         with:
           credentials_json: '${{ secrets.GCP_SERVICE_ACCOUNT }}'
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
       - name: Set up fireci
         run: pip3 install -e ci/fireci
       - name: Run coverage tests (presubmit)
@@ -59,24 +59,24 @@ jobs:
               && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
           submodules: true
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin
           cache: gradle
       - name: Set up Python 3.10
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.10'
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
         with:
           credentials_json: '${{ secrets.GCP_SERVICE_ACCOUNT }}'
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
       - name: Set up fireci
         run: pip3 install -e ci/fireci
       - name: Run size tests (presubmit)
@@ -95,24 +95,24 @@ jobs:
               && github.event.pull_request.base.ref == 'main')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
           submodules: true
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin
           cache: gradle
       - name: Set up Python 3.10
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.10'
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
         with:
           credentials_json: '${{ secrets.GCP_SERVICE_ACCOUNT }}'
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
       - name: Set up fireci
         run: pip3 install -e ci/fireci
       - name: Add google-services.json

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -31,16 +31,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
+        uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1.0.13
         with:
           source: ./contributor-docs
           destination: ./_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa #v3.0.1
 
   deploy:
     if: ${{ github.event_name == 'push' && github.repository == 'firebase/firebase-android-sdk' }}
@@ -52,4 +52,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e #v4.0.5

--- a/.github/workflows/make-bom.yml
+++ b/.github/workflows/make-bom.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python 3.10
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.10'
 
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin
@@ -26,21 +26,21 @@ jobs:
           ./gradlew buildBomBundleZip
 
       - name: Upload bom
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: bom
           path: build/bom/
           retention-days: 15
 
       - name: Upload release notes
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: bom_release_notes
           path: build/bomReleaseNotes.md
           retention-days: 15
 
       - name: Upload recipe version update
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: recipe_version
           path: build/recipeVersionUpdate.txt

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-    - uses: mshick/add-pr-comment@a65df5f64fc741e91c59b8359a4bc56e57aaf5b1
+    - uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
       with:
         message: >
           ### 📝 PRs merging into main branch

--- a/.github/workflows/metalava-semver-check.yml
+++ b/.github/workflows/metalava-semver-check.yml
@@ -10,12 +10,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.base_ref }}
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin
@@ -25,7 +25,7 @@ jobs:
         run: ./gradlew copyApiTxtFile
 
       - name: Checkout PR
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.head_ref }}
           clean: false

--- a/.github/workflows/plugins-check.yml
+++ b/.github/workflows/plugins-check.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           ./gradlew plugins:check
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@82082dac68ad6a19d980f8ce817e108b9f496c2a
+        uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b # v2.18.0
         with:
           files: "**/build/test-results/**/*.xml"
           check_name: "plugins test results"

--- a/.github/workflows/plugins-check.yml
+++ b/.github/workflows/plugins-check.yml
@@ -13,9 +13,9 @@ jobs:
   plugins-check:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin

--- a/.github/workflows/post_release_cleanup.yml
+++ b/.github/workflows/post_release_cleanup.yml
@@ -26,7 +26,7 @@ jobs:
           ./gradlew postReleaseCleanup
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: ${{ secrets.GOOGLE_OSS_BOT_TOKEN }}
           committer: google-oss-bot <firebase-oss-bot@google.com>
@@ -41,6 +41,6 @@ jobs:
           title: '${{ inputs.name}} mergeback'
           body: |
             Auto-generated PR for cleaning up release ${{ inputs.name}}
-            
+
             NO_RELEASE_CHANGE
           commit-message: 'Post release cleanup for ${{ inputs.name }}'

--- a/.github/workflows/post_release_cleanup.yml
+++ b/.github/workflows/post_release_cleanup.yml
@@ -12,11 +12,11 @@ jobs:
   create-pull-request:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin

--- a/.github/workflows/private-mirror-sync.yml
+++ b/.github/workflows/private-mirror-sync.yml
@@ -10,14 +10,14 @@ jobs:
     if: github.repository == 'FirebasePrivate/firebase-android-sdk'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: firebase/firebase-android-sdk
           ref: main
           fetch-depth: 0
           submodules: true
 
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           submodules: true

--- a/.github/workflows/release-note-changes.yml
+++ b/.github/workflows/release-note-changes.yml
@@ -54,7 +54,7 @@ jobs:
           fireci changelog_comment -c "${{ steps.changed-files.outputs.all_changed_files }}" -o ./changelog_comment.md
 
       - name: Add PR Comment
-        uses: mshick/add-pr-comment@v2.8.1
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
         continue-on-error: true
         with:
           status: ${{ steps.generate-comment.outcome }}

--- a/.github/workflows/release-note-changes.yml
+++ b/.github/workflows/release-note-changes.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -26,14 +26,14 @@ jobs:
             **/CHANGELOG.md
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin
           cache: gradle
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         with:
           python-version: '3.10'

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
@@ -73,7 +73,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: Upload artifact
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/semver-check.yml
+++ b/.github/workflows/semver-check.yml
@@ -10,9 +10,9 @@ jobs:
   semver-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin

--- a/.github/workflows/sessions-e2e.yml
+++ b/.github/workflows/sessions-e2e.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout firebase-sessions
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -31,10 +31,10 @@ jobs:
         run: |
           echo $SESSIONS_E2E_GOOGLE_SERVICES | base64 -d > google-services.json
 
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
         with:
           credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
       - name: Run sessions end-to-end tests
         env:
           FTL_RESULTS_BUCKET: fireescape

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -7,20 +7,20 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
           submodules: true
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin
           cache: gradle
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
         with:
           credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
 
       # TODO(yifany): make it a fireci plugin and remove the separately distributed jar file
       - name: Download smoke tests runner
@@ -51,7 +51,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: smoke-tests-artifacts
           path: |

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       released_version_changed: ${{ steps.check_version.outputs.released_version_changed }}
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # Check out the actual head commit, not any merge commit.
           ref: ${{ github.sha }}
@@ -51,12 +51,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup python
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: 3.7
 
       - name: Check out firebase-cpp-sdk
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: firebase/firebase-cpp-sdk
           ref: main

--- a/.github/workflows/validate-dependencies.yml
+++ b/.github/workflows/validate-dependencies.yml
@@ -10,9 +10,9 @@ jobs:
   build-artifacts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -10,9 +10,9 @@ jobs:
   version-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: 17
           distribution: temurin


### PR DESCRIPTION
Tags can be modified to point to different commits, which is a
security issue. By pinning to specific commits we ensure the code
executing isn't changing.