### PR TITLE
Migrate LiveContentResponse.Status to properties

### DIFF
--- a/firebase-vertexai/CHANGELOG.md
+++ b/firebase-vertexai/CHANGELOG.md
@@ -15,7 +15,7 @@
 * [fixed] Fixed an issue with `LiveSession` not converting exceptions to `FirebaseVertexAIException`. (#6870)
 * [feature] Enable response generation in multiple modalities. (#6901)
 * [changed] Removed the `LiveContentResponse.Status` class, and instead have nested the status
-  fields as properties of `LiveContentResponse`. (#TODO)
+  fields as properties of `LiveContentResponse`. (#6906)
 
 
 # 16.3.0

--- a/firebase-vertexai/CHANGELOG.md
+++ b/firebase-vertexai/CHANGELOG.md
@@ -14,6 +14,8 @@
   interrupted or the turn completed. (#6870)
 * [fixed] Fixed an issue with `LiveSession` not converting exceptions to `FirebaseVertexAIException`. (#6870)
 * [feature] Enable response generation in multiple modalities. (#6901)
+* [changed] Removed the `LiveContentResponse.Status` class, and instead have nested the status
+  fields as properties of `LiveContentResponse`. (#TODO)
 
 
 # 16.3.0

--- a/firebase-vertexai/api.txt
+++ b/firebase-vertexai/api.txt
@@ -569,25 +569,14 @@ package com.google.firebase.vertexai.type {
   @com.google.firebase.vertexai.type.PublicPreviewAPI public final class LiveContentResponse {
     method public com.google.firebase.vertexai.type.Content? getData();
     method public java.util.List<com.google.firebase.vertexai.type.FunctionCallPart>? getFunctionCalls();
-    method public int getStatus();
+    method public Boolean? getInterrupted();
     method public String? getText();
+    method public Boolean? getTurnComplete();
     property public final com.google.firebase.vertexai.type.Content? data;
     property public final java.util.List<com.google.firebase.vertexai.type.FunctionCallPart>? functionCalls;
-    property public final int status;
+    property public final Boolean? interrupted;
     property public final String? text;
-  }
-
-  @kotlin.jvm.JvmInline public static final value class LiveContentResponse.Status {
-    field public static final com.google.firebase.vertexai.type.LiveContentResponse.Status.Companion Companion;
-  }
-
-  public static final class LiveContentResponse.Status.Companion {
-    method public int getINTERRUPTED();
-    method public int getNORMAL();
-    method public int getTURN_COMPLETE();
-    property public final int INTERRUPTED;
-    property public final int NORMAL;
-    property public final int TURN_COMPLETE;
+    property public final Boolean? turnComplete;
   }
 
   @com.google.firebase.vertexai.type.PublicPreviewAPI public final class LiveGenerationConfig {

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/LiveContentResponse.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/LiveContentResponse.kt
@@ -30,10 +30,19 @@ internal constructor(
   public val data: Content?,
 
   /**
-   * The status of the live content response. Indicates whether the response is normal, was
-   * interrupted, or signifies the completion of a turn.
+   * The model was interrupted while generating data.
+   *
+   * An interruption occurs when the client sends a message while the model is actively sending
+   * data.
    */
-  public val status: Status,
+  public val interrupted: Boolean?,
+
+  /**
+   * The model has finished sending data in the current interaction.
+   *
+   * Can be set alongside content, signifying that the content is the last in the turn.
+   */
+  public val turnComplete: Boolean?,
 
   /**
    * A list of [FunctionCallPart] included in the response, if any.
@@ -49,26 +58,4 @@ internal constructor(
    */
   public val text: String? =
     data?.parts?.filterIsInstance<TextPart>()?.joinToString(" ") { it.text }
-
-  /** Represents the status of a [LiveContentResponse], within a single interaction. */
-  @JvmInline
-  public value class Status private constructor(private val value: Int) {
-    public companion object {
-      /** The server is actively sending data for the current interaction. */
-      public val NORMAL: Status = Status(0)
-      /**
-       * The server was interrupted while generating data.
-       *
-       * An interruption occurs when the client sends a message while the server is [actively]
-       * [NORMAL] sending data.
-       */
-      public val INTERRUPTED: Status = Status(1)
-      /**
-       * The model has finished sending data in the current interaction.
-       *
-       * Can be set alongside content, signifying that the content is the last in the turn.
-       */
-      public val TURN_COMPLETE: Status = Status(2)
-    }
-  }
 }


### PR DESCRIPTION
Per [b/410855548](https://b.corp.google.com/issues/410855548),

This removes the `LiveContentResponse.Status` class, and instead nests the status as corresponding fields directly on `LiveContentResponse`.  This is done to ensure we can support the model returning multiple statuses, since the model does not define them as exclusive.

Note that proto alignment efforts will be in a separate PR. This PR is _only_ for migrating `Status` to properties.