### PR TITLE
Fix NetworkOnMainThreadException for API levels below 26

### DIFF
--- a/firebase-config/CHANGELOG.md
+++ b/firebase-config/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Unreleased
-
+* [fixed] Fixed `NetworkOnMainThreadException` on Android versions below 8 by disconnecting HttpURLConnection only on API levels 26 and higher.
 
 # 22.1.1
-[fixed] Fixed an issue where the connection to the real-time Remote Config backend could remain
+* [fixed] Fixed an issue where the connection to the real-time Remote Config backend could remain
 open in the background.
 
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -22,6 +22,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.util.Log;
 import androidx.annotation.GuardedBy;
 import androidx.annotation.NonNull;
@@ -409,8 +410,13 @@ public class ConfigRealtimeHttpClient {
       }
       // Close the connection if the app is in the background and there is an active
       // HttpUrlConnection.
-      if (isInBackground && httpURLConnection != null) {
-        httpURLConnection.disconnect();
+      // This is now only done on Android versions >= O (API 26) because
+      // on older versions, background detection callbacks run on the main thread, which
+      // could lead to a NetworkOnMainThreadException when disconnecting the connection.
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        if (isInBackground && httpURLConnection != null) {
+          httpURLConnection.disconnect();
+        }
       }
     }
   }


### PR DESCRIPTION
This change addresses a ``NetworkOnMainThreadException`` that was observed  on Android API levels below 26.
The crash happened during background transitions when disconnecting an ``HttpURLConnection`` because background callbacks on these older OS versions could run on the main thread. The fix restricts the disconnect logic to run only on API level 26 (Android 8.0) and higher.