### PR TITLE
include the full googleid module in GenerateTutorialBundleTask.kt

### DIFF
--- a/plugins/src/main/java/com/google/firebase/gradle/bomgenerator/GenerateTutorialBundleTask.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/bomgenerator/GenerateTutorialBundleTask.kt
@@ -261,7 +261,7 @@ abstract class GenerateTutorialBundleTask : DefaultTask() {
           ArtifactTutorialMapping("Auth Google Sign In", "auth-google-signin-first-dependency"),
         "androidx.credentials:credentials-play-services-auth" to
           ArtifactTutorialMapping("Auth Google Sign In", "auth-google-signin-second-dependency"),
-        "com.google.android.libraries.identity.googleid" to
+        "com.google.android.libraries.identity.googleid:googleid" to
           ArtifactTutorialMapping("Auth Google Sign In", "auth-google-signin-third-dependency"),
         "com.google.firebase:firebase-appdistribution-gradle" to
           ArtifactTutorialMapping(


### PR DESCRIPTION
I suspect this is what is causing the plugin to try and remove the `com.google.android.libraries.identity.googleid:googleid:1.1.1` library. (as seen in [cl/738906664](https://critique.corp.google.com/cl/738906664/depot/google3/third_party/devsite/firebase/en/android-studio/firebase_assistant/firebase_tutorial_bundle.xml?version=r201#43))