### PR TITLE
Add write permisison to VertexAI Response Checking task

### DIFF
--- a/.github/workflows/check-vertexai-responses.yml
+++ b/.github/workflows/check-vertexai-responses.yml
@@ -5,7 +5,8 @@ on: pull_request
 jobs:
   check-version:
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Clone mock responses

--- a/.github/workflows/check-vertexai-responses.yml
+++ b/.github/workflows/check-vertexai-responses.yml
@@ -5,6 +5,7 @@ on: pull_request
 jobs:
   check-version:
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Clone mock responses


### PR DESCRIPTION
The task began failing recently likely due to changes in global permissions, this updates the workflow to explicitly have write permissions to make comments.