### PR TITLE
Exclude protolite well known types from version bump.

### DIFF
--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/PostReleasePlugin.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/PostReleasePlugin.kt
@@ -63,7 +63,12 @@ class PostReleasePlugin : Plugin<Project> {
    * @see VersionBumpTask
    */
   fun registerVersionBumpTask(project: Project) =
-    project.tasks.register<VersionBumpTask>("versionBump")
+    project.tasks.register<VersionBumpTask>("versionBump") {
+      // TODO(b/285892320): Remove condition when bug fixed
+      bumpVersion.set(project.firebaseLibrary.artifactId.map {
+        it !== "protolite-well-known-types"
+      })
+    }
 
   /**
    * Registers the `moveUnreleasedChanges` task for the provided [Project].

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/VersionBumpTask.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/VersionBumpTask.kt
@@ -39,7 +39,8 @@ import org.gradle.kotlin.dsl.provideDelegate
  * @property releasedVersion A [ModuleVersion] of what to bump from. Defaults to the project
  *   version.
  * @property newVersion A [ModuleVersion] of what to set the version to. Defaults to one patch
- *   higher than [releasedVersion]
+ *   higher than [releasedVersion].
+ * @property bumpVersion If set, then the default provided by [newVersion] will be bumped by one patch. Defaults to `true`.
  * @see PostReleasePlugin
  */
 abstract class VersionBumpTask : DefaultTask() {
@@ -52,16 +53,22 @@ abstract class VersionBumpTask : DefaultTask() {
   @get:[Optional Input]
   abstract val newVersion: Property<ModuleVersion>
 
+  @get:[Optional Input]
+  abstract val bumpVersion: Property<Boolean>
+
   init {
     configure()
   }
 
   @TaskAction
   fun build() {
+    val latestVersion = releasedVersion.get()
+    val version = newVersion.orNull ?: if(bumpVersion.get()) latestVersion.bump() else latestVersion
+
     versionFile.get().asFile.rewriteLines {
       when {
-        it.startsWith("version=") -> "version=${newVersion.get()}"
-        it.startsWith("latestReleasedVersion") -> "latestReleasedVersion=${releasedVersion.get()}"
+        it.startsWith("version=") -> "version=${version}"
+        it.startsWith("latestReleasedVersion") -> "latestReleasedVersion=${latestVersion}"
         else -> it
       }
     }
@@ -70,7 +77,7 @@ abstract class VersionBumpTask : DefaultTask() {
   fun configure() {
     versionFile.convention(project.layout.projectDirectory.file("gradle.properties"))
     releasedVersion.convention(computeReleasedVersion())
-    newVersion.convention(releasedVersion.map { it.bump() })
+    bumpVersion.convention(true)
   }
 
   fun computeReleasedVersion(): ModuleVersion? {


### PR DESCRIPTION
Per [b/413403910](https://b.corp.google.com/issues/413403910),

This adds filtering logic to not bump the version of `protolite-well-known-types` when it releases. This solves the issue of the `version` and `latestReleasedVersion` not aligning (which must be enforced due to [b/285892320](https://buganizer.corp.google.com/issues/285892320)).

More specifically, this PR adds a toggle for the default `bump` behavior in `VersionBumpTask`. We then set this to `false` when the project's `artifactId` is `protolite-well-known-types`.

This allows us to still [automatically] update the `latestReleasedVersion` (should we ever release well known types again), without bumping the `version`.

The `VersionBumpTask` docs have been updated to accommodate this.