### PR TITLE
dataconnect: fix two flaky tests due to their failure to wait for FirebaseAuth to be initialized

### DIFF
--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/AuthIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/AuthIntegrationTest.kt
@@ -127,6 +127,7 @@ class AuthIntegrationTest : DataConnectIntegrationTestBase() {
       grpcServer.metadatas.map { it.get(firebaseAuthTokenHeader) }.toCollection(authTokens)
     }
     val dataConnect = dataConnectFactory.newInstance(auth.app, grpcServer)
+    (dataConnect as FirebaseDataConnectInternal).awaitAuthReady()
     val operationName = Arb.dataConnect.operationName().next(rs)
     val queryRef =
       dataConnect.query(operationName, Unit, serializer<TestData>(), serializer<Unit>())
@@ -155,6 +156,7 @@ class AuthIntegrationTest : DataConnectIntegrationTestBase() {
       grpcServer.metadatas.map { it.get(firebaseAuthTokenHeader) }.toCollection(authTokens)
     }
     val dataConnect = dataConnectFactory.newInstance(auth.app, grpcServer)
+    (dataConnect as FirebaseDataConnectInternal).awaitAuthReady()
     val operationName = Arb.dataConnect.operationName().next(rs)
     val mutationRef =
       dataConnect.mutation(operationName, Unit, serializer<TestData>(), serializer<Unit>())


### PR DESCRIPTION
This PR fixes two tests in `AuthIntegrationTest.kt` that would flakily fail: `queryShouldRetryOnUnauthenticated` and `mutationShouldRetryOnUnauthenticated`.

The fix was to ensure that FirebaseAuth was ready in the `FirebaseDataConnect` instance _before_ starting the test. I had thought that the test was _already_ doing this because the `signIn()` method calls `awaitAuthReady()` on a `FirebaseDataConnect` object; however, the test actually used a _different_ `FirebaseDataConnect` object and no call to `awaitAuthReady()` was made on it. As a result, occasionally the query would be executed _before_ FirebaseAuth was ready and in those cases the test would fail. The fix was to simply call `awaitAuthReady()` on the _other_ `FirebaseDataConnect` object that was used by the test to run the query.

Googlers can see b/399689249 for more details.