### PR TITLE
fix(ai): fix serialization for `Content` with no `parts` field

### DIFF
--- a/firebase-ai/CHANGELOG.md
+++ b/firebase-ai/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* [fixed] Fixed a serialization error that was thrown for the last message when using
+  `generateContentStream()` with `googleAI()`.
 * [fixed] Fixed `FirebaseAI.getInstance` StackOverflowException (#6971)
 * [fixed] Fixed an issue that was causing the SDK to send empty `FunctionDeclaration` descriptions to the API.
 * [changed] Introduced the `Voice` class, which accepts a voice name, and deprecated the `Voices` class.

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/Content.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/Content.kt
@@ -90,7 +90,7 @@ constructor(public val role: String? = "user", public val parts: List<Part>) {
   @Serializable
   internal data class Internal(
     @EncodeDefault val role: String? = "user",
-    @EncodeDefault val parts: List<InternalPart> = emptyList()
+    val parts: List<InternalPart> = emptyList()
   ) {
     internal fun toPublic(): Content {
       val returnedParts =

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/Content.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/Content.kt
@@ -90,13 +90,9 @@ constructor(public val role: String? = "user", public val parts: List<Part>) {
   @Serializable
   internal data class Internal(
     @EncodeDefault val role: String? = "user",
-    @EncodeDefault val parts: List<InternalPart>? = emptyList()
+    @EncodeDefault val parts: List<InternalPart> = emptyList()
   ) {
-    // TODO: add unit tests before sending a pull request (see DevAPIStreamingSnapshotTests.kt)
     internal fun toPublic(): Content {
-      if (parts.isNullOrEmpty()) {
-        return Content(role, listOf(TextPart(" ")))
-      }
       val returnedParts =
         parts.map { it.toPublic() }.filterNot { it is TextPart && it.text.isEmpty() }
       // If all returned parts were text and empty, we coalesce them into a single one-character

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/Content.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/Content.kt
@@ -90,9 +90,13 @@ constructor(public val role: String? = "user", public val parts: List<Part>) {
   @Serializable
   internal data class Internal(
     @EncodeDefault val role: String? = "user",
-    val parts: List<InternalPart>
+    @EncodeDefault val parts: List<InternalPart>? = emptyList()
   ) {
+    // TODO: add unit tests before sending a pull request (see DevAPIStreamingSnapshotTests.kt)
     internal fun toPublic(): Content {
+      if (parts.isNullOrEmpty()) {
+        return Content(role, listOf(TextPart(" ")))
+      }
       val returnedParts =
         parts.map { it.toPublic() }.filterNot { it is TextPart && it.text.isEmpty() }
       // If all returned parts were text and empty, we coalesce them into a single one-character

--- a/firebase-ai/src/test/java/com/google/firebase/ai/DevAPIStreamingSnapshotTests.kt
+++ b/firebase-ai/src/test/java/com/google/firebase/ai/DevAPIStreamingSnapshotTests.kt
@@ -89,6 +89,21 @@ internal class DevAPIStreamingSnapshotTests {
     }
 
   @Test
+  fun `streaming returned the last Content without parts`() =
+    goldenDevAPIStreamingFile("streaming-success-no-content-parts.txt") {
+      val responses = model.generateContentStream("prompt")
+
+      withTimeout(testTimeout) {
+        val responseList = responses.toList()
+        responseList.isEmpty() shouldBe false
+        responseList.last().candidates.first().apply {
+          finishReason shouldBe FinishReason.STOP
+          content.parts.isEmpty() shouldBe false
+        }
+      }
+    }
+
+  @Test
   fun `stopped for recitation`() =
     goldenDevAPIStreamingFile("streaming-failure-recitation-no-content.txt") {
       val responses = model.generateContentStream("prompt")


### PR DESCRIPTION
In the Gemini Dev API, `Content#parts` is optional, while in the Vertex AI API it is marked as required.
This PR should settle the difference by exposing a list of parts with at least 1 element whenever `Content#parts` is not present.

Golden file PR: https://github.com/FirebaseExtended/vertexai-sdk-test-data/pull/40