### PR TITLE
feat: Add responseModalities to GenerationConfig

### DIFF
--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/GenerationConfig.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/GenerationConfig.kt
@@ -157,13 +157,9 @@ private constructor(
       stopSequences = stopSequences,
       frequencyPenalty = frequencyPenalty,
       presencePenalty = presencePenalty,
-        responseMimeType = responseMimeType,
-        responseSchema = responseSchema,
-        responseModalities = responseModalities,
-      )
       responseMimeType = responseMimeType,
       responseSchema = responseSchema?.toInternal(),
-      responseModalities = responseModalities?.map { it.toInternal() }
+      responseModalities = responseModalities?.map { it.toInternal() },
     )
 
   @Serializable

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/GenerationConfig.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/GenerationConfig.kt
@@ -88,6 +88,7 @@ private constructor(
   internal val stopSequences: List<String>?,
   internal val responseMimeType: String?,
   internal val responseSchema: Schema?,
+  internal val responseModalities: List<ResponseModality>?,
 ) {
 
   /**
@@ -128,6 +129,7 @@ private constructor(
     @JvmField public var stopSequences: List<String>? = null
     @JvmField public var responseMimeType: String? = null
     @JvmField public var responseSchema: Schema? = null
+    @JvmField public var responseModalities: List<ResponseModality>? = null
 
     /** Create a new [GenerationConfig] with the attached arguments. */
     public fun build(): GenerationConfig =
@@ -155,8 +157,13 @@ private constructor(
       stopSequences = stopSequences,
       frequencyPenalty = frequencyPenalty,
       presencePenalty = presencePenalty,
+        responseMimeType = responseMimeType,
+        responseSchema = responseSchema,
+        responseModalities = responseModalities,
+      )
       responseMimeType = responseMimeType,
-      responseSchema = responseSchema?.toInternal()
+      responseSchema = responseSchema?.toInternal(),
+      responseModalities = responseModalities?.map { it.toInternal() }
     )
 
   @Serializable
@@ -171,6 +178,7 @@ private constructor(
     @SerialName("presence_penalty") val presencePenalty: Float? = null,
     @SerialName("frequency_penalty") val frequencyPenalty: Float? = null,
     @SerialName("response_schema") val responseSchema: Schema.Internal? = null,
+    @SerialName("response_modalities") val responseModalities: List<String>? = null,
   )
 
   public companion object {


### PR DESCRIPTION
Adds an optional `responseModalities` property to the `GenerationConfig` class. This allows specifying the desired modality types (e.g., TEXT, IMAGE, AUDIO) for the response.

The changes include:
- Adding `responseModalities: List<ResponseModality>?` to the `GenerationConfig` primary constructor.
- Updating the `GenerationConfig.Builder` to include the new property.
- Updating the internal `GenerationConfig.Internal` data class and the `toInternal` mapping for serialization.