### PR TITLE
dataconnect: generateApiTxtFile.sh added

### DIFF
--- a/firebase-dataconnect/scripts/generateApiTxtFile.sh
+++ b/firebase-dataconnect/scripts/generateApiTxtFile.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+readonly PROJECT_ROOT_DIR="$(dirname "$0")/../.."
+
+readonly args=(
+  "${PROJECT_ROOT_DIR}/gradlew"
+  "-p"
+  "${PROJECT_ROOT_DIR}"
+  "--configure-on-demand"
+  "$@"
+  ":firebase-dataconnect:generateApiTxtFile"
+)
+
+echo "${args[*]}"
+exec "${args[@]}"


### PR DESCRIPTION
This new script makes it easy to regenerate the api.txt file without having to remember the gradle command.