### PR TITLE
docs: explicitly call out that ImagenInlineImage#data is base64 encoded

### DIFF
--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/ImagenInlineImage.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/ImagenInlineImage.kt
@@ -23,7 +23,7 @@ import android.util.Base64
 /**
  * Represents an Imagen-generated image that is contained inline
  *
- * @param data Contains the base64 encoded image data.
+ * @param data Contains the base64-encoded image data.
  * @param mimeType Contains the MIME type of the image (for example, `"image/png"`)
  */
 @PublicPreviewAPI

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/ImagenInlineImage.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/ImagenInlineImage.kt
@@ -23,7 +23,7 @@ import android.util.Base64
 /**
  * Represents an Imagen-generated image that is contained inline
  *
- * @param data Contains the raw bytes of the image
+ * @param data Contains the base64 encoded image data.
  * @param mimeType Contains the MIME type of the image (for example, `"image/png"`)
  */
 @PublicPreviewAPI


### PR DESCRIPTION
This is meant to match the [JS ref docs](https://firebase.google.com/docs/reference/js/vertexai.imageninlineimage#imageninlineimagebytesbase64encoded).

See context in #6786
