### PR TITLE
Add Firebase AI to recipe version generation

### DIFF
--- a/plugins/src/main/java/com/google/firebase/gradle/bomgenerator/GenerateTutorialBundleTask.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/bomgenerator/GenerateTutorialBundleTask.kt
@@ -235,8 +235,8 @@ abstract class GenerateTutorialBundleTask : DefaultTask() {
           ArtifactTutorialMapping("Crashlytics", "crashlytics-dependency"),
         "com.google.firebase:firebase-perf" to
           ArtifactTutorialMapping("Performance Monitoring", "perf-dependency"),
-        "com.google.firebase:firebase-vertexai" to
-          ArtifactTutorialMapping("Vertex AI in Firebase", "vertex-dependency"),
+        "com.google.firebase:firebase-ai" to
+          ArtifactTutorialMapping("Firebase AI Logic", "firebase-ai"),
         "com.google.firebase:firebase-messaging" to
           ArtifactTutorialMapping("Cloud Messaging", "messaging-dependency"),
         "com.google.firebase:firebase-auth" to

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/PublishingPlugin.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/PublishingPlugin.kt
@@ -417,7 +417,6 @@ abstract class PublishingPlugin : Plugin<Project> {
           "com.google.firebase:firebase-analytics",
           "com.google.firebase:firebase-crashlytics",
           "com.google.firebase:firebase-perf",
-          "com.google.firebase:firebase-vertexai",
           "com.google.firebase:firebase-ai",
           "com.google.firebase:firebase-messaging",
           "com.google.firebase:firebase-auth",


### PR DESCRIPTION
Per [b/416734504](https://b.corp.google.com/issues/416734504),

This updates the `GenerateTutorialBundleTask` that we use to generate the tutorial bundle versions (recipe versions) to support `firebase-ai`. More specifically, it replaces the existing `firebase-vertexai` entry in the process.

While this PR removes `firebase-vertexai` from the tutorial bundle, it does _not_ remove it from the BoM. That will be a breaking change we'll make down the road.