### PR TITLE
Add transform action to remove package prefix in toc files

### DIFF
--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
@@ -38,6 +38,7 @@ import org.gradle.api.tasks.TaskAction
  * - Adds the deprecated status to ktx sections in _toc.yaml files
  * - Fixes broken hyperlinks in `@see` blocks
  * - Removes the prefix path from book_path
+ * - Removes the `com.google` package prefix from _toc.yaml files
  *
  * **Please note:** This task is idempotent- meaning it can safely be ran multiple times on the same
  * set of files.
@@ -77,9 +78,34 @@ abstract class FiresiteTransformTask : DefaultTask() {
   }
 
   private fun File.fixYamlFile() {
-    val fixedContent = readText().removeClassHeader().removeIndexHeader().addDeprecatedStatus()
+    val fixedContent =
+      readText().removeClassHeader().removeIndexHeader().addDeprecatedStatus().removePackagePrefix()
     writeText(fixedContent)
   }
+
+  /**
+   * Removes the `com.google.` prefix from the package titles in the table of contents.
+   *
+   * The prefix pollutes the TOC, especially on smaller screen sizes; so we opt to removed it
+   * entirely.
+   *
+   * Example input:
+   * ```
+   * toc:
+   * - title: "com.google.firebase.functions"
+   *   path: "/docs/reference/android/com/google/firebase/functions/package-summary.html"
+   * ```
+   *
+   * Example output:
+   * ```
+   * toc:
+   * - title: "firebase.functions"
+   *   path: "/docs/reference/android/com/google/firebase/functions/package-summary.html"
+   * ```
+   *
+   * TODO(b/378717454): Migrate to the param packagePrefixToRemoveInToc in dackka when fixed
+   */
+  private fun String.removePackagePrefix() = remove(Regex("(?<=title: \")(com\\.google\\.)"))
 
   /**
    * Fixes broken hyperlinks in the rendered HTML


### PR DESCRIPTION
Per [b/379093944](https://b.corp.google.com/issues/379093944),

This adds a transform action to remove the `com.google.` package prefix in the TOC files, as it pollutes the visual landscape for consumers. Long-term, this action will be replaced by a parameter offered via newer versions of dackka- but we don't currently have the bandwidth for such an upgrade. A tracking bug has been left with the implementation to migrate to said parameter whenever we have the time to upgrade.