### PR TITLE
Use the same tag for all logs in sessions

### DIFF
--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/EventGDTLogger.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/EventGDTLogger.kt
@@ -21,6 +21,7 @@ import com.google.android.datatransport.Encoding
 import com.google.android.datatransport.Event
 import com.google.android.datatransport.TransportFactory
 import com.google.firebase.inject.Provider
+import com.google.firebase.sessions.FirebaseSessions.Companion.TAG
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -61,8 +62,6 @@ constructor(private val transportFactoryProvider: Provider<TransportFactory>) :
   }
 
   companion object {
-    private const val TAG = "EventGDTLogger"
-
     private const val AQS_LOG_SOURCE = "FIREBASE_APPQUALITY_SESSION"
   }
 }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
@@ -75,7 +75,7 @@ constructor(
   }
 
   companion object {
-    private const val TAG = "FirebaseSessions"
+    internal const val TAG = "FirebaseSessions"
 
     val instance: FirebaseSessions
       get() = Firebase.app[FirebaseSessions::class.java]

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsComponent.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsComponent.kt
@@ -31,6 +31,7 @@ import com.google.firebase.annotations.concurrent.Background
 import com.google.firebase.annotations.concurrent.Blocking
 import com.google.firebase.inject.Provider
 import com.google.firebase.installations.FirebaseInstallationsApi
+import com.google.firebase.sessions.FirebaseSessions.Companion.TAG
 import com.google.firebase.sessions.settings.CrashlyticsSettingsFetcher
 import com.google.firebase.sessions.settings.LocalOverrideSettings
 import com.google.firebase.sessions.settings.RemoteSettings
@@ -121,8 +122,6 @@ internal interface FirebaseSessionsComponent {
     @Binds @Singleton fun processDataManager(impl: ProcessDataManagerImpl): ProcessDataManager
 
     companion object {
-      private const val TAG = "FirebaseSessions"
-
       @Provides @Singleton fun timeProvider(): TimeProvider = TimeProviderImpl
 
       @Provides @Singleton fun uuidGenerator(): UuidGenerator = UuidGeneratorImpl

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsRegistrar.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsRegistrar.kt
@@ -31,6 +31,7 @@ import com.google.firebase.components.Qualified.qualified
 import com.google.firebase.components.Qualified.unqualified
 import com.google.firebase.installations.FirebaseInstallationsApi
 import com.google.firebase.platforminfo.LibraryVersionComponent
+import com.google.firebase.sessions.FirebaseSessions.Companion.TAG
 import kotlinx.coroutines.CoroutineDispatcher
 
 /**
@@ -71,7 +72,6 @@ internal class FirebaseSessionsRegistrar : ComponentRegistrar {
     )
 
   private companion object {
-    const val TAG = "FirebaseSessions"
     const val LIBRARY_NAME = "fire-sessions"
 
     val appContext = unqualified(Context::class.java)

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/InstallationId.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/InstallationId.kt
@@ -18,13 +18,12 @@ package com.google.firebase.sessions
 
 import android.util.Log
 import com.google.firebase.installations.FirebaseInstallationsApi
+import com.google.firebase.sessions.FirebaseSessions.Companion.TAG
 import kotlinx.coroutines.tasks.await
 
 /** Provides the Firebase installation id and Firebase authentication token. */
 internal class InstallationId private constructor(val fid: String, val authToken: String) {
   companion object {
-    private const val TAG = "InstallationId"
-
     suspend fun create(firebaseInstallations: FirebaseInstallationsApi): InstallationId {
       // Fetch the auth token first, so the fid will be validated.
       val authToken: String =

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionFirelogPublisher.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionFirelogPublisher.kt
@@ -22,6 +22,7 @@ import com.google.firebase.FirebaseApp
 import com.google.firebase.annotations.concurrent.Background
 import com.google.firebase.app
 import com.google.firebase.installations.FirebaseInstallationsApi
+import com.google.firebase.sessions.FirebaseSessions.Companion.TAG
 import com.google.firebase.sessions.api.FirebaseSessionsDependencies
 import com.google.firebase.sessions.settings.SessionsSettings
 import javax.inject.Inject
@@ -122,8 +123,6 @@ constructor(
   }
 
   internal companion object {
-    private const val TAG = "SessionFirelogPublisher"
-
     private val randomValueForSampling: Double = Math.random()
   }
 }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SharedSessionRepository.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SharedSessionRepository.kt
@@ -19,6 +19,7 @@ package com.google.firebase.sessions
 import android.util.Log
 import androidx.datastore.core.DataStore
 import com.google.firebase.annotations.concurrent.Background
+import com.google.firebase.sessions.FirebaseSessions.Companion.TAG
 import com.google.firebase.sessions.api.FirebaseSessionsDependencies
 import com.google.firebase.sessions.api.SessionSubscriber
 import com.google.firebase.sessions.settings.SessionsSettings
@@ -232,9 +233,5 @@ constructor(
 
     Log.d(TAG, "No process data for ${processDataManager.myProcessName}")
     return true
-  }
-
-  private companion object {
-    const val TAG = "SharedSessionRepository"
   }
 }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/api/FirebaseSessionsDependencies.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/api/FirebaseSessionsDependencies.kt
@@ -18,6 +18,7 @@ package com.google.firebase.sessions.api
 
 import android.util.Log
 import androidx.annotation.VisibleForTesting
+import com.google.firebase.sessions.FirebaseSessions.Companion.TAG
 import java.util.Collections.synchronizedMap
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -30,8 +31,6 @@ import kotlinx.coroutines.sync.withLock
  * This is important because the Sessions SDK starts up before dependent SDKs.
  */
 object FirebaseSessionsDependencies {
-  private const val TAG = "SessionsDependencies"
-
   private val dependencies = synchronizedMap(mutableMapOf<SessionSubscriber.Name, Dependency>())
 
   /**

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/RemoteSettings.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/RemoteSettings.kt
@@ -21,6 +21,7 @@ import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.google.firebase.installations.FirebaseInstallationsApi
 import com.google.firebase.sessions.ApplicationInfo
+import com.google.firebase.sessions.FirebaseSessions.Companion.TAG
 import com.google.firebase.sessions.InstallationId
 import com.google.firebase.sessions.TimeProvider
 import javax.inject.Inject
@@ -150,8 +151,6 @@ constructor(
   private fun sanitize(s: String) = s.replace(sanitizeRegex, "")
 
   private companion object {
-    const val TAG = "SessionConfigFetcher"
-
     val defaultCacheDuration = 24.hours.inWholeSeconds.toInt()
 
     val sanitizeRegex = "/".toRegex()

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/SettingsCache.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/SettingsCache.kt
@@ -20,6 +20,7 @@ import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.datastore.core.DataStore
 import com.google.firebase.annotations.concurrent.Background
+import com.google.firebase.sessions.FirebaseSessions.Companion.TAG
 import com.google.firebase.sessions.TimeProvider
 import java.io.IOException
 import java.util.concurrent.atomic.AtomicReference
@@ -107,8 +108,4 @@ constructor(
     } catch (ex: IOException) {
       Log.w(TAG, "Failed to remove config values: $ex")
     }
-
-  private companion object {
-    const val TAG = "SettingsCache"
-  }
 }


### PR DESCRIPTION
Use the same tag for all logs in sessions. This will make it easier to dogfood, and is consistent with Perf and Crashlytics

If any context is lost by losing the tag named after the class, we can update those log lines as we run into them. A future change we can do is refactor to use the firebase common logger