### PR TITLE
Add buttons to log an identical performance trace across processes

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
@@ -40,7 +40,9 @@ public class PerfSession implements Parcelable {
   public static PerfSession createWithId(@NonNull String sessionId) {
     String prunedSessionId = sessionId.replace("-", "");
     PerfSession session = new PerfSession(prunedSessionId, new Clock());
-    session.setGaugeAndEventCollectionEnabled(shouldCollectGaugesAndEvents());
+//    session.setGaugeAndEventCollectionEnabled(shouldCollectGaugesAndEvents());
+    // For testing.
+    session.setGaugeAndEventCollectionEnabled(true);
 
     return session;
   }

--- a/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/FirstFragment.kt
+++ b/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/FirstFragment.kt
@@ -71,7 +71,7 @@ class FirstFragment : Fragment() {
       }
     }
     binding.createTrace.setOnClickListener {
-      viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+      lifecycleScope.launch(Dispatchers.IO) {
         val performanceTrace = performance.newTrace("test_trace")
         performanceTrace.start()
         delay(1000)

--- a/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/FirstFragment.kt
+++ b/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/FirstFragment.kt
@@ -27,6 +27,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.google.firebase.perf.FirebasePerformance
+import com.google.firebase.perf.metrics.Trace as PerfTrace
 import com.google.firebase.testing.sessions.databinding.FragmentFirstBinding
 import java.util.Date
 import java.util.Locale
@@ -34,6 +36,9 @@ import java.util.Locale
 /** A simple [Fragment] subclass as the default destination in the navigation. */
 class FirstFragment : Fragment() {
   val crashlytics = FirebaseCrashlytics.getInstance()
+  val performance = FirebasePerformance.getInstance()
+  var performanceTrace: PerfTrace?  = null
+  var performanceTraceIdenticalName: PerfTrace? = null
 
   private var _binding: FragmentFirstBinding? = null
 
@@ -63,6 +68,18 @@ class FirstFragment : Fragment() {
       while (true) {
         Thread.sleep(1_000)
       }
+    }
+    binding.createTrace.setOnClickListener {
+      performanceTrace = performance.newTrace("test_trace")
+      performanceTraceIdenticalName = performance.newTrace("test_trace")
+    }
+    binding.startTrace.setOnClickListener {
+      performanceTrace?.start()
+      performanceTraceIdenticalName?.start()
+    }
+    binding.stopTrace.setOnClickListener {
+      performanceTrace?.stop()
+      performanceTraceIdenticalName?.stop()
     }
     binding.buttonForegroundProcess.setOnClickListener {
       if (binding.buttonForegroundProcess.getText().startsWith("Start")) {

--- a/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/FirstFragment.kt
+++ b/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/FirstFragment.kt
@@ -26,19 +26,20 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.firebase.perf.FirebasePerformance
-import com.google.firebase.perf.metrics.Trace as PerfTrace
 import com.google.firebase.testing.sessions.databinding.FragmentFirstBinding
+import kotlinx.coroutines.Dispatchers
 import java.util.Date
 import java.util.Locale
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.delay
 
 /** A simple [Fragment] subclass as the default destination in the navigation. */
 class FirstFragment : Fragment() {
   val crashlytics = FirebaseCrashlytics.getInstance()
   val performance = FirebasePerformance.getInstance()
-  var performanceTrace: PerfTrace?  = null
-  var performanceTraceIdenticalName: PerfTrace? = null
 
   private var _binding: FragmentFirstBinding? = null
 
@@ -70,16 +71,12 @@ class FirstFragment : Fragment() {
       }
     }
     binding.createTrace.setOnClickListener {
-      performanceTrace = performance.newTrace("test_trace")
-      performanceTraceIdenticalName = performance.newTrace("test_trace")
-    }
-    binding.startTrace.setOnClickListener {
-      performanceTrace?.start()
-      performanceTraceIdenticalName?.start()
-    }
-    binding.stopTrace.setOnClickListener {
-      performanceTrace?.stop()
-      performanceTraceIdenticalName?.stop()
+      viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+        val performanceTrace = performance.newTrace("test_trace")
+        performanceTrace.start()
+        delay(1000)
+        performanceTrace.stop()
+      }
     }
     binding.buttonForegroundProcess.setOnClickListener {
       if (binding.buttonForegroundProcess.getText().startsWith("Start")) {

--- a/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/SecondActivity.kt
+++ b/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/SecondActivity.kt
@@ -22,10 +22,13 @@ import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.os.Build
 import android.os.Bundle
 import android.widget.Button
+import androidx.lifecycle.lifecycleScope
+import com.google.firebase.perf.FirebasePerformance
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 /** Second activity from the MainActivity that runs on a different process. */
 class SecondActivity : BaseActivity() {
-
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_second)
@@ -37,6 +40,15 @@ class SecondActivity : BaseActivity() {
     }
     findViewById<Button>(R.id.second_crash_button).setOnClickListener {
       throw IllegalStateException("SecondActivity has crashed")
+    }
+    findViewById<Button>(R.id.second_create_trace).setOnClickListener {
+      lifecycleScope.launch {
+        val performanceTrace = FirebasePerformance.getInstance().newTrace("test_trace")
+        performanceTrace.start()
+        delay(1000)
+        performanceTrace.stop()
+      }
+
     }
     findViewById<Button>(R.id.kill_background_processes).setOnClickListener {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {

--- a/firebase-sessions/test-app/src/main/res/layout/activity_second.xml
+++ b/firebase-sessions/test-app/src/main/res/layout/activity_second.xml
@@ -39,6 +39,14 @@
     app:layout_constraintLeft_toLeftOf="parent" />
 
   <Button
+      android:id="@+id/second_create_trace"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/create_trace"
+      app:layout_constraintTop_toBottomOf="@id/second_crash_button"
+      app:layout_constraintLeft_toLeftOf="parent" />
+
+  <Button
     android:id="@+id/kill_background_processes"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"

--- a/firebase-sessions/test-app/src/main/res/layout/fragment_first.xml
+++ b/firebase-sessions/test-app/src/main/res/layout/fragment_first.xml
@@ -56,22 +56,6 @@
         app:layout_constraintTop_toBottomOf="@id/button_anr" />
 
     <Button
-        android:id="@+id/start_trace"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/start_trace"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/button_anr" />
-
-    <Button
-        android:id="@+id/stop_trace"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/stop_trace"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/start_trace" />
-
-    <Button
         android:id="@+id/button_foreground_process"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/firebase-sessions/test-app/src/main/res/layout/fragment_first.xml
+++ b/firebase-sessions/test-app/src/main/res/layout/fragment_first.xml
@@ -48,6 +48,30 @@
         app:layout_constraintTop_toBottomOf="@id/button_non_fatal" />
 
     <Button
+        android:id="@+id/create_trace"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/create_trace"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/button_anr" />
+
+    <Button
+        android:id="@+id/start_trace"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/start_trace"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/button_anr" />
+
+    <Button
+        android:id="@+id/stop_trace"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/stop_trace"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/start_trace" />
+
+    <Button
         android:id="@+id/button_foreground_process"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/firebase-sessions/test-app/src/main/res/values/strings.xml
+++ b/firebase-sessions/test-app/src/main/res/values/strings.xml
@@ -23,6 +23,9 @@
   <string name="crash_button_text">Crash!</string>
   <string name="non_fatal_button_text">Non Fatal</string>
   <string name="button_anr_text">ANR</string>
+  <string name="create_trace">Create New Trace: test_trace</string>
+  <string name="start_trace">Start Trace: test_trace</string>
+  <string name="stop_trace">Stop Trace: test_trace</string>
   <string name="start_foreground_service_text">Start Foreground Service</string>
   <string name="start_splitcreen_text">Start splitscreen - Different activity</string>
   <string name="start_splitcreen_same_text">Start splitscreen - Same activity</string>

--- a/firebase-sessions/test-app/src/main/res/values/strings.xml
+++ b/firebase-sessions/test-app/src/main/res/values/strings.xml
@@ -24,8 +24,6 @@
   <string name="non_fatal_button_text">Non Fatal</string>
   <string name="button_anr_text">ANR</string>
   <string name="create_trace">Create New Trace: test_trace</string>
-  <string name="start_trace">Start Trace: test_trace</string>
-  <string name="stop_trace">Stop Trace: test_trace</string>
   <string name="start_foreground_service_text">Start Foreground Service</string>
   <string name="start_splitcreen_text">Start splitscreen - Different activity</string>
   <string name="start_splitcreen_same_text">Start splitscreen - Same activity</string>

--- a/firebase-sessions/test-app/test-app.gradle.kts
+++ b/firebase-sessions/test-app/test-app.gradle.kts
@@ -84,6 +84,8 @@ dependencies {
   implementation("androidx.navigation:navigation-fragment-ktx:2.4.1")
   implementation("androidx.navigation:navigation-ui-ktx:2.4.1")
   implementation("com.google.android.material:material:1.9.0")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9")
+  implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.4.0")
   implementation(libs.androidx.core)
 
   androidTestImplementation("com.google.firebase:firebase-common:21.0.0")


### PR DESCRIPTION
This change adds a way to repeatedly log identical performance traces.