### PR TITLE
[VertexAI] Bump timeout for error test

### DIFF
--- a/firebase-functions/src/androidTest/java/com/google/firebase/functions/StreamTests.kt
+++ b/firebase-functions/src/androidTest/java/com/google/firebase/functions/StreamTests.kt
@@ -128,14 +128,14 @@ class StreamTests {
   fun genStreamError_receivesError() = runBlocking {
     val input = mapOf("data" to "test error")
     val function =
-      functions.getHttpsCallable("genStreamError").withTimeout(2000, TimeUnit.MILLISECONDS)
+      functions.getHttpsCallable("genStreamError").withTimeout(10_000, TimeUnit.MILLISECONDS)
     val subscriber = StreamSubscriber()
 
     function.stream(input).subscribe(subscriber)
 
-    withTimeout(2000) {
+    withTimeout(10_000) {
       while (subscriber.throwable == null) {
-        delay(100)
+        delay(1_000)
       }
     }
 


### PR DESCRIPTION
The test `genStreamError_receivesError` is flaky due to timeout issues. Bumping timeout to 10s.