### PR TITLE
[Ai] Add workaround for invalid SafetyRating from the backend.

### DIFF
--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/PromptFeedback.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/PromptFeedback.kt
@@ -42,7 +42,7 @@ public class PromptFeedback(
   ) {
 
     internal fun toPublic(): PromptFeedback {
-      val safetyRatings = safetyRatings?.map { it.toPublic() }.orEmpty()
+      val safetyRatings = safetyRatings?.mapNotNull { it.toPublic() }.orEmpty()
       return PromptFeedback(blockReason?.toPublic(), safetyRatings, blockReasonMessage)
     }
   }

--- a/firebase-ai/src/test/java/com/google/firebase/ai/VertexAIStreamingSnapshotTests.kt
+++ b/firebase-ai/src/test/java/com/google/firebase/ai/VertexAIStreamingSnapshotTests.kt
@@ -36,7 +36,10 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withTimeout
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 internal class VertexAIStreamingSnapshotTests {
   private val testTimeout = 5.seconds
 
@@ -82,6 +85,18 @@ internal class VertexAIStreamingSnapshotTests {
         responseList.any {
           it.candidates.any { it.safetyRatings.any { it.category == HarmCategory.UNKNOWN } }
         } shouldBe true
+      }
+    }
+
+  @Test
+  fun `invalid safety ratings during image generation`() =
+    goldenVertexStreamingFile("streaming-success-image-invalid-safety-ratings.txt") {
+      val responses = model.generateContentStream("prompt")
+
+      withTimeout(testTimeout) {
+        val responseList = responses.toList()
+
+        responseList.isEmpty() shouldBe false
       }
     }
 

--- a/firebase-ai/src/test/java/com/google/firebase/ai/VertexAIUnarySnapshotTests.kt
+++ b/firebase-ai/src/test/java/com/google/firebase/ai/VertexAIUnarySnapshotTests.kt
@@ -55,8 +55,11 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.json.JSONArray
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
 @OptIn(PublicPreviewAPI::class)
+@RunWith(RobolectricTestRunner::class)
 internal class VertexAIUnarySnapshotTests {
   private val testTimeout = 5.seconds
 
@@ -122,6 +125,16 @@ internal class VertexAIUnarySnapshotTests {
         candidate.safetyRatings.any { it.category == HarmCategory.UNKNOWN } shouldBe true
         response.promptFeedback?.safetyRatings?.any { it.category == HarmCategory.UNKNOWN } shouldBe
           true
+      }
+    }
+
+  @Test
+  fun `invalid safety ratings during image generation`() =
+    goldenVertexUnaryFile("unary-success-image-invalid-safety-ratings.json") {
+      withTimeout(testTimeout) {
+        val response = model.generateContent("prompt")
+
+        response.candidates.isEmpty() shouldBe false
       }
     }
 


### PR DESCRIPTION
Due to a bug in the backend, it's possible that we receive an invalid `SafetyRating` value, without either category or probability. We return null in those cases to enable filtering by the higher level types.