### PR TITLE
fix(ai): pass FunctionDeclaration#description arg to internal class

### DIFF
--- a/firebase-ai/CHANGELOG.md
+++ b/firebase-ai/CHANGELOG.md
@@ -21,4 +21,5 @@
 * [feature] Added support for the `id` field on `FunctionResponsePart` and `FunctionCallPart`. (#6910)
 * [feature] Add support for specifying response modalities in `GenerationConfig`. (#6921)
 * [feature] Added a helper field for getting all the `InlineDataPart` from a `GenerateContentResponse`. (#6922)
+* [fixed] Fixed an issue that was causing the SDK to send empty `FunctionDeclaration` descriptions to the API. 
 

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/FunctionDeclaration.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/FunctionDeclaration.kt
@@ -61,7 +61,7 @@ public class FunctionDeclaration(
   internal val schema: Schema =
     Schema.obj(properties = parameters, optionalProperties = optionalParameters, nullable = false)
 
-  internal fun toInternal() = Internal(name, "", schema.toInternal())
+  internal fun toInternal() = Internal(name, description, schema.toInternal())
 
   @Serializable
   internal data class Internal(

--- a/firebase-ai/src/test/java/com/google/firebase/ai/type/FunctionDeclarationTest.kt
+++ b/firebase-ai/src/test/java/com/google/firebase/ai/type/FunctionDeclarationTest.kt
@@ -9,15 +9,15 @@ internal class FunctionDeclarationTest {
 
   @Test
   fun `Basic FunctionDeclaration with name, description and parameters`() {
-    val functionDeclaration = FunctionDeclaration(
-      name = "isUserAGoat",
-      description = "Determine if the user is subject to teleportations.",
-      parameters = mapOf(
-        "userID" to Schema.string("ID of the User making the call")
+    val functionDeclaration =
+      FunctionDeclaration(
+        name = "isUserAGoat",
+        description = "Determine if the user is subject to teleportations.",
+        parameters = mapOf("userID" to Schema.string("ID of the User making the call"))
       )
-    )
 
-    val expectedJson = """
+    val expectedJson =
+      """
       {
           "name": "isUserAGoat",
           "description": "Determine if the user is subject to teleportations.",
@@ -34,24 +34,28 @@ internal class FunctionDeclarationTest {
             ]
           }
         }
-    """.trimIndent()
+    """
+        .trimIndent()
 
     Json.encodeToString(functionDeclaration.toInternal()).shouldEqualJson(expectedJson)
   }
 
   @Test
   fun `FunctionDeclaration with optional parameters`() {
-    val functionDeclaration = FunctionDeclaration(
-      name = "isUserAGoat",
-      description = "Determine if the user is subject to teleportations.",
-      parameters = mapOf(
-        "userID" to Schema.string("ID of the user making the call"),
-        "userName" to Schema.string("Name of the user making the call")
-      ),
-      optionalParameters = listOf("userName")
-    )
+    val functionDeclaration =
+      FunctionDeclaration(
+        name = "isUserAGoat",
+        description = "Determine if the user is subject to teleportations.",
+        parameters =
+          mapOf(
+            "userID" to Schema.string("ID of the user making the call"),
+            "userName" to Schema.string("Name of the user making the call")
+          ),
+        optionalParameters = listOf("userName")
+      )
 
-    val expectedJson = """
+    val expectedJson =
+      """
       {
           "name": "isUserAGoat",
           "description": "Determine if the user is subject to teleportations.",
@@ -72,7 +76,8 @@ internal class FunctionDeclarationTest {
             ]
           }
         }
-    """.trimIndent()
+    """
+        .trimIndent()
 
     Json.encodeToString(functionDeclaration.toInternal()).shouldEqualJson(expectedJson)
   }

--- a/firebase-ai/src/test/java/com/google/firebase/ai/type/FunctionDeclarationTest.kt
+++ b/firebase-ai/src/test/java/com/google/firebase/ai/type/FunctionDeclarationTest.kt
@@ -1,0 +1,81 @@
+package com.google.firebase.ai.type
+
+import io.kotest.assertions.json.shouldEqualJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+internal class FunctionDeclarationTest {
+
+  @Test
+  fun `Basic FunctionDeclaration with name, description and parameters`() {
+    val functionDeclaration = FunctionDeclaration(
+      name = "isUserAGoat",
+      description = "Determine if the user is subject to teleportations.",
+      parameters = mapOf(
+        "userID" to Schema.string("ID of the User making the call")
+      )
+    )
+
+    val expectedJson = """
+      {
+          "name": "isUserAGoat",
+          "description": "Determine if the user is subject to teleportations.",
+          "parameters": {
+            "type": "OBJECT",
+            "properties": {
+              "userID": {
+                "type": "STRING",
+                "description": "ID of the User making the call"
+              }
+            },
+            "required": [
+              "userID"
+            ]
+          }
+        }
+    """.trimIndent()
+
+    Json.encodeToString(functionDeclaration.toInternal()).shouldEqualJson(expectedJson)
+  }
+
+  @Test
+  fun `FunctionDeclaration with optional parameters`() {
+    val functionDeclaration = FunctionDeclaration(
+      name = "isUserAGoat",
+      description = "Determine if the user is subject to teleportations.",
+      parameters = mapOf(
+        "userID" to Schema.string("ID of the user making the call"),
+        "userName" to Schema.string("Name of the user making the call")
+      ),
+      optionalParameters = listOf("userName")
+    )
+
+    val expectedJson = """
+      {
+          "name": "isUserAGoat",
+          "description": "Determine if the user is subject to teleportations.",
+          "parameters": {
+            "type": "OBJECT",
+            "properties": {
+              "userID": {
+                "type": "STRING",
+                "description": "ID of the user making the call"
+              },
+              "userName": {
+                "type": "STRING",
+                "description": "Name of the user making the call"
+              }
+            },
+            "required": [
+              "userID"
+            ]
+          }
+        }
+    """.trimIndent()
+
+    Json.encodeToString(functionDeclaration.toInternal()).shouldEqualJson(expectedJson)
+  }
+
+
+}

--- a/firebase-ai/src/test/java/com/google/firebase/ai/type/FunctionDeclarationTest.kt
+++ b/firebase-ai/src/test/java/com/google/firebase/ai/type/FunctionDeclarationTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.firebase.ai.type
 
 import io.kotest.assertions.json.shouldEqualJson

--- a/firebase-ai/src/test/java/com/google/firebase/ai/type/FunctionDeclarationTest.kt
+++ b/firebase-ai/src/test/java/com/google/firebase/ai/type/FunctionDeclarationTest.kt
@@ -76,6 +76,4 @@ internal class FunctionDeclarationTest {
 
     Json.encodeToString(functionDeclaration.toInternal()).shouldEqualJson(expectedJson)
   }
-
-
 }


### PR DESCRIPTION
It seems like the value set in `FunctionDeclaration#description` was never making it to the API.

~Aside: I wonder if this is why some function calls would sometimes fail (ie. the model wouldn't know which function to call)~ Nevermind, I found a bug in the implementation I was testing with.