### PR TITLE
Fix AI builders for Java consumers

### DIFF
--- a/firebase-ai/CHANGELOG.md
+++ b/firebase-ai/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* [fixed] **Breaking Change**: Fixed missing builder methods and return types in builders.
 * [changed] **Breaking Change**: `LiveModelFutures.connect` now returns `ListenableFuture<LiveSessionFutures>` instead of `ListenableFuture<LiveSession>`.
     * **Action Required:** Remove any transformations from LiveSession object to LiveSessionFutures object.
     * **Action Required:** Change type of variable handling `LiveModelFutures.connect` to `ListenableFuture<LiveSessionsFutures>`

--- a/firebase-ai/api.txt
+++ b/firebase-ai/api.txt
@@ -216,12 +216,10 @@ package com.google.firebase.ai.type {
     method public <T extends com.google.firebase.ai.type.Part> com.google.firebase.ai.type.Content.Builder addPart(T data);
     method public com.google.firebase.ai.type.Content.Builder addText(String text);
     method public com.google.firebase.ai.type.Content build();
-    method public java.util.List<com.google.firebase.ai.type.Part> getParts();
-    method public String? getRole();
-    method public void setParts(java.util.List<com.google.firebase.ai.type.Part>);
-    method public void setRole(String?);
-    property public final java.util.List<com.google.firebase.ai.type.Part> parts;
-    property public final String? role;
+    method public com.google.firebase.ai.type.Content.Builder setParts(java.util.List<com.google.firebase.ai.type.Part> parts);
+    method public com.google.firebase.ai.type.Content.Builder setRole(String? role);
+    field public java.util.List<com.google.firebase.ai.type.Part> parts;
+    field public String? role;
   }
 
   public final class ContentBlockedException extends com.google.firebase.ai.type.FirebaseAIException {
@@ -355,6 +353,17 @@ package com.google.firebase.ai.type {
   public static final class GenerationConfig.Builder {
     ctor public GenerationConfig.Builder();
     method public com.google.firebase.ai.type.GenerationConfig build();
+    method public com.google.firebase.ai.type.GenerationConfig.Builder setCandidateCount(Integer? candidateCount);
+    method public com.google.firebase.ai.type.GenerationConfig.Builder setFrequencyPenalty(Float? frequencyPenalty);
+    method public com.google.firebase.ai.type.GenerationConfig.Builder setMaxOutputTokens(Integer? maxOutputTokens);
+    method public com.google.firebase.ai.type.GenerationConfig.Builder setPresencePenalty(Float? presencePenalty);
+    method public com.google.firebase.ai.type.GenerationConfig.Builder setResponseMimeType(String? responseMimeType);
+    method public com.google.firebase.ai.type.GenerationConfig.Builder setResponseModalities(java.util.List<com.google.firebase.ai.type.ResponseModality>? responseModalities);
+    method public com.google.firebase.ai.type.GenerationConfig.Builder setResponseSchema(com.google.firebase.ai.type.Schema? responseSchema);
+    method public com.google.firebase.ai.type.GenerationConfig.Builder setStopSequences(java.util.List<java.lang.String>? stopSequences);
+    method public com.google.firebase.ai.type.GenerationConfig.Builder setTemperature(Float? temperature);
+    method public com.google.firebase.ai.type.GenerationConfig.Builder setTopK(Integer? topK);
+    method public com.google.firebase.ai.type.GenerationConfig.Builder setTopP(Float? topP);
     field public Integer? candidateCount;
     field public Float? frequencyPenalty;
     field public Integer? maxOutputTokens;

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/Content.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/Content.kt
@@ -44,14 +44,17 @@ constructor(public val role: String? = "user", public val parts: List<Part>) {
   public class Builder {
 
     /** The producer of the content. Must be either 'user' or 'model'. By default, it's "user". */
-    public var role: String? = "user"
+    @JvmField public var role: String? = "user"
 
     /**
      * The mutable list of [Part]s comprising the [Content].
      *
      * Prefer using the provided helper methods over modifying this list directly.
      */
-    public var parts: MutableList<Part> = arrayListOf()
+    @JvmField public var parts: MutableList<Part> = arrayListOf()
+
+    public fun setRole(role: String?): Content.Builder = apply { this.role = role }
+    public fun setParts(parts: MutableList<Part>): Content.Builder = apply { this.parts = parts }
 
     /** Adds a new [Part] to [parts]. */
     @JvmName("addPart")

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/GenerationConfig.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/GenerationConfig.kt
@@ -136,6 +136,36 @@ private constructor(
     @JvmField public var responseSchema: Schema? = null
     @JvmField public var responseModalities: List<ResponseModality>? = null
 
+    public fun setTemperature(temperature: Float?): Builder = apply {
+      this.temperature = temperature
+    }
+    public fun setTopK(topK: Int?): Builder = apply { this.topK = topK }
+    public fun setTopP(topP: Float?): Builder = apply { this.topP = topP }
+    public fun setCandidateCount(candidateCount: Int?): Builder = apply {
+      this.candidateCount = candidateCount
+    }
+    public fun setMaxOutputTokens(maxOutputTokens: Int?): Builder = apply {
+      this.maxOutputTokens = maxOutputTokens
+    }
+    public fun setPresencePenalty(presencePenalty: Float?): Builder = apply {
+      this.presencePenalty = presencePenalty
+    }
+    public fun setFrequencyPenalty(frequencyPenalty: Float?): Builder = apply {
+      this.frequencyPenalty = frequencyPenalty
+    }
+    public fun setStopSequences(stopSequences: List<String>?): Builder = apply {
+      this.stopSequences = stopSequences
+    }
+    public fun setResponseMimeType(responseMimeType: String?): Builder = apply {
+      this.responseMimeType = responseMimeType
+    }
+    public fun setResponseSchema(responseSchema: Schema?): Builder = apply {
+      this.responseSchema = responseSchema
+    }
+    public fun setResponseModalities(responseModalities: List<ResponseModality>?): Builder = apply {
+      this.responseModalities = responseModalities
+    }
+
     /** Create a new [GenerationConfig] with the attached arguments. */
     public fun build(): GenerationConfig =
       GenerationConfig(


### PR DESCRIPTION
Fixes all Firebase AI builder patterns to be properly usable by Java consumers. Small breaking binary change, no breaking source change. Additionally, now that the builder pattern can be used, compile tests for the builders and other classes like `Schema` have been implemented.