### PR TITLE
dataconnect: fix flaky test that ensures deserialize() throws IllegalArgumentException on invalid input

### DIFF
--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/serializers/LocalDateSerializerUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/serializers/LocalDateSerializerUnitTest.kt
@@ -101,13 +101,9 @@ class LocalDateSerializerUnitTest {
   @Test
   fun `deserialize() should throw IllegalArgumentException when given unparseable strings`() =
     runTest {
-      val seededPropTestConfig = propTestConfig.copy(seed=-7108070269336260794)
-      checkAll(seededPropTestConfig, Arb.unparseableDate()) { encodedDate ->
+      checkAll(propTestConfig, Arb.unparseableDate()) { encodedDate ->
         val decoder: Decoder = mockk { every { decodeString() } returns encodedDate }
-        shouldThrow<IllegalArgumentException> {
-          val deserializedDate = LocalDateSerializer.deserialize(decoder)
-          println("zzyzx deserializedDate=$deserializedDate")
-        }
+        shouldThrow<IllegalArgumentException> { LocalDateSerializer.deserialize(decoder) }
       }
     }
 
@@ -233,10 +229,7 @@ class LocalDateSerializerUnitTest {
       val unparseableNumber = unparseableNumber()
       val unparseableDash = unparseableDash()
       val booleanArray = booleanArray(Arb.constant(5), Arb.boolean())
-      var count = 0
       return arbitrary(edgecases = listOf("", "-", "--", "---")) { rs ->
-        count++
-        println("count=$count")
         val invalidCharFlags = booleanArray.bind()
         if (invalidCharFlags.count { it } == 0) {
           invalidCharFlags[rs.random.nextInt(invalidCharFlags.indices)] = true


### PR DESCRIPTION
Fix `unparseableDash()` in `LocalDateSerializerUnitTest.kt` to not include numbers in the set of "invalid" characters because they become "valid" when adjacent to other numeric digits. In certain situations, using a "digit" as an invalid character was causing flaky test failures such as this one in `deserialize() should throw IllegalArgumentException when given unparseable strings`:

```
Arg 0: "96-082895-312"

Repeat this test by using seed -7108070269336260794

Caused by: Expected exception java.lang.IllegalArgumentException but no exception was thrown.
	at com.google.firebase.dataconnect.serializers.LocalDateSerializerUnitTest$deserialize() should throw IllegalArgumentException when given unparseable strings$1.invokeSuspend(LocalDateSerializerUnitTest.kt:104)
	at com.google.firebase.dataconnect.serializers.LocalDateSerializerUnitTest$deserialize() should throw IllegalArgumentException when given unparseable strings$1.invoke(LocalDateSerializerUnitTest.kt)
	at com.google.firebase.dataconnect.serializers.LocalDateSerializerUnitTest$deserialize() should throw IllegalArgumentException when given unparseable strings$1.invoke(LocalDateSerializerUnitTest.kt)
```

Note that the string `"96-082895-312"` is 3 valid numbers separated by dashes and, therefore, is successfully parsed as a date. The `"-0"` was the string produced by `unparseableDash()` which, when combined with the rest of the string, did _not_, in fact, produce an unparseable dash.