### PR TITLE
Fix startup check failures

### DIFF
--- a/health-metrics/benchmark/template/app/build.gradle.mustache
+++ b/health-metrics/benchmark/template/app/build.gradle.mustache
@@ -21,14 +21,14 @@ plugins {
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 34
 
     namespace "com.google.firebase.benchmark"
 
     defaultConfig {
         applicationId 'com.google.firebase.benchmark'
         minSdkVersion 29
-        targetSdkVersion 32
+        targetSdkVersion 34
         versionCode 1
         versionName '1.0'
 

--- a/health-metrics/benchmark/template/macrobenchmark/build.gradle
+++ b/health-metrics/benchmark/template/macrobenchmark/build.gradle
@@ -33,7 +33,7 @@ android {
 
     defaultConfig {
         minSdk 29
-        targetSdk 32
+        targetSdk 34
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }


### PR DESCRIPTION
Per [b/407077784](https://b.corp.google.com/issues/407077784),

This bumps the `compileSdkVersion` and `targetSdkVersion` within our health metrics test app and benchmarks to match what our SDKs actually use. This also fixes the issue with our startup checks failing due to certain SDK dependencies requiring a higher compile target.