### PR TITLE
dataconnect: github actions cache key fix

### DIFF
--- a/.github/workflows/dataconnect.yml
+++ b/.github/workflows/dataconnect.yml
@@ -27,8 +27,6 @@ env:
   FDC_FIREBASE_TOOLS_VERSION: ${{ inputs.firebaseToolsVersion || '13.29.1' }}
   FDC_FIREBASE_TOOLS_DIR: /tmp/firebase-tools
   FDC_FIREBASE_COMMAND: /tmp/firebase-tools/node_modules/.bin/firebase
-  FDC_GRADLE_CACHE_KEY: gradle-cache-jqnvfzw6w7-${{ github.run_id }}
-  FDC_AVD_CACHE_KEY: avd-cache-zhdsn586je-api${{ env.FDC_ANDROID_EMULATOR_API_LEVEL }}-${{ github.run_id }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -81,7 +79,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ env.FDC_GRADLE_CACHE_KEY }}
+          key: gradle-cache-jqnvfzw6w7-${{ github.run_id }}
           restore-keys: |
             gradle-cache-jqnvfzw6w7-
 
@@ -124,7 +122,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ env.FDC_GRADLE_CACHE_KEY }}
+          key: gradle-cache-jqnvfzw6w7-${{ github.run_id }}
 
       - name: Enable KVM group permissions for Android Emulator
         run: |
@@ -140,7 +138,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: ${{ env.FDC_AVD_CACHE_KEY }}
+          key: avd-cache-zhdsn586je-api${{ env.FDC_ANDROID_EMULATOR_API_LEVEL }}-${{ github.run_id }}
           restore-keys: |
             avd-cache-zhdsn586je-api${{ env.FDC_ANDROID_EMULATOR_API_LEVEL }}-
 
@@ -161,7 +159,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: ${{ env.FDC_AVD_CACHE_KEY }}
+          key: avd-cache-zhdsn586je-api${{ env.FDC_ANDROID_EMULATOR_API_LEVEL }}-${{ github.run_id }}
 
       - name: Data Connect Emulator
         run: |

--- a/.github/workflows/dataconnect.yml
+++ b/.github/workflows/dataconnect.yml
@@ -27,6 +27,8 @@ env:
   FDC_FIREBASE_TOOLS_VERSION: ${{ inputs.firebaseToolsVersion || '13.29.1' }}
   FDC_FIREBASE_TOOLS_DIR: /tmp/firebase-tools
   FDC_FIREBASE_COMMAND: /tmp/firebase-tools/node_modules/.bin/firebase
+  FDC_GRADLE_CACHE_KEY: gradle-cache-jqnvfzw6w7-${{ github.run_id }}
+  FDC_AVD_CACHE_KEY: avd-cache-zhdsn586je-api${{ env.FDC_ANDROID_EMULATOR_API_LEVEL }}-${{ github.run_id }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -80,7 +82,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: gradle-cache-jqnvfzw6w7-${{ github.run_id }}
+          key: ${{ env.FDC_GRADLE_CACHE_KEY }}
           restore-keys: |
             gradle-cache-jqnvfzw6w7-
 
@@ -124,7 +126,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ steps.restore-gradle-cache.outputs.cache-primary-key }}
+          key: ${{ env.FDC_GRADLE_CACHE_KEY }}
 
       - name: Enable KVM group permissions for Android Emulator
         run: |
@@ -141,7 +143,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-cache-zhdsn586je-api${{ env.FDC_ANDROID_EMULATOR_API_LEVEL }}-${{ github.run_id }}
+          key: ${{ env.FDC_AVD_CACHE_KEY }}
           restore-keys: |
             avd-cache-zhdsn586je-api${{ env.FDC_ANDROID_EMULATOR_API_LEVEL }}-
 
@@ -163,7 +165,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: ${{ steps.restore-avd-cache.outputs.cache-primary-key }}
+          key: ${{ env.FDC_AVD_CACHE_KEY }}
 
       - name: Data Connect Emulator
         run: |

--- a/.github/workflows/dataconnect.yml
+++ b/.github/workflows/dataconnect.yml
@@ -154,7 +154,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: echo "Generated AVD snapshot for caching: event_name=${{ github.event_name }}, cache-matched-key=${{ steps.restore-avd-cache.outputs.cache-matched-key }}"
+          script: 'echo "Generated AVD snapshot for caching: event_name=${{ github.event_name }}, cache-matched-key=${{ steps.restore-avd-cache.outputs.cache-matched-key }}"'
 
       - name: Save AVD cache
         uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # 4.2.2

--- a/.github/workflows/dataconnect.yml
+++ b/.github/workflows/dataconnect.yml
@@ -146,7 +146,7 @@ jobs:
             avd-cache-zhdsn586je-api${{ env.FDC_ANDROID_EMULATOR_API_LEVEL }}-
 
       - name: Create AVD
-        if: github.event_name == 'schedule' || steps.restore-avd-cache.outputs.cache-matched-key != ''
+        if: github.event_name == 'schedule' || steps.restore-avd-cache.outputs.cache-matched-key == ''
         uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d #v2.33.0
         with:
           api-level: ${{ env.FDC_ANDROID_EMULATOR_API_LEVEL }}
@@ -154,7 +154,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: 'echo "Generated AVD snapshot for caching: event_name=${{ github.event_name }}, cache-matched-key=${{ steps.restore-avd-cache.outputs.cache-matched-key }}"'
+          script: 'echo "Generated AVD snapshot for caching; event_name=${{ github.event_name }}, cache-matched-key=${{ steps.restore-avd-cache.outputs.cache-matched-key }}"'
 
       - name: Save AVD cache
         uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # 4.2.2

--- a/.github/workflows/dataconnect.yml
+++ b/.github/workflows/dataconnect.yml
@@ -146,7 +146,7 @@ jobs:
             avd-cache-zhdsn586je-api${{ env.FDC_ANDROID_EMULATOR_API_LEVEL }}-
 
       - name: Create AVD
-        if: github.event_name == 'schedule' || steps.restore-avd-cache.outputs.cache-hit != 'true'
+        if: github.event_name == 'schedule' || steps.restore-avd-cache.outputs.cache-matched-key != ''
         uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d #v2.33.0
         with:
           api-level: ${{ env.FDC_ANDROID_EMULATOR_API_LEVEL }}
@@ -154,7 +154,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: echo "Generated AVD snapshot for caching."
+          script: echo "Generated AVD snapshot for caching: event_name=${{ github.event_name }}, cache-matched-key=${{ steps.restore-avd-cache.outputs.cache-matched-key }}"
 
       - name: Save AVD cache
         uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # 4.2.2

--- a/.github/workflows/dataconnect.yml
+++ b/.github/workflows/dataconnect.yml
@@ -75,6 +75,7 @@ jobs:
       - name: Restore Gradle cache
         id: restore-gradle-cache
         uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # 4.2.2
+        if: github.event_name != 'schedule'
         with:
           path: |
             ~/.gradle/caches
@@ -118,6 +119,7 @@ jobs:
 
       - name: Save Gradle cache
         uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # 4.2.2
+        if: github.event_name == 'schedule'
         with:
           path: |
             ~/.gradle/caches
@@ -133,6 +135,7 @@ jobs:
 
       - name: Restore AVD cache
         uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # 4.2.2
+        if: github.event_name != 'schedule'
         id: restore-avd-cache
         with:
           path: |
@@ -143,7 +146,7 @@ jobs:
             avd-cache-zhdsn586je-api${{ env.FDC_ANDROID_EMULATOR_API_LEVEL }}-
 
       - name: Create AVD
-        if: steps.restore-avd-cache.outputs.cache-hit != 'true'
+        if: github.event_name == 'schedule' || steps.restore-avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d #v2.33.0
         with:
           api-level: ${{ env.FDC_ANDROID_EMULATOR_API_LEVEL }}
@@ -155,6 +158,7 @@ jobs:
 
       - name: Save AVD cache
         uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # 4.2.2
+        if: github.event_name == 'schedule'
         with:
           path: |
             ~/.android/avd/*

--- a/.github/workflows/dataconnect.yml
+++ b/.github/workflows/dataconnect.yml
@@ -77,7 +77,6 @@ jobs:
       - name: Restore Gradle cache
         id: restore-gradle-cache
         uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # 4.2.2
-        if: github.event_name != 'schedule'
         with:
           path: |
             ~/.gradle/caches
@@ -121,7 +120,6 @@ jobs:
 
       - name: Save Gradle cache
         uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # 4.2.2
-        if: github.event_name == 'schedule'
         with:
           path: |
             ~/.gradle/caches
@@ -137,7 +135,6 @@ jobs:
 
       - name: Restore AVD cache
         uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # 4.2.2
-        if: github.event_name != 'schedule'
         id: restore-avd-cache
         with:
           path: |
@@ -148,7 +145,7 @@ jobs:
             avd-cache-zhdsn586je-api${{ env.FDC_ANDROID_EMULATOR_API_LEVEL }}-
 
       - name: Create AVD
-        if: github.event_name == 'schedule' || steps.restore-avd-cache.outputs.cache-hit != 'true'
+        if: steps.restore-avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d #v2.33.0
         with:
           api-level: ${{ env.FDC_ANDROID_EMULATOR_API_LEVEL }}
@@ -160,7 +157,6 @@ jobs:
 
       - name: Save AVD cache
         uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # 4.2.2
-        if: github.event_name == 'schedule'
         with:
           path: |
             ~/.android/avd/*


### PR DESCRIPTION
This fixes the "Warning: Key is not specified" warning in the scheduled nightly runs in the "Save Gradle cache" and "Save AVD cache" steps of the dataconnect github actions workflow. The problem was that it was defining the key as `${{ steps.restore-gradle-cache.outputs.cache-primary-key }}` and `${{ steps.restore-avd-cache.outputs.cache-primary-key }}`, respectively, but since those dependent steps were explicitly _skipped_ in nightly runs their outputs were not defined.