### PR TITLE
dataconnect: Fixed occasional `NullPointerException` leading to erroneous UNAUTHENTICATED exceptions

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 * [fixed] Fixed occasional `NullPointerException` when registering with
   FirebaseAuth, leading to erroneous UNAUTHENTICATED exceptions.
-  ([#nnnn](https://github.com/firebase/firebase-android-sdk/pull/nnnn))
+  ([#7001](https://github.com/firebase/firebase-android-sdk/pull/7001))
 
 # 16.0.2
 * [changed] Improved code robustness related to state management in

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
-
+* [fixed] Fixed occasional `NullPointerException` when registering with
+  FirebaseAuth, leading to erroneous UNAUTHENTICATED exceptions.
+  ([#nnnn](https://github.com/firebase/firebase-android-sdk/pull/nnnn))
 
 # 16.0.2
 * [changed] Improved code robustness related to state management in

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImpl.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImpl.kt
@@ -118,11 +118,12 @@ internal class FirebaseDataConnectImpl(
 
   private val dataConnectAuth: DataConnectAuth =
     DataConnectAuth(
-      deferredAuthProvider = deferredAuthProvider,
-      parentCoroutineScope = coroutineScope,
-      blockingDispatcher = blockingDispatcher,
-      logger = Logger("DataConnectAuth").apply { debug { "created by $instanceId" } },
-    )
+        deferredAuthProvider = deferredAuthProvider,
+        parentCoroutineScope = coroutineScope,
+        blockingDispatcher = blockingDispatcher,
+        logger = Logger("DataConnectAuth").apply { debug { "created by $instanceId" } },
+      )
+      .apply { initialize() }
 
   override suspend fun awaitAuthReady() {
     dataConnectAuth.awaitTokenProvider()
@@ -130,11 +131,12 @@ internal class FirebaseDataConnectImpl(
 
   private val dataConnectAppCheck: DataConnectAppCheck =
     DataConnectAppCheck(
-      deferredAppCheckTokenProvider = deferredAppCheckProvider,
-      parentCoroutineScope = coroutineScope,
-      blockingDispatcher = blockingDispatcher,
-      logger = Logger("DataConnectAppCheck").apply { debug { "created by $instanceId" } },
-    )
+        deferredAppCheckTokenProvider = deferredAppCheckProvider,
+        parentCoroutineScope = coroutineScope,
+        blockingDispatcher = blockingDispatcher,
+        logger = Logger("DataConnectAppCheck").apply { debug { "created by $instanceId" } },
+      )
+      .apply { initialize() }
 
   override suspend fun awaitAppCheckReady() {
     dataConnectAppCheck.awaitTokenProvider()

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
@@ -224,6 +224,30 @@ class DataConnectAuthUnitTest {
   }
 
   @Test
+  fun `forceRefresh() should throw if invoked before initialize() close()`() = runTest {
+    val dataConnectAuth = newDataConnectAuth()
+
+    val exception = shouldThrow<IllegalStateException> { dataConnectAuth.forceRefresh() }
+
+    assertSoftly {
+      exception.message shouldContainWithNonAbuttingText "forceRefresh()"
+      exception.message shouldContainWithNonAbuttingTextIgnoringCase "initialize() must be called"
+    }
+  }
+
+  @Test
+  fun `getToken() should throw if invoked before initialize() close()`() = runTest {
+    val dataConnectAuth = newDataConnectAuth()
+
+    val exception = shouldThrow<IllegalStateException> { dataConnectAuth.getToken(requestId) }
+
+    assertSoftly {
+      exception.message shouldContainWithNonAbuttingText "getToken()"
+      exception.message shouldContainWithNonAbuttingTextIgnoringCase "initialize() must be called"
+    }
+  }
+
+  @Test
   fun `getToken() should return null if InternalAuthProvider is not available`() = runTest {
     val dataConnectAuth = newDataConnectAuth(deferredInternalAuthProvider = UnavailableDeferred())
     dataConnectAuth.initialize()


### PR DESCRIPTION
This PR fixes a race condition in Data Connect where `DataConnectAuth` could register a null token listener before its constructor completed, leading to spurious `NullPointerException` and downstream `UNAUTHENTICATED` errors. It introduces an explicit `initialize()` API to control the setup phase, hooks `initialize()` into `FirebaseDataConnectImpl` for both Auth and AppCheck, and augments unit tests to cover `initialize` and `close` behaviors.

There is, unfortunately, no workaround for the bug. The only mitigation would be to close the `FirebaseDataConnect` object, re-open it, and try again. This fix will be included in the release of the firebase-android-sdk in about 4 weeks, near the end of June 2025.

The bug was easy to reproduce: simply add a call to `Thread.sleep()` in a certain place and, boom. This is a race condition in this code: https://github.com/firebase/firebase-android-sdk/blob/51b4a1c3c03608ad40555113e1189b64dd12505c/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectCredentialsTokenManager.kt#L77-L84

The problem occurred when the `DeferredProviderHandlerImpl` was called back very quickly and the `DataConnectAuth` constructor had not yet completed, namely, not having yet assigned `idTokenListener` ([link](https://github.com/firebase/firebase-android-sdk/blob/4e2dcd0b7518c5fb84d01036c2b196f3c1363473/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAuth.kt#L41)), and, therefore, registering a null listener, resulting in the NullPointerException.


The problematic exception was:

```
FirebaseDataConnect     [16.0.2] DataConnectAuth[id=lgrbeqq7n984t] uncaught exception from a coroutine named CoroutineName(k6rwgqg9gh DataConnectAuth[id=lgrbeqq7n984t] whenAvailable):
java.lang.NullPointerException: null reference
	at com.google.android.gms.common.internal.Preconditions.checkNotNull(com.google.android.gms:play-services-basement@@18.5.0:1)
	at com.google.firebase.auth.FirebaseAuth.addIdTokenListener(com.google.firebase:firebase-auth@@23.2.1:365)
	at com.google.firebase.dataconnect.core.DataConnectAuth.addTokenListener(DataConnectAuth.kt:45)
	at com.google.firebase.dataconnect.core.DataConnectAuth.addTokenListener(DataConnectAuth.kt:29)
	at com.google.firebase.dataconnect.core.DataConnectCredentialsTokenManager.onProviderAvailable(DataConnectCredentialsTokenManager.kt:351)
	at com.google.firebase.dataconnect.core.DataConnectCredentialsTokenManager.access$onProviderAvailable(DataConnectCredentialsTokenManager.kt:54)
	at com.google.firebase.dataconnect.core.DataConnectCredentialsTokenManager$DeferredProviderHandlerImpl.handle(DataConnectCredentialsTokenManager.kt:393)
	at com.google.firebase.components.OptionalProvider.whenAvailable(OptionalProvider.java:77)
	at com.google.firebase.dataconnect.core.DataConnectCredentialsTokenManager$1.invokeSuspend(DataConnectCredentialsTokenManager.kt:82)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:101)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1156)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:651)
	at com.google.firebase.concurrent.CustomThreadFactory.lambda$newThread$0$com-google-firebase-concurrent-CustomThreadFactory(CustomThreadFactory.java:47)
	at com.google.firebase.concurrent.CustomThreadFactory$$ExternalSyntheticLambda0.run(D8$$SyntheticClass:0)
	at java.lang.Thread.run(Thread.java:1119)

```

which would result in an exception later on when a query or mutation was executed:

```
io.grpc.StatusException: UNAUTHENTICATED: unauthenticated: this operation requires a signed-in user
	at io.grpc.Status.asException(Status.java:548)
	at io.grpc.kotlin.ClientCalls$rpcImpl$1$1$1.onClose(ClientCalls.kt:300)
	at io.grpc.internal.DelayedClientCall$DelayedListener$3.run(DelayedClientCall.java:489)
	at io.grpc.internal.DelayedClientCall$DelayedListener.delayOrExecute(DelayedClientCall.java:453)
	at io.grpc.internal.DelayedClientCall$DelayedListener.onClose(DelayedClientCall.java:486)
	at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:574)
	at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:72)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:742)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:723)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1156)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:651)
	at com.google.firebase.concurrent.CustomThreadFactory.lambda$newThread$0$com-google-firebase-concurrent-CustomThreadFactory(CustomThreadFactory.java:47)
	at com.google.firebase.concurrent.CustomThreadFactory$$ExternalSyntheticLambda0.run(D8$$SyntheticClass:0)
	at java.lang.Thread.run(Thread.java:1119)

```

Googlers see b/419064737 for full details of the bug, as reported by a customer.