### PR TITLE
convert perf session to use aqs support session id

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformance.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformance.java
@@ -34,6 +34,7 @@ import com.google.firebase.perf.config.ConfigResolver;
 import com.google.firebase.perf.config.RemoteConfigManager;
 import com.google.firebase.perf.logging.AndroidLogger;
 import com.google.firebase.perf.logging.ConsoleUrlGenerator;
+import com.google.firebase.perf.logging.DebugEnforcementCheck;
 import com.google.firebase.perf.metrics.HttpMetric;
 import com.google.firebase.perf.metrics.Trace;
 import com.google.firebase.perf.session.FirebasePerformanceSessionSubscriber;
@@ -43,6 +44,7 @@ import com.google.firebase.perf.util.Constants;
 import com.google.firebase.perf.util.ImmutableBundle;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.remoteconfig.RemoteConfigComponent;
+import com.google.firebase.sessions.BuildConfig;
 import com.google.firebase.sessions.api.FirebaseSessionsDependencies;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -169,6 +171,7 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
       this.mMetadataBundle = new ImmutableBundle(new Bundle());
       return;
     }
+    DebugEnforcementCheck.setEnforcement(BuildConfig.DEBUG);
 
     TransportManager.getInstance()
         .initialize(firebaseApp, firebaseInstallationsApi, transportFactoryProvider);

--- a/firebase-perf/src/main/java/com/google/firebase/perf/logging/DebugEnforcementCheck.kt
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/logging/DebugEnforcementCheck.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.perf.logging
+
+class DebugEnforcementCheck {
+  companion object {
+    /** When enabled, failed preconditions will cause assertion errors for debugging. */
+    @JvmStatic var enforcement: Boolean = false
+    private var logger: AndroidLogger = AndroidLogger.getInstance()
+
+    public fun checkSession(isAqsAvailable: Boolean, failureMessage: String) {
+      if (!isAqsAvailable) {
+        Companion.logger.debug(failureMessage)
+        assert(!enforcement) { failureMessage }
+      }
+    }
+  }
+}

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/FirebasePerformanceSessionSubscriber.kt
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/FirebasePerformanceSessionSubscriber.kt
@@ -30,17 +30,15 @@ class FirebasePerformanceSessionSubscriber(override val isDataCollectionEnabled:
     val currentPerfSession = SessionManager.getInstance().perfSession()
 
     // A [PerfSession] was created before a session was started.
-    if (currentPerfSession.aqsSessionId() == null) {
-      currentPerfSession.setAQSId(sessionDetails)
+    if (!currentPerfSession.isAqsReady) {
       GaugeManager.getInstance()
-        .logGaugeMetadata(currentPerfSession.aqsSessionId(), ApplicationProcessState.FOREGROUND)
+        .logGaugeMetadata(currentPerfSession.sessionId(), ApplicationProcessState.FOREGROUND)
       return
     }
 
     val updatedSession = PerfSession.createWithId(UUID.randomUUID().toString())
-    updatedSession.setAQSId(sessionDetails)
     SessionManager.getInstance().updatePerfSession(updatedSession)
     GaugeManager.getInstance()
-      .logGaugeMetadata(updatedSession.aqsSessionId(), ApplicationProcessState.FOREGROUND)
+      .logGaugeMetadata(updatedSession.sessionId(), ApplicationProcessState.FOREGROUND)
   }
 }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
@@ -23,34 +23,40 @@ import com.google.firebase.perf.config.ConfigResolver;
 import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.perf.v1.SessionVerbosity;
-import com.google.firebase.sessions.api.SessionSubscriber;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 /** Details of a session including a unique Id and related information. */
 public class PerfSession implements Parcelable {
-
-  private final String sessionId;
   private final Timer creationTime;
-  @Nullable private String aqsSessionId;
-
+  private final String sessionId;
   private boolean isGaugeAndEventCollectionEnabled = false;
+  public final boolean isAqsReady;
 
   /*
    * Creates a PerfSession object and decides what metrics to collect.
    */
-  public static PerfSession createWithId(@NonNull String sessionId) {
-    String prunedSessionId = sessionId.replace("-", "");
-    PerfSession session = new PerfSession(prunedSessionId, new Clock());
-    session.setGaugeAndEventCollectionEnabled(shouldCollectGaugesAndEvents());
-
+  public static PerfSession createWithId(@Nullable String aqsSessionId) {
+    String sessionId;
+    Boolean isAqsReady;
+    if (aqsSessionId != null) {
+      sessionId = aqsSessionId;
+      isAqsReady = true;
+    } else {
+      sessionId = UUID.randomUUID().toString().replace("-", "");
+      isAqsReady = false;
+    }
+    PerfSession session = new PerfSession(sessionId, new Clock(), isAqsReady);
+    session.setGaugeAndEventCollectionEnabled(shouldCollectGaugesAndEvents(sessionId));
     return session;
   }
 
   /** Creates a PerfSession with the provided {@code sessionId} and {@code clock}. */
   @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
-  public PerfSession(String sessionId, Clock clock) {
+  public PerfSession(String sessionId, Clock clock, boolean isAqsReady) {
     this.sessionId = sessionId;
+    this.isAqsReady = isAqsReady;
     creationTime = clock.getTime();
   }
 
@@ -58,25 +64,13 @@ public class PerfSession implements Parcelable {
     super();
     sessionId = in.readString();
     isGaugeAndEventCollectionEnabled = in.readByte() != 0;
+    isAqsReady = in.readByte() != 0;
     creationTime = in.readParcelable(Timer.class.getClassLoader());
   }
 
-  /** Returns the sessionId of the session. */
+  /** Returns the sessionId for the given session. */
   public String sessionId() {
     return sessionId;
-  }
-
-  /** Returns the AQS sessionId for the given session. */
-  @Nullable
-  public String aqsSessionId() {
-    return aqsSessionId;
-  }
-
-  /** Sets the AQS sessionId for the given session. */
-  public void setAQSId(SessionSubscriber.SessionDetails aqs) {
-    if (aqsSessionId == null) {
-      aqsSessionId = aqs.getSessionId();
-    }
   }
 
   /**
@@ -105,18 +99,6 @@ public class PerfSession implements Parcelable {
     return isGaugeAndEventCollectionEnabled;
   }
 
-  /** Checks if the current {@link com.google.firebase.perf.v1.PerfSession} is verbose or not. */
-  @VisibleForTesting
-  static boolean isVerbose(@NonNull com.google.firebase.perf.v1.PerfSession perfSession) {
-    for (SessionVerbosity sessionVerbosity : perfSession.getSessionVerbosityList()) {
-      if (sessionVerbosity == SessionVerbosity.GAUGES_AND_SYSTEM_EVENTS) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
   /**
    * Checks if it has been more than {@link ConfigResolver#getSessionsMaxDurationMinutes()} time
    * since the creation time of the current session.
@@ -128,7 +110,6 @@ public class PerfSession implements Parcelable {
 
   /** Creates and returns the proto object for PerfSession object. */
   public com.google.firebase.perf.v1.PerfSession build() {
-    // TODO(b/394127311): Switch to using AQS.
     com.google.firebase.perf.v1.PerfSession.Builder sessionMetric =
         com.google.firebase.perf.v1.PerfSession.newBuilder().setSessionId(sessionId);
 
@@ -179,11 +160,10 @@ public class PerfSession implements Parcelable {
   }
 
   /** If true, Session Gauge collection is enabled. */
-  public static boolean shouldCollectGaugesAndEvents() {
+  public static boolean shouldCollectGaugesAndEvents(String sessionId) {
     ConfigResolver configResolver = ConfigResolver.getInstance();
-
     return configResolver.isPerformanceMonitoringEnabled()
-        && Math.random() < configResolver.getSessionsSamplingRate();
+        && (Math.abs(sessionId.hashCode() % 100) < configResolver.getSessionsSamplingRate() * 100);
   }
 
   /**
@@ -207,6 +187,7 @@ public class PerfSession implements Parcelable {
   public void writeToParcel(@NonNull Parcel out, int flags) {
     out.writeString(sessionId);
     out.writeByte((byte) (isGaugeAndEventCollectionEnabled ? 1 : 0));
+    out.writeByte((byte) (isAqsReady ? 1 : 0));
     out.writeParcelable(creationTime, 0);
   }
 
@@ -224,4 +205,16 @@ public class PerfSession implements Parcelable {
           return new PerfSession[size];
         }
       };
+
+  /** Checks if the current {@link com.google.firebase.perf.v1.PerfSession} is verbose or not. */
+  @VisibleForTesting
+  static boolean isVerbose(@NonNull com.google.firebase.perf.v1.PerfSession perfSession) {
+    for (SessionVerbosity sessionVerbosity : perfSession.getSessionVerbosityList()) {
+      if (sessionVerbosity == SessionVerbosity.GAUGES_AND_SYSTEM_EVENTS) {
+        return true;
+      }
+    }
+
+    return false;
+  }
 }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/application/AppStateMonitorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/application/AppStateMonitorTest.java
@@ -39,6 +39,8 @@ import com.google.firebase.perf.config.ConfigResolver;
 import com.google.firebase.perf.config.DeviceCacheManager;
 import com.google.firebase.perf.metrics.NetworkRequestMetricBuilder;
 import com.google.firebase.perf.metrics.Trace;
+import com.google.firebase.perf.session.PerfSession;
+import com.google.firebase.perf.session.SessionManager;
 import com.google.firebase.perf.session.gauges.GaugeManager;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.util.Clock;
@@ -80,6 +82,7 @@ public class AppStateMonitorTest extends FirebasePerformanceTestBase {
   @Before
   public void setUp() {
     currentTime = 0;
+    SessionManager.getInstance().updatePerfSession(PerfSession.createWithId("sessionId"));
     initMocks(this);
     doAnswer((Answer<Timer>) invocationOnMock -> new Timer(currentTime)).when(clock).getTime();
 

--- a/firebase-perf/src/test/java/com/google/firebase/perf/session/PerfSessionTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/session/PerfSessionTest.java
@@ -62,7 +62,7 @@ public class PerfSessionTest extends FirebasePerformanceTestBase {
 
   @Test
   public void instanceCreation() {
-    PerfSession session = new PerfSession("sessionId", mockClock);
+    PerfSession session = new PerfSession("sessionId", mockClock, true);
     assertThat(session).isNotNull();
     session.setGaugeAndEventCollectionEnabled(true);
     Assert.assertTrue(session.isGaugeAndEventCollectionEnabled());
@@ -78,17 +78,17 @@ public class PerfSessionTest extends FirebasePerformanceTestBase {
     configResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
     // By default, session is verbose if developer has set 100% of session verbosity.
-    assertThat(PerfSession.shouldCollectGaugesAndEvents()).isTrue();
+    assertThat(PerfSession.shouldCollectGaugesAndEvents("sessionId")).isTrue();
 
     // Case #1: developer has disabled Performance Monitoring during runtime.
     configResolver.setIsPerformanceCollectionEnabled(false);
 
-    assertThat(PerfSession.shouldCollectGaugesAndEvents()).isFalse();
+    assertThat(PerfSession.shouldCollectGaugesAndEvents("sessionId")).isFalse();
 
     // Case #2: developer has enabled Performance Monitoring during runtime.
     configResolver.setIsPerformanceCollectionEnabled(true);
 
-    assertThat(PerfSession.shouldCollectGaugesAndEvents()).isTrue();
+    assertThat(PerfSession.shouldCollectGaugesAndEvents("sessionId")).isTrue();
   }
 
   @Test
@@ -102,17 +102,17 @@ public class PerfSessionTest extends FirebasePerformanceTestBase {
 
     // By default, session is not verbose if developer disabled performance monitoring at build
     // time.
-    assertThat(PerfSession.shouldCollectGaugesAndEvents()).isFalse();
+    assertThat(PerfSession.shouldCollectGaugesAndEvents("sessionId")).isFalse();
 
     // Case #1: developer has enabled Performance Monitoring during runtime.
     configResolver.setIsPerformanceCollectionEnabled(true);
 
-    assertThat(PerfSession.shouldCollectGaugesAndEvents()).isTrue();
+    assertThat(PerfSession.shouldCollectGaugesAndEvents("sessionId")).isTrue();
 
     // Case #2: developer has disabled Performance Monitoring during runtime.
     configResolver.setIsPerformanceCollectionEnabled(false);
 
-    assertThat(PerfSession.shouldCollectGaugesAndEvents()).isFalse();
+    assertThat(PerfSession.shouldCollectGaugesAndEvents("sessionId")).isFalse();
   }
 
   @Test
@@ -124,22 +124,22 @@ public class PerfSessionTest extends FirebasePerformanceTestBase {
     configResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
     // Session will never be verbose if developer deactivated performance monitoring at build time.
-    assertThat(PerfSession.shouldCollectGaugesAndEvents()).isFalse();
+    assertThat(PerfSession.shouldCollectGaugesAndEvents("sessionId")).isFalse();
 
     // Case #1: developer has enabled Performance Monitoring during runtime.
     configResolver.setIsPerformanceCollectionEnabled(true);
 
-    assertThat(PerfSession.shouldCollectGaugesAndEvents()).isFalse();
+    assertThat(PerfSession.shouldCollectGaugesAndEvents("sessionId")).isFalse();
 
     // Case #2: developer has disabled Performance Monitoring during runtime.
     configResolver.setIsPerformanceCollectionEnabled(false);
 
-    assertThat(PerfSession.shouldCollectGaugesAndEvents()).isFalse();
+    assertThat(PerfSession.shouldCollectGaugesAndEvents("sessionId")).isFalse();
   }
 
   @Test
   public void testPerfSessionConversion() {
-    PerfSession session1 = new PerfSession("sessionId", mockClock);
+    PerfSession session1 = new PerfSession("sessionId", mockClock, true);
     session1.setGaugeAndEventCollectionEnabled(true);
 
     com.google.firebase.perf.v1.PerfSession perfSession = session1.build();
@@ -150,7 +150,7 @@ public class PerfSessionTest extends FirebasePerformanceTestBase {
 
   @Test
   public void testPerfSessionConversionWithoutVerbosity() {
-    PerfSession session1 = new PerfSession("sessionId", mockClock);
+    PerfSession session1 = new PerfSession("sessionId", mockClock, true);
 
     com.google.firebase.perf.v1.PerfSession perfSession = session1.build();
     Assert.assertEquals(session1.sessionId(), perfSession.getSessionId());
@@ -216,7 +216,7 @@ public class PerfSessionTest extends FirebasePerformanceTestBase {
                 - TimeUnit.MINUTES.toMicros(1)); // Default Max Session Length is 4 hours
     when(mockClock.getTime()).thenReturn(mockTimer);
 
-    PerfSession session = new PerfSession("sessionId", mockClock);
+    PerfSession session = new PerfSession("sessionId", mockClock, true);
     assertThat(session.isSessionRunningTooLong()).isFalse();
   }
 
@@ -227,7 +227,7 @@ public class PerfSessionTest extends FirebasePerformanceTestBase {
         .thenReturn(TimeUnit.HOURS.toMicros(4)); // Default Max Session Length is 4 hours
     when(mockClock.getTime()).thenReturn(mockTimer);
 
-    PerfSession session = new PerfSession("sessionId", mockClock);
+    PerfSession session = new PerfSession("sessionId", mockClock, true);
     assertThat(session.isSessionRunningTooLong()).isFalse();
   }
 
@@ -238,7 +238,7 @@ public class PerfSessionTest extends FirebasePerformanceTestBase {
         .thenReturn(TimeUnit.HOURS.toMicros(5)); // Default Max Session Length is 4 hours
     when(mockClock.getTime()).thenReturn(mockTimer);
 
-    PerfSession session = new PerfSession("sessionId", mockClock);
+    PerfSession session = new PerfSession("sessionId", mockClock, true);
     assertThat(session.isSessionRunningTooLong()).isTrue();
   }
 }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/session/SessionManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/session/SessionManagerTest.java
@@ -66,7 +66,6 @@ public class SessionManagerTest extends FirebasePerformanceTestBase {
   public void testInstanceCreation() {
     assertThat(SessionManager.getInstance()).isNotNull();
     assertThat(SessionManager.getInstance()).isEqualTo(SessionManager.getInstance());
-    assertThat(SessionManager.getInstance().perfSession().sessionId()).isNotNull();
   }
 
   @Test
@@ -113,7 +112,7 @@ public class SessionManagerTest extends FirebasePerformanceTestBase {
     Timer mockTimer = mock(Timer.class);
     when(mockClock.getTime()).thenReturn(mockTimer);
 
-    PerfSession session = new PerfSession("sessionId", mockClock);
+    PerfSession session = new PerfSession("sessionId", mockClock, true);
     SessionManager testSessionManager =
         new SessionManager(mockGaugeManager, session, mockAppStateMonitor);
 
@@ -132,10 +131,10 @@ public class SessionManagerTest extends FirebasePerformanceTestBase {
     when(mockClock.getTime()).thenReturn(mockTimer);
     when(mockAppStateMonitor.getAppState()).thenReturn(ApplicationProcessState.FOREGROUND);
 
-    PerfSession previousSession = new PerfSession("previousSession", mockClock);
+    PerfSession previousSession = new PerfSession("previousSession", mockClock, true);
     previousSession.setGaugeAndEventCollectionEnabled(false);
 
-    PerfSession newSession = new PerfSession("newSession", mockClock);
+    PerfSession newSession = new PerfSession("newSession", mockClock, true);
     newSession.setGaugeAndEventCollectionEnabled(true);
 
     SessionManager testSessionManager =

--- a/firebase-perf/src/test/java/com/google/firebase/perf/session/gauges/GaugeManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/session/gauges/GaugeManagerTest.java
@@ -124,7 +124,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
 
   @Test
   public void testStartCollectingGaugesStartsCollectingMetricsInBackgroundState() {
-    PerfSession fakeSession = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(fakeSession, ApplicationProcessState.BACKGROUND);
     verify(fakeCpuGaugeCollector)
         .startCollecting(
@@ -138,7 +138,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
 
   @Test
   public void testStartCollectingGaugesStartsCollectingMetricsInForegroundState() {
-    PerfSession fakeSession = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(fakeSession, ApplicationProcessState.FOREGROUND);
     verify(fakeCpuGaugeCollector)
         .startCollecting(
@@ -153,7 +153,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
   @Test
   public void
       testStartCollectingGaugesDoesNotStartCollectingMetricsWithUnknownApplicationProcessState() {
-    PerfSession fakeSession = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(
         fakeSession, ApplicationProcessState.APPLICATION_PROCESS_STATE_UNKNOWN);
     verify(fakeCpuGaugeCollector, never())
@@ -167,7 +167,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
       stopCollectingCPUMetric_invalidCPUCaptureFrequency_OtherMetricsWithValidFrequencyInBackground() {
     // PASS 1: Test with 0
     doReturn(0L).when(mockConfigResolver).getSessionsCpuCaptureFrequencyBackgroundMs();
-    PerfSession fakeSession1 = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession1 = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(fakeSession1, ApplicationProcessState.BACKGROUND);
 
     // Verify that Cpu metric collection is not started
@@ -180,7 +180,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
 
     // PASS 2: Test with -ve value
     doReturn(-25L).when(mockConfigResolver).getSessionsCpuCaptureFrequencyBackgroundMs();
-    PerfSession fakeSession2 = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession2 = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(fakeSession2, ApplicationProcessState.BACKGROUND);
 
     // Verify that Cpu metric collection is not started
@@ -197,7 +197,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
       startCollectingGaugesOnBackground_invalidMemoryCaptureMs_onlyDisableMemoryCollection() {
     // PASS 1: Test with 0
     doReturn(0L).when(mockConfigResolver).getSessionsMemoryCaptureFrequencyBackgroundMs();
-    PerfSession fakeSession1 = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession1 = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(fakeSession1, ApplicationProcessState.BACKGROUND);
 
     // Verify that Memory metric collection is not started
@@ -210,7 +210,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
 
     // PASS 2: Test with -ve value
     doReturn(-25L).when(mockConfigResolver).getSessionsMemoryCaptureFrequencyBackgroundMs();
-    PerfSession fakeSession2 = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession2 = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(fakeSession2, ApplicationProcessState.BACKGROUND);
 
     // Verify that Memory metric collection is not started
@@ -226,7 +226,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
   public void stopCollectingCPUMetric_invalidCPUCaptureFrequency_OtherMetricsWithValidFrequency() {
     // PASS 1: Test with 0
     doReturn(0L).when(mockConfigResolver).getSessionsCpuCaptureFrequencyForegroundMs();
-    PerfSession fakeSession1 = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession1 = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(fakeSession1, ApplicationProcessState.FOREGROUND);
 
     // Verify that Cpu metric collection is not started
@@ -239,7 +239,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
 
     // PASS 2: Test with -ve value
     doReturn(-25L).when(mockConfigResolver).getSessionsCpuCaptureFrequencyForegroundMs();
-    PerfSession fakeSession2 = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession2 = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(fakeSession2, ApplicationProcessState.FOREGROUND);
 
     // Verify that Cpu metric collection is not started
@@ -256,7 +256,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
       startCollectingGaugesOnForeground_invalidMemoryCaptureMs_onlyDisableMemoryCollection() {
     // PASS 1: Test with 0
     doReturn(0L).when(mockConfigResolver).getSessionsMemoryCaptureFrequencyForegroundMs();
-    PerfSession fakeSession1 = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession1 = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(fakeSession1, ApplicationProcessState.FOREGROUND);
 
     // Verify that Memory metric collection is not started
@@ -269,7 +269,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
 
     // PASS 2: Test with -ve value
     doReturn(-25L).when(mockConfigResolver).getSessionsMemoryCaptureFrequencyForegroundMs();
-    PerfSession fakeSession2 = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession2 = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(fakeSession2, ApplicationProcessState.FOREGROUND);
 
     // Verify that Memory metric collection is not started
@@ -283,7 +283,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
 
   @Test
   public void testStartCollectingGaugesDoesNotStartAJobToConsumeMetricsWithUnknownAppState() {
-    PerfSession fakeSession = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(
         fakeSession, ApplicationProcessState.APPLICATION_PROCESS_STATE_UNKNOWN);
     assertThat(fakeScheduledExecutorService.isEmpty()).isTrue();
@@ -294,14 +294,14 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
     // PASS 1: Test with 0
     doReturn(0L).when(mockConfigResolver).getSessionsCpuCaptureFrequencyForegroundMs();
 
-    PerfSession fakeSession1 = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession1 = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(fakeSession1, ApplicationProcessState.FOREGROUND);
     assertThat(fakeScheduledExecutorService.isEmpty()).isFalse();
 
     // PASS 2: Test with -ve value
     doReturn(-25L).when(mockConfigResolver).getSessionsCpuCaptureFrequencyForegroundMs();
 
-    PerfSession fakeSession2 = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession2 = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(fakeSession2, ApplicationProcessState.FOREGROUND);
     assertThat(fakeScheduledExecutorService.isEmpty()).isFalse();
   }
@@ -311,14 +311,14 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
     // PASS 1: Test with 0
     doReturn(0L).when(mockConfigResolver).getSessionsMemoryCaptureFrequencyForegroundMs();
 
-    PerfSession fakeSession1 = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession1 = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(fakeSession1, ApplicationProcessState.FOREGROUND);
     assertThat(fakeScheduledExecutorService.isEmpty()).isFalse();
 
     // PASS 2: Test with -ve value
     doReturn(-25L).when(mockConfigResolver).getSessionsMemoryCaptureFrequencyForegroundMs();
 
-    PerfSession fakeSession2 = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession2 = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(fakeSession2, ApplicationProcessState.FOREGROUND);
     assertThat(fakeScheduledExecutorService.isEmpty()).isFalse();
   }
@@ -329,7 +329,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
     doReturn(0L).when(mockConfigResolver).getSessionsCpuCaptureFrequencyForegroundMs();
     doReturn(0L).when(mockConfigResolver).getSessionsMemoryCaptureFrequencyForegroundMs();
 
-    PerfSession fakeSession1 = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession1 = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(fakeSession1, ApplicationProcessState.FOREGROUND);
     assertThat(fakeScheduledExecutorService.isEmpty()).isTrue();
 
@@ -337,7 +337,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
     doReturn(-25L).when(mockConfigResolver).getSessionsCpuCaptureFrequencyForegroundMs();
     doReturn(-25L).when(mockConfigResolver).getSessionsMemoryCaptureFrequencyForegroundMs();
 
-    PerfSession fakeSession2 = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession2 = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(fakeSession2, ApplicationProcessState.FOREGROUND);
     assertThat(fakeScheduledExecutorService.isEmpty()).isTrue();
   }
@@ -347,7 +347,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
     doReturn(25L).when(mockConfigResolver).getSessionsCpuCaptureFrequencyForegroundMs();
     doReturn(15L).when(mockConfigResolver).getSessionsMemoryCaptureFrequencyForegroundMs();
 
-    PerfSession fakeSession = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(fakeSession, ApplicationProcessState.FOREGROUND);
 
     assertThat(fakeScheduledExecutorService.isEmpty()).isFalse();
@@ -357,7 +357,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
 
   @Test
   public void testStartCollectingGaugesStartsAJobToConsumeTheGeneratedMetrics() {
-    PerfSession fakeSession = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(fakeSession, ApplicationProcessState.BACKGROUND);
 
     assertThat(fakeScheduledExecutorService.isEmpty()).isFalse();
@@ -391,7 +391,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
 
   @Test
   public void testStopCollectingGaugesStopsCollectingAllGaugeMetrics() {
-    PerfSession fakeSession = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession = new PerfSession("sessionId", new Clock(), true);
 
     testGaugeManager.startCollectingGauges(fakeSession, ApplicationProcessState.BACKGROUND);
     verify(fakeCpuGaugeCollector)
@@ -405,7 +405,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
 
   @Test
   public void testStopCollectingGaugesCreatesOneLastJobToConsumeAnyPendingMetrics() {
-    PerfSession fakeSession = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession = new PerfSession("sessionId", new Clock(), true);
     testGaugeManager.startCollectingGauges(fakeSession, ApplicationProcessState.BACKGROUND);
     assertThat(fakeScheduledExecutorService.isEmpty()).isFalse();
 
@@ -433,7 +433,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
 
   @Test
   public void testGaugeManagerClearsTheQueueEachRun() {
-    PerfSession fakeSession = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession = new PerfSession("sessionId", new Clock(), true);
 
     testGaugeManager.startCollectingGauges(fakeSession, ApplicationProcessState.BACKGROUND);
 
@@ -465,7 +465,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
 
   @Test
   public void testStartingGaugeManagerWithNewSessionIdButSameAppState() {
-    PerfSession fakeSession1 = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession1 = new PerfSession("sessionId", new Clock(), true);
 
     // Start collecting Gauges.
     testGaugeManager.startCollectingGauges(fakeSession1, ApplicationProcessState.BACKGROUND);
@@ -490,7 +490,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
         createFakeAndroidMetricReading(/* currentUsedAppJavaHeapMemoryKb= */ 2345);
     fakeMemoryGaugeCollector.memoryMetricReadings.add(fakeMemoryMetricReading2);
 
-    PerfSession fakeSession2 = new PerfSession("sessionId2", new Clock());
+    PerfSession fakeSession2 = new PerfSession("sessionId2", new Clock(), true);
 
     // Start collecting gauges for new session, but same app state.
     testGaugeManager.startCollectingGauges(fakeSession2, ApplicationProcessState.BACKGROUND);
@@ -523,7 +523,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
 
   @Test
   public void testStartGaugeManagerWithSameSessionIdButDifferentAppState() {
-    PerfSession fakeSession = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession = new PerfSession("sessionId", new Clock(), true);
 
     // Start collecting Gauges.
     testGaugeManager.startCollectingGauges(fakeSession, ApplicationProcessState.BACKGROUND);
@@ -579,7 +579,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
 
   @Test
   public void testStartGaugeManagerWithNewSessionIdAndNewAppState() {
-    PerfSession fakeSession1 = new PerfSession("sessionId", new Clock());
+    PerfSession fakeSession1 = new PerfSession("sessionId", new Clock(), true);
 
     // Start collecting Gauges.
     testGaugeManager.startCollectingGauges(fakeSession1, ApplicationProcessState.BACKGROUND);
@@ -604,7 +604,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
         createFakeAndroidMetricReading(/* currentUsedAppJavaHeapMemoryKb= */ 2345);
     fakeMemoryGaugeCollector.memoryMetricReadings.add(fakeMemoryMetricReading2);
 
-    PerfSession fakeSession2 = new PerfSession("sessionId2", new Clock());
+    PerfSession fakeSession2 = new PerfSession("sessionId2", new Clock(), true);
 
     // Start collecting gauges for new session and new app state
     testGaugeManager.startCollectingGauges(fakeSession2, ApplicationProcessState.FOREGROUND);

--- a/firebase-perf/src/test/java/com/google/firebase/perf/transport/TransportManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/transport/TransportManagerTest.java
@@ -1169,7 +1169,8 @@ public class TransportManagerTest extends FirebasePerformanceTestBase {
     TraceMetric.Builder validTrace = createValidTraceMetric().toBuilder();
     List<PerfSession> perfSessions = new ArrayList<>();
     perfSessions.add(
-        new com.google.firebase.perf.session.PerfSession("fakeSessionId", new Clock()).build());
+        new com.google.firebase.perf.session.PerfSession("fakeSessionId", new Clock(), true)
+            .build());
     validTrace.addAllPerfSessions(perfSessions);
 
     testTransportManager.log(validTrace.build());
@@ -1187,7 +1188,8 @@ public class TransportManagerTest extends FirebasePerformanceTestBase {
         createValidNetworkRequestMetric().toBuilder();
     List<PerfSession> perfSessions = new ArrayList<>();
     perfSessions.add(
-        new com.google.firebase.perf.session.PerfSession("fakeSessionId", new Clock()).build());
+        new com.google.firebase.perf.session.PerfSession("fakeSessionId", new Clock(), true)
+            .build());
     validNetworkRequest.clearPerfSessions().addAllPerfSessions(perfSessions);
 
     testTransportManager.log(validNetworkRequest.build());


### PR DESCRIPTION
- Override PerfSession session id to aqs session id when possible
- Add assertion for debug mode to double check if aqs session id available by the time of use