### PR TITLE
fix: remove null value inclusion from `whereNotEqualTo` and `whereNotIn` filter results 

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+* [fixed] Fixed the `null` value handling in `whereNotEqualTo` and `whereNotIn` filters.
 
 # 25.1.3
 * [fixed] Use lazy encoding in UTF-8 encoded byte comparison for strings to solve performance issues. [#6706](//github.com/firebase/firebase-android-sdk/pull/6706)

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
@@ -1655,6 +1655,9 @@ public class QueryTest {
 
     query = collection.whereNotEqualTo("zip", Double.NaN);
     checkOnlineAndOfflineResultsMatch(query, "b", "c", "d", "e", "f", "g", "h");
+
+    query = collection.whereNotEqualTo("zip", null);
+    checkOnlineAndOfflineResultsMatch(query, "a", "b", "c", "d", "e", "f", "g", "h");
   }
 
   @Test

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
@@ -1664,17 +1664,14 @@ public class QueryTest {
             "j", map("code", 500L));
     CollectionReference collection = testCollectionWithDocs(testDocs);
 
-    // populate cache with all documents first to ensure getDocsFromCache() scans all docs
-    waitFor(testCollectionWithDocs(testDocs).get());
-
     Query query = collection.whereNotEqualTo("zip", 98101L);
-    checkOnlineAndOfflineResultsMatch(query, "a", "b", "d", "e", "f", "g", "h");
+    checkOnlineAndOfflineResultsMatch(collection, query, "a", "b", "d", "e", "f", "g", "h");
 
     query = collection.whereNotEqualTo("zip", Double.NaN);
-    checkOnlineAndOfflineResultsMatch(query, "b", "c", "d", "e", "f", "g", "h");
+    checkOnlineAndOfflineResultsMatch(collection, query, "b", "c", "d", "e", "f", "g", "h");
 
     query = collection.whereNotEqualTo("zip", null);
-    checkOnlineAndOfflineResultsMatch(query, "a", "b", "c", "d", "e", "f", "g", "h");
+    checkOnlineAndOfflineResultsMatch(collection, query, "a", "b", "c", "d", "e", "f", "g", "h");
   }
 
   @Test
@@ -1693,13 +1690,10 @@ public class QueryTest {
             "j", map("code", 500L));
     CollectionReference collection = testCollectionWithDocs(testDocs);
 
-    // populate cache with all documents first to ensure getDocsFromCache() scans all docs
-    waitFor(testCollectionWithDocs(testDocs).get());
-
     Query query = collection.whereNotIn("zip", asList(98101L, 98103L, asList(98101L, 98102L)));
-    checkOnlineAndOfflineResultsMatch(query, "a", "b", "d", "e", "g", "h");
+    checkOnlineAndOfflineResultsMatch(collection, query, "a", "b", "d", "e", "g", "h");
 
     query = collection.whereNotIn("zip", nullList());
-    checkOnlineAndOfflineResultsMatch(query);
+    checkOnlineAndOfflineResultsMatch(collection, query);
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FieldFilter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FieldFilter.java
@@ -115,7 +115,9 @@ public class FieldFilter extends Filter {
     Value other = doc.getField(field);
     // Types do not have to match in NOT_EQUAL filters.
     if (operator == Operator.NOT_EQUAL) {
-      return other != null && this.matchesComparison(Values.compare(other, value));
+      return other != null
+          && !other.hasNullValue()
+          && this.matchesComparison(Values.compare(other, value));
     }
     // Only compare types with matching backend order (such as double and int).
     return other != null

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/NotInFilter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/NotInFilter.java
@@ -34,6 +34,8 @@ public class NotInFilter extends FieldFilter {
       return false;
     }
     Value other = doc.getField(getField());
-    return other != null && !Values.contains(getValue().getArrayValue(), other);
+    return other != null
+        && !other.hasNullValue()
+        && !Values.contains(getValue().getArrayValue(), other);
   }
 }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/QueryTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/QueryTest.java
@@ -237,7 +237,7 @@ public class QueryTest {
 
     // Null match.
     document = doc("collection/1", 0, map("zip", null));
-    assertTrue(query.matches(document));
+    assertFalse(query.matches(document));
 
     // NaN match.
     document = doc("collection/1", 0, map("zip", Double.NaN));
@@ -333,7 +333,7 @@ public class QueryTest {
     assertTrue(query.matches(doc3));
     assertTrue(query.matches(doc4));
     assertTrue(query.matches(doc5));
-    assertTrue(query.matches(doc6));
+    assertFalse(query.matches(doc6));
   }
 
   @Test


### PR DESCRIPTION
ported from https://github.com/firebase/firebase-ios-sdk/pull/14704