### PR TITLE
Fix firelog send

### DIFF
--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SharedSessionRepository.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SharedSessionRepository.kt
@@ -90,20 +90,18 @@ constructor(
     Log.d(TAG, "App foregrounded on ${getProcessName()} - $sessionData")
 
     if (shouldInitiateNewSession(sessionData)) {
-      // Generate new session details on main thread so the timestamp is as current as possible
-      val newSessionDetails = sessionGenerator.generateNewSession(sessionData.sessionDetails)
-
       CoroutineScope(backgroundDispatcher).launch {
         sessionDataStore.updateData { currentSessionData ->
           // Double-check pattern
           if (shouldInitiateNewSession(currentSessionData)) {
+            val newSessionDetails = sessionGenerator.generateNewSession(sessionData.sessionDetails)
+            sessionFirelogPublisher.mayLogSession(sessionDetails = newSessionDetails)
             currentSessionData.copy(sessionDetails = newSessionDetails)
           } else {
             currentSessionData
           }
         }
       }
-      sessionFirelogPublisher.mayLogSession(sessionDetails = newSessionDetails)
     }
   }
 


### PR DESCRIPTION
Fix where we generate and send session details to firelog. Before this, we might send false positives to firelog, or even update the session details with a stale copy. Now the session generate and send to firelog happen inside the datastore transform with the data in datastore.