### PR TITLE
Fix AI test timeout

### DIFF
--- a/firebase-ai/src/test/java/com/google/firebase/ai/util/tests.kt
+++ b/firebase-ai/src/test/java/com/google/firebase/ai/util/tests.kt
@@ -210,15 +210,16 @@ internal fun goldenUnaryFile(
   httpStatusCode: HttpStatusCode = HttpStatusCode.OK,
   backend: GenerativeBackend = GenerativeBackend.vertexAI(),
   block: CommonTest,
-) =
+) = doBlocking {
   commonTest(httpStatusCode, backend = backend) {
     val goldenFile = loadGoldenFile(name)
     val message = goldenFile.readText()
 
-    channel.send(message.toByteArray())
+    launch { channel.send(message.toByteArray()) }
 
     block()
   }
+}
 
 /**
  * A variant of [goldenUnaryFile] for vertexai tests Loads the *Golden File* and automatically

--- a/firebase-vertexai/src/test/java/com/google/firebase/vertexai/util/tests.kt
+++ b/firebase-vertexai/src/test/java/com/google/firebase/vertexai/util/tests.kt
@@ -189,15 +189,16 @@ internal fun goldenUnaryFile(
   name: String,
   httpStatusCode: HttpStatusCode = HttpStatusCode.OK,
   block: CommonTest,
-) =
+) = doBlocking {
   commonTest(httpStatusCode) {
     val goldenFile = loadGoldenFile(name)
     val message = goldenFile.readText()
 
-    channel.send(message.toByteArray())
+    launch { channel.send(message.toByteArray()) }
 
     block()
   }
+}
 
 /**
  * A variant of [goldenUnaryFile] for vertexai tests Loads the *Golden File* and automatically


### PR DESCRIPTION
Per [b/414406390](https://b.corp.google.com/issues/414406390),

This fixes the issue with long text golden files timing out the tests. This occurred because the text contents were too large for the channel's buffer- so the channel entered a suspension point until the content was read. Unfortunately, this suspension point blocked the test thread. To solve this, we do the same thing we do for `goldenStreamingFile`- we write to the channel in a separate coroutine scope. This allows Kotlin to properly recognize that the suspension point within the writer should allow for the test thread to continue.