### PR TITLE
ci: add missing permissions to .github/workflows/plugins-check.yml

### DIFF
--- a/.github/workflows/plugins-check.yml
+++ b/.github/workflows/plugins-check.yml
@@ -13,6 +13,7 @@ jobs:
   plugins-check:
     permissions:
       checks: write
+      pull-requests: write
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/plugins-check.yml
+++ b/.github/workflows/plugins-check.yml
@@ -11,6 +11,8 @@ concurrency:
 
 jobs:
   plugins-check:
+    permissions:
+      checks: write
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/plugins/src/main/java/com/google/firebase/gradle/bomgenerator/GenerateTutorialBundleTask.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/bomgenerator/GenerateTutorialBundleTask.kt
@@ -261,7 +261,7 @@ abstract class GenerateTutorialBundleTask : DefaultTask() {
           ArtifactTutorialMapping("Auth Google Sign In", "auth-google-signin-first-dependency"),
         "androidx.credentials:credentials-play-services-auth" to
           ArtifactTutorialMapping("Auth Google Sign In", "auth-google-signin-second-dependency"),
-        "com.google.android.libraries.identity.googleid:googleid" to
+        "com.google.android.libraries.identity.googleid" to
           ArtifactTutorialMapping("Auth Google Sign In", "auth-google-signin-third-dependency"),
         "com.google.firebase:firebase-appdistribution-gradle" to
           ArtifactTutorialMapping(

--- a/plugins/src/main/java/com/google/firebase/gradle/bomgenerator/GenerateTutorialBundleTask.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/bomgenerator/GenerateTutorialBundleTask.kt
@@ -261,7 +261,7 @@ abstract class GenerateTutorialBundleTask : DefaultTask() {
           ArtifactTutorialMapping("Auth Google Sign In", "auth-google-signin-first-dependency"),
         "androidx.credentials:credentials-play-services-auth" to
           ArtifactTutorialMapping("Auth Google Sign In", "auth-google-signin-second-dependency"),
-        "com.google.android.libraries.identity.googleid" to
+        "com.google.android.libraries.identity.googleid:googleid" to
           ArtifactTutorialMapping("Auth Google Sign In", "auth-google-signin-third-dependency"),
         "com.google.firebase:firebase-appdistribution-gradle" to
           ArtifactTutorialMapping(


### PR DESCRIPTION
This might be the cause of https://github.com/firebase/firebase-android-sdk/actions/runs/13979443579/job/39141224363?pr=6789


Update: confirmed in https://github.com/firebase/firebase-android-sdk/actions/runs/13979884815/job/39142572824?pr=6790