### PR TITLE
Update headers to track vertex ai/developer usage in kotlin

### DIFF
--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/GenerativeModel.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/GenerativeModel.kt
@@ -84,7 +84,7 @@ internal constructor(
       apiKey,
       modelName,
       requestOptions,
-      "ai-kotlin/${KotlinVersion.CURRENT} fire/${BuildConfig.VERSION_NAME}",
+      "gl-kotlin/${KotlinVersion.CURRENT}-ai fire/${BuildConfig.VERSION_NAME}",
       firebaseApp,
       AppCheckHeaderProvider(TAG, appCheckTokenProvider, internalAuthProvider),
     ),

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/GenerativeModel.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/GenerativeModel.kt
@@ -84,7 +84,7 @@ internal constructor(
       apiKey,
       modelName,
       requestOptions,
-      "gl-kotlin/${KotlinVersion.CURRENT} fire/${BuildConfig.VERSION_NAME}",
+      "ai-kotlin/${KotlinVersion.CURRENT} fire/${BuildConfig.VERSION_NAME}",
       firebaseApp,
       AppCheckHeaderProvider(TAG, appCheckTokenProvider, internalAuthProvider),
     ),

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/ImagenModel.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/ImagenModel.kt
@@ -65,7 +65,7 @@ internal constructor(
       apiKey,
       modelName,
       requestOptions,
-      "ai-kotlin/${KotlinVersion.CURRENT} fire/${BuildConfig.VERSION_NAME}",
+      "gl-kotlin/${KotlinVersion.CURRENT}-ai fire/${BuildConfig.VERSION_NAME}",
       firebaseApp,
       AppCheckHeaderProvider(TAG, appCheckTokenProvider, internalAuthProvider),
     ),

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/ImagenModel.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/ImagenModel.kt
@@ -65,7 +65,7 @@ internal constructor(
       apiKey,
       modelName,
       requestOptions,
-      "gl-kotlin/${KotlinVersion.CURRENT} fire/${BuildConfig.VERSION_NAME}",
+      "ai-kotlin/${KotlinVersion.CURRENT} fire/${BuildConfig.VERSION_NAME}",
       firebaseApp,
       AppCheckHeaderProvider(TAG, appCheckTokenProvider, internalAuthProvider),
     ),

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/LiveGenerativeModel.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/LiveGenerativeModel.kt
@@ -83,7 +83,7 @@ internal constructor(
       apiKey,
       modelName,
       requestOptions,
-      "ai-kotlin/${KotlinVersion.CURRENT} fire/${BuildConfig.VERSION_NAME}",
+      "gl-kotlin/${KotlinVersion.CURRENT}-ai fire/${BuildConfig.VERSION_NAME}",
       firebaseApp,
       AppCheckHeaderProvider(TAG, appCheckTokenProvider, internalAuthProvider),
     ),

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/LiveGenerativeModel.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/LiveGenerativeModel.kt
@@ -83,7 +83,7 @@ internal constructor(
       apiKey,
       modelName,
       requestOptions,
-      "gl-kotlin/${KotlinVersion.CURRENT} fire/${BuildConfig.VERSION_NAME}",
+      "ai-kotlin/${KotlinVersion.CURRENT} fire/${BuildConfig.VERSION_NAME}",
       firebaseApp,
       AppCheckHeaderProvider(TAG, appCheckTokenProvider, internalAuthProvider),
     ),


### PR DESCRIPTION
This change is required to track the usage of vertex ai/developer api in kotlin. This change adds a suffix to the version value in the headers we send to the backend (This will mainly distinguish between the 16.0.0 versions from the old sdk and the new one)