### PR TITLE
Refactor: Rename encodeBitmapToBase64Png to encodeBitmapToBase64Jpeg

### DIFF
--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/Part.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/Part.kt
@@ -164,7 +164,7 @@ internal fun Part.toInternal(): InternalPart {
     is TextPart -> TextPart.Internal(text)
     is ImagePart ->
       InlineDataPart.Internal(
-        InlineDataPart.Internal.InlineData("image/jpeg", encodeBitmapToBase64Png(image))
+        InlineDataPart.Internal.InlineData("image/jpeg", encodeBitmapToBase64Jpeg(image))
       )
     is InlineDataPart ->
       InlineDataPart.Internal(
@@ -186,7 +186,7 @@ internal fun Part.toInternal(): InternalPart {
   }
 }
 
-private fun encodeBitmapToBase64Png(input: Bitmap): String {
+private fun encodeBitmapToBase64Jpeg(input: Bitmap): String {
   ByteArrayOutputStream().let {
     input.compress(Bitmap.CompressFormat.JPEG, 80, it)
     return android.util.Base64.encodeToString(it.toByteArray(), BASE_64_FLAGS)


### PR DESCRIPTION
The private function `encodeBitmapToBase64Png` in `firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/Part.kt` was already compressing Bitmap images to JPEG format, not PNG.

This commit renames the function to `encodeBitmapToBase64Jpeg` to accurately reflect its behavior. The single call site within the same file has also been updated.

no-changelog