### PR TITLE
Add a NamedThreadFactory to WithinAppServiceConnection's Executor.

### DIFF
--- a/firebase-messaging/CHANGELOG.md
+++ b/firebase-messaging/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
-
+* [changed] Added a NamedThreadFactory to WithinAppServiceConnection's service 
+  connection Executor.
 
 # 24.1.1
 * [changed] Bug fix in SyncTask to always unregister the receiver on the same

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/WithinAppServiceConnection.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/WithinAppServiceConnection.java
@@ -27,6 +27,7 @@ import androidx.annotation.GuardedBy;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.common.stats.ConnectionTracker;
+import com.google.android.gms.common.util.concurrent.NamedThreadFactory;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -109,7 +110,9 @@ class WithinAppServiceConnection implements ServiceConnection {
 
   @SuppressLint("ThreadPoolCreation")
   private static ScheduledThreadPoolExecutor createScheduledThreadPoolExecutor() {
-    ScheduledThreadPoolExecutor threadPoolExecutor = new ScheduledThreadPoolExecutor(1);
+    ScheduledThreadPoolExecutor threadPoolExecutor =
+        new ScheduledThreadPoolExecutor(
+            1, new NamedThreadFactory("Firebase-FirebaseInstanceIdServiceConnection"));
     threadPoolExecutor.setKeepAliveTime(EnhancedIntentService.MESSAGE_TIMEOUT_S * 2, SECONDS);
     threadPoolExecutor.allowCoreThreadTimeOut(true);
     return threadPoolExecutor;


### PR DESCRIPTION
- Added back the NamedThreadFactory used by scheduledExecutorService that was removed by https://github.com/firebase/firebase-android-sdk/commit/6383f6d71218b24318372573aaf962711776f4d1