### PR TITLE
[Storage] Migrate from Robolectric.flushForegroundThreadScheduler to ShadowLooper.runToEndOfTasks

### DIFF
--- a/firebase-storage/CHANGELOG.md
+++ b/firebase-storage/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* [fixed] Fixed an issue where tests were depending on a deprecated feature of the test framework (#6927)
 
 # 21.0.1
 * [fixed] Fixed an issue where `maxUploadRetryTimeMillis` parameter is ignored when uploading using
@@ -208,4 +209,3 @@ updates.
   `UploadTask.TaskSnapshot.getDownloadUrl()` methods. To get a current download
   URL, use
   [`StorageReference.getDownloadUr()`](/docs/reference/android/com/google/firebase/storage/StorageReference.html#getDownloadUrl()).
-

--- a/firebase-storage/CHANGELOG.md
+++ b/firebase-storage/CHANGELOG.md
@@ -209,3 +209,4 @@ updates.
   `UploadTask.TaskSnapshot.getDownloadUrl()` methods. To get a current download
   URL, use
   [`StorageReference.getDownloadUr()`](/docs/reference/android/com/google/firebase/storage/StorageReference.html#getDownloadUrl()).
+

--- a/firebase-storage/src/test/java/com/google/firebase/storage/DownloadTest.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/DownloadTest.java
@@ -18,9 +18,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.robolectric.Shadows.shadowOf;
 
 import android.net.Uri;
 import android.os.Build;
+import android.os.Looper;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.storage.TestDownloadHelper.StreamDownloadResponse;
@@ -40,14 +42,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 /** Tests for {@link FirebaseStorage}. */
 @SuppressWarnings("ConstantConditions")
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = Build.VERSION_CODES.LOLLIPOP_MR1)
+@Config(sdk = Build.VERSION_CODES.M)
 public class DownloadTest {
 
   @Rule public RetryRule retryRule = new RetryRule(3);
@@ -137,7 +138,7 @@ public class DownloadTest {
     ControllableSchedulerHelper.getInstance().resume();
 
     for (int i = 0; i < 3000; i++) {
-      Robolectric.flushForegroundThreadScheduler();
+      shadowOf(Looper.getMainLooper()).runToEndOfTasks();
       if (semaphore.tryAcquire(2, 1, TimeUnit.MILLISECONDS)) {
         Assert.assertEquals(bytesDownloaded.get(), bytesTransferred.get());
         return;
@@ -256,7 +257,7 @@ public class DownloadTest {
         TestDownloadHelper.byteDownload(
             new StringBuilder(), bitmap -> assertEquals(1076408, bitmap.length));
     for (int i = 0; i < 3000; i++) {
-      Robolectric.flushForegroundThreadScheduler();
+      shadowOf(Looper.getMainLooper()).runToEndOfTasks();
       if (semaphore.tryAcquire(1, 1, TimeUnit.MILLISECONDS)) {
         // success!
         factory.verifyOldMock();

--- a/firebase-storage/src/test/java/com/google/firebase/storage/TestUtil.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/TestUtil.java
@@ -14,6 +14,9 @@
 
 package com.google.firebase.storage;
 
+import static org.robolectric.Shadows.shadowOf;
+
+import android.os.Looper;
 import androidx.annotation.Nullable;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.android.gms.tasks.Task;
@@ -26,7 +29,6 @@ import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
-import org.robolectric.Robolectric;
 
 /** Test helpers. */
 public class TestUtil {
@@ -138,7 +140,7 @@ public class TestUtil {
     long timeoutMillis = timeUnit.toMillis(timeout);
 
     for (int i = 0; i < timeoutMillis; i++) {
-      Robolectric.flushForegroundThreadScheduler();
+      shadowOf(Looper.getMainLooper()).runToEndOfTasks();
       if (task.isComplete()) {
         // success!
         return;


### PR DESCRIPTION

The Robolectric Scheduler APIs are designed for LEGACY Looper mode, where tasks were controlled by Scheduler objects. LEGACY Looper mode has been deprecated for 5+ years. Migrate from Robolectric.flushForegroundThreadScheduler to ShadowLooper APIs.

See cl/752917858 for reference