### PR TITLE
Handle error when stream was cancelled prior to calling halfClose.

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 * [fixed] Fixed the `null` value handling in `whereNotEqualTo` and `whereNotIn` filters.
+* [fixed] Catch exception when stream is already cancelled during close. [#6894](//github.com/firebase/firebase-android-sdk/pull/6894)
 
 # 25.1.3
 * [fixed] Use lazy encoding in UTF-8 encoded byte comparison for strings to solve performance issues. [#6706](//github.com/firebase/firebase-android-sdk/pull/6706)


### PR DESCRIPTION
This should fix issue https://github.com/firebase/firebase-android-sdk/issues/6883