### PR TITLE
Add inlineDataParts helper property

### DIFF
--- a/firebase-ai/CHANGELOG.md
+++ b/firebase-ai/CHANGELOG.md
@@ -13,3 +13,4 @@
 * [fixed] Fixed an issue with `LiveContentResponse` audio data not being present when the model was
   interrupted or the turn completed. (#6870)
 * [fixed] Fixed an issue with `LiveSession` not converting exceptions to `FirebaseVertexAIException`. (#6870)
+* [feature] Added a helper field for getting all the `InlineDataPart` from a `GenerateContentResponse`. (#6922)

--- a/firebase-ai/api.txt
+++ b/firebase-ai/api.txt
@@ -330,11 +330,13 @@ package com.google.firebase.ai.type {
     ctor public GenerateContentResponse(java.util.List<com.google.firebase.ai.type.Candidate> candidates, com.google.firebase.ai.type.PromptFeedback? promptFeedback, com.google.firebase.ai.type.UsageMetadata? usageMetadata);
     method public java.util.List<com.google.firebase.ai.type.Candidate> getCandidates();
     method public java.util.List<com.google.firebase.ai.type.FunctionCallPart> getFunctionCalls();
+    method public java.util.List<com.google.firebase.ai.type.InlineDataPart> getInlineDataParts();
     method public com.google.firebase.ai.type.PromptFeedback? getPromptFeedback();
     method public String? getText();
     method public com.google.firebase.ai.type.UsageMetadata? getUsageMetadata();
     property public final java.util.List<com.google.firebase.ai.type.Candidate> candidates;
     property public final java.util.List<com.google.firebase.ai.type.FunctionCallPart> functionCalls;
+    property public final java.util.List<com.google.firebase.ai.type.InlineDataPart> inlineDataParts;
     property public final com.google.firebase.ai.type.PromptFeedback? promptFeedback;
     property public final String? text;
     property public final com.google.firebase.ai.type.UsageMetadata? usageMetadata;

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/GenerateContentResponse.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/GenerateContentResponse.kt
@@ -44,6 +44,18 @@ public class GenerateContentResponse(
     candidates.first().content.parts.filterIsInstance<FunctionCallPart>()
   }
 
+  /**
+   * Convenience field representing all the [InlineDataPart]s in the first candidate, if they exist.
+   *
+   * This also includes any [ImagePart], but they will be represented as [InlineDataPart] instead.
+   */
+  public val inlineDataParts: List<InlineDataPart> by lazy {
+    candidates.first().content.parts.let { parts ->
+      parts.filterIsInstance<ImagePart>().map { it.toInlineDataPart() } +
+        parts.filterIsInstance<InlineDataPart>()
+    }
+  }
+
   @Serializable
   internal data class Internal(
     val candidates: List<Candidate.Internal>? = null,


### PR DESCRIPTION
Per [b/414639898](https://b.corp.google.com/issues/414639898),

This adds a helper property to `GenerateContentResponse` for getting all the `InlineDataPart` present in the first candidate, similar to `text`.

This was actually added in #6901, but it seems to have been missed during our `firebase-ai` migration.