### PR TITLE
[VertexAI] Log warning for unsupported model names

### DIFF
--- a/firebase-vertexai/CHANGELOG.md
+++ b/firebase-vertexai/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+* [feature] Emits a warning when attempting to use an incompatible model with
+  `GenerativeModel` or `ImagenModel`.
 * [changed] Added new exception type for quota exceeded scenarios.
 * [feature] `CountTokenRequest` now includes `GenerationConfig` from the model.
 

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/FirebaseVertexAI.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/FirebaseVertexAI.kt
@@ -16,6 +16,7 @@
 
 package com.google.firebase.vertexai
 
+import android.util.Log
 import com.google.firebase.Firebase
 import com.google.firebase.FirebaseApp
 import com.google.firebase.app
@@ -68,6 +69,15 @@ internal constructor(
     if (location.trim().isEmpty() || location.contains("/")) {
       throw InvalidLocationException(location)
     }
+    if (!modelName.startsWith(GEMINI_MODEL_NAME_PREFIX)) {
+      Log.w(
+        TAG,
+        """Unsupported Gemini model "${modelName}"; see
+      https://firebase.google.com/docs/vertex-ai/models for a list supported Gemini model names.
+      """
+          .trimIndent()
+      )
+    }
     return GenerativeModel(
       "projects/${firebaseApp.options.projectId}/locations/${location}/publishers/google/models/${modelName}",
       firebaseApp.options.apiKey,
@@ -102,6 +112,15 @@ internal constructor(
     if (location.trim().isEmpty() || location.contains("/")) {
       throw InvalidLocationException(location)
     }
+    if (!modelName.startsWith(IMAGEN_MODEL_NAME_PREFIX)) {
+      Log.w(
+        TAG,
+        """Unsupported Imagen model "${modelName}"; see
+      https://firebase.google.com/docs/vertex-ai/models for a list supported Imagen model names.
+      """
+          .trimIndent()
+      )
+    }
     return ImagenModel(
       "projects/${firebaseApp.options.projectId}/locations/${location}/publishers/google/models/${modelName}",
       firebaseApp.options.apiKey,
@@ -134,6 +153,12 @@ internal constructor(
       val multiResourceComponent = app[FirebaseVertexAIMultiResourceComponent::class.java]
       return multiResourceComponent.get(location)
     }
+
+    private const val GEMINI_MODEL_NAME_PREFIX = "gemini-"
+
+    private const val IMAGEN_MODEL_NAME_PREFIX = "imagen-"
+
+    private val TAG = FirebaseVertexAI::class.java.simpleName
   }
 }
 


### PR DESCRIPTION
Added a warning message to the initializers of GenerativeModel and ImagenModel that is logged when the provided model name does not start with the expected prefix ("gemini-" for GenerativeModel and "imagen-" for ImagenModel). The warning message includes a link to the documentation for supported models.

Note: No error is thrown in case the naming scheme is changed in the future, though we would want to update the logic/message at that time.

Related iOS PR https://github.com/firebase/firebase-ios-sdk/pull/14610