### PR TITLE
[Firebase AI] Fix `goldenDevAPIStreamingFile` util

### DIFF
--- a/firebase-ai/src/test/java/com/google/firebase/ai/util/tests.kt
+++ b/firebase-ai/src/test/java/com/google/firebase/ai/util/tests.kt
@@ -193,7 +193,7 @@ internal fun goldenDevAPIStreamingFile(
   name: String,
   httpStatusCode: HttpStatusCode = HttpStatusCode.OK,
   block: CommonTest,
-) = goldenStreamingFile("vertexai/$name", httpStatusCode, GenerativeBackend.googleAI(), block)
+) = goldenStreamingFile("googleai/$name", httpStatusCode, GenerativeBackend.googleAI(), block)
 
 /**
  * A variant of [commonTest] for performing snapshot tests.

--- a/firebase-vertexai/update_responses.sh
+++ b/firebase-vertexai/update_responses.sh
@@ -17,7 +17,7 @@
 # This script replaces mock response files for Vertex AI unit tests with a fresh
 # clone of the shared repository of Vertex AI test data.
 
-RESPONSES_VERSION='v7.*' # The major version of mock responses to use
+RESPONSES_VERSION='v11.*' # The major version of mock responses to use
 REPO_NAME="vertexai-sdk-test-data"
 REPO_LINK="https://github.com/FirebaseExtended/$REPO_NAME.git"
 


### PR DESCRIPTION
The `goldenDevAPIStreamingFile` was returning golden files for Vertex AI. Switching this to Google AI should result in the [`prompt blocked for safety`](https://github.com/firebase/firebase-android-sdk/blob/a6010b2f8c24d500fbf4eaeaf79a7d8d83c84a8e/firebase-ai/src/test/java/com/google/firebase/ai/DevAPIStreamingSnapshotTests.kt#L67-L76) test failing since the Google AI version of [`streaming-failure-prompt-blocked-safety.txt`](https://github.com/FirebaseExtended/vertexai-sdk-test-data/blob/220b68ef7d103375c563545be66535feb30b4729/mock-responses/googleai/streaming-failure-prompt-blocked-safety.txt) does not contain a blocked prompt response.