### PR TITLE
[ai] Include missing dependency suffix to firebase-ai

### DIFF
--- a/plugins/src/main/java/com/google/firebase/gradle/bomgenerator/GenerateTutorialBundleTask.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/bomgenerator/GenerateTutorialBundleTask.kt
@@ -236,7 +236,7 @@ abstract class GenerateTutorialBundleTask : DefaultTask() {
         "com.google.firebase:firebase-perf" to
           ArtifactTutorialMapping("Performance Monitoring", "perf-dependency"),
         "com.google.firebase:firebase-ai" to
-          ArtifactTutorialMapping("Firebase AI Logic", "firebase-ai"),
+          ArtifactTutorialMapping("Firebase AI Logic", "firebase-ai-depedency"),
         "com.google.firebase:firebase-messaging" to
           ArtifactTutorialMapping("Cloud Messaging", "messaging-dependency"),
         "com.google.firebase:firebase-auth" to


### PR DESCRIPTION
All SDK dependency declarations follow the same pattern, `<libname>-dependency`