### PR TITLE
Add crashlytics-ndk changelog entry

### DIFF
--- a/firebase-crashlytics-ndk/CHANGELOG.md
+++ b/firebase-crashlytics-ndk/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* [changed] Updated `firebase-crashlytics` dependency to v19.4.4
 
 
 # 19.4.3


### PR DESCRIPTION
#6945 was missing a changelog entry for the dependent library. This PR adds that changelog.