### PR TITLE
[plugins] Remove JavaPluginConvention from FirebaseJavaLibraryPlugin

### DIFF
--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/FirebaseJavaLibraryPlugin.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/FirebaseJavaLibraryPlugin.kt
@@ -125,7 +125,7 @@ class FirebaseJavaLibraryPlugin : BaseFirebaseLibraryPlugin() {
           .sourceSets
           .getByName("main")
           .java
-          .srcDirs()
+          .srcDirs
       )
 
     val apiInfo = getApiInfo(project, srcDirs)

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/FirebaseJavaLibraryPlugin.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/FirebaseJavaLibraryPlugin.kt
@@ -25,6 +25,7 @@ import org.gradle.api.plugins.JavaLibraryPlugin
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -120,7 +121,7 @@ class FirebaseJavaLibraryPlugin : BaseFirebaseLibraryPlugin() {
     val srcDirs =
       project.files(
         project.extensions
-          .getByType(JavaPluginExtension::class.java)
+          .getByType<JavaPluginExtension>()
           .sourceSets
           .getByName("main")
           .java

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/FirebaseJavaLibraryPlugin.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/FirebaseJavaLibraryPlugin.kt
@@ -22,10 +22,9 @@ import com.google.firebase.gradle.plugins.semver.GmavenCopier
 import org.gradle.api.Project
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.plugins.JavaLibraryPlugin
-import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.create
-import org.gradle.kotlin.dsl.getPlugin
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -120,12 +119,12 @@ class FirebaseJavaLibraryPlugin : BaseFirebaseLibraryPlugin() {
   private fun setupApiInformationAnalysis(project: Project) {
     val srcDirs =
       project.files(
-        project.convention
-          .getPlugin<JavaPluginConvention>()
+        project.extensions
+          .getByType(JavaPluginExtension::class.java)
           .sourceSets
           .getByName("main")
           .java
-          .srcDirs
+          .srcDirs()
       )
 
     val apiInfo = getApiInfo(project, srcDirs)


### PR DESCRIPTION
`JavaPluginConvention` and the use of convetions in general is deprecated and will cause an error when migrated to Gradle 9.0. The recommended replacement is to use extensions.