### PR TITLE
dataconnect: DataConnectExecutableVersions.json updated with versions 2.3.0, 2.3.1, 2.4.0, 2.4.1, 2.5.0, 2.6.0, 2.6.1, and 2.6.2

### DIFF
--- a/.github/workflows/dataconnect.yml
+++ b/.github/workflows/dataconnect.yml
@@ -25,7 +25,7 @@ env:
   FDC_JAVA_VERSION: ${{ inputs.javaVersion || '17' }}
   FDC_ANDROID_EMULATOR_API_LEVEL: ${{ inputs.androidEmulatorApiLevel || '34' }}
   FDC_NODEJS_VERSION: ${{ inputs.nodeJsVersion || '20' }}
-  FDC_FIREBASE_TOOLS_VERSION: ${{ inputs.firebaseToolsVersion || '14.2.0' }}
+  FDC_FIREBASE_TOOLS_VERSION: ${{ inputs.firebaseToolsVersion || '14.5.1' }}
   FDC_FIREBASE_TOOLS_DIR: /tmp/firebase-tools
   FDC_FIREBASE_COMMAND: /tmp/firebase-tools/node_modules/.bin/firebase
   FDC_PYTHON_VERSION: ${{ inputs.pythonVersion || '3.13' }}

--- a/.github/workflows/dataconnect_demo_app.yml
+++ b/.github/workflows/dataconnect_demo_app.yml
@@ -18,7 +18,7 @@ on:
 
 env:
   FDC_NODE_VERSION: ${{ inputs.nodeVersion || '20' }}
-  FDC_FIREBASE_TOOLS_VERSION: ${{ inputs.firebaseToolsVersion || '14.2.0' }}
+  FDC_FIREBASE_TOOLS_VERSION: ${{ inputs.firebaseToolsVersion || '14.5.1' }}
   FDC_JAVA_VERSION: ${{ inputs.javaVersion || '17' }}
   FDC_FIREBASE_TOOLS_DIR: ${{ github.workspace }}/firebase-tools
   FDC_FIREBASE_COMMAND: ${{ github.workspace }}/firebase-tools/node_modules/.bin/firebase

--- a/firebase-dataconnect/emulator/dataconnect/connector/person/person_ops.gql
+++ b/firebase-dataconnect/emulator/dataconnect/connector/person/person_ops.gql
@@ -100,3 +100,8 @@ mutation createPersonWithPartialFailure($id: String!, $name: String!) @auth(leve
   person2: person_insert(data: { id_expr: "uuidV4()", name: $name })
 }
 
+mutation createPersonWithPartialFailureInTransaction($id: String!, $name: String!) @auth(level: PUBLIC) @transaction {
+  person1: person_insert(data: { id: $id, name: $name })
+  person2: person_insert(data: { id_expr: "uuidV4()", name: $name }) @check(expr: "false", message: "te36b3zkvn")
+}
+

--- a/firebase-dataconnect/emulator/dataconnect/connector/person/person_ops.gql
+++ b/firebase-dataconnect/emulator/dataconnect/connector/person/person_ops.gql
@@ -96,6 +96,7 @@ query getPersonWithPartialFailure($id: String!) @auth(level: PUBLIC) {
 
 mutation createPersonWithPartialFailure($id: String!, $name: String!) @auth(level: PUBLIC) {
   person1: person_insert(data: { id: $id, name: $name })
-  person2: person_insert(data: { id_expr: "uuidV4()", name: $name }) @check(expr: "false", message: "ecxpjy4qfy")
+  query @redact { person(id: $id) { id @check(expr: "false", message: "ecxpjy4qfy") } }
+  person2: person_insert(data: { id_expr: "uuidV4()", name: $name })
 }
 

--- a/firebase-dataconnect/gradleplugin/plugin/src/main/resources/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableVersions.json
+++ b/firebase-dataconnect/gradleplugin/plugin/src/main/resources/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableVersions.json
@@ -1,5 +1,5 @@
 {
-  "defaultVersion": "2.2.0",
+  "defaultVersion": "2.6.2",
   "versions": [
     {
       "version": "1.3.4",
@@ -630,6 +630,150 @@
       "os": "linux",
       "size": 26452120,
       "sha512DigestHex": "aab441e47115489b968f90d588b08f7a5848cef79849653bde84ffea5612404ec142c3bc87c6a466036a7e3e4228eff667a56ba633d3af93be0082ef4819c25f"
+    },
+    {
+      "version": "2.3.0",
+      "os": "windows",
+      "size": 27728384,
+      "sha512DigestHex": "c822af6c3096923c8448619e1196effcd41f3c4ef1c073743529cc661ca7360aab7e4f09802178d704464dd46d84a66e8a1302d2afe33cc593eebede5d4d08da"
+    },
+    {
+      "version": "2.3.0",
+      "os": "macos",
+      "size": 27271936,
+      "sha512DigestHex": "0e38ba4ec5ac2ad7e4f35f0898006ac465b727ec0342353eb93272422ffa947d63cf41fe0734b427cc6d3101c52aefa1ed4e6309c0dbfb7c4df67c46dfab9bcd"
+    },
+    {
+      "version": "2.3.0",
+      "os": "linux",
+      "size": 27185304,
+      "sha512DigestHex": "206058ffc632139a725ccbb4673edc309f18cef9ffb1c207fa4d38b8f8ada333b710e5360e931022d98a101b06ab9b0e03c8212f7f50c27687e105c97ea5401a"
+    },
+    {
+      "version": "2.3.1",
+      "os": "windows",
+      "size": 27729408,
+      "sha512DigestHex": "86b7f8ebfe786827937bd57d51d1187deae3d910e3146e5fb0e8504cc651a1b984ed529efb6d3741e07e92d43d9605968c8b503c912d22d28d765d9ffddb78c2"
+    },
+    {
+      "version": "2.3.1",
+      "os": "macos",
+      "size": 27271936,
+      "sha512DigestHex": "42a047df82f0cbd89ff266abd460ed2899d92e77f7e5a9a8c4746d478cb1358c7ee91d2dff60eb1873fd59c3647c8f6808ac410a6c952b654f45df50b74ba6e7"
+    },
+    {
+      "version": "2.3.1",
+      "os": "linux",
+      "size": 27185304,
+      "sha512DigestHex": "1f7be86d576bbd7e562c612d36ad49b896618003bc94604e4809a07773a1bcde9b7383ed0dc39e6c2f540f0f49b107867c72cd1333fecc339a82e72bb821af8a"
+    },
+    {
+      "version": "2.4.0",
+      "os": "windows",
+      "size": 27774464,
+      "sha512DigestHex": "0d3b7570daea7b4f5879ed6d8ca0e1e8e4c55b5e617dbf571aa2b479fad3a1ba207d40bdd4ceba5ab557fdb101b9b7149bdeac2c4cb0d9d7885b4afc22df16a2"
+    },
+    {
+      "version": "2.4.0",
+      "os": "macos",
+      "size": 27316992,
+      "sha512DigestHex": "c0fd2654d874528af6dc5296d191bf6d7edca56695b2604e4fe6bff553f81a2871e348686914af22378e3fbfe10bf9c66a41d031521a617fe6c0f6728bf0ba69"
+    },
+    {
+      "version": "2.4.0",
+      "os": "linux",
+      "size": 27230360,
+      "sha512DigestHex": "1edce919f3c2496a1c837b2b84360cca12dfc3b725bdc694a503bea17faacf2f8e32a955eab540d479180f4aab1c46ee82b7c0e752595ed1aeeabc9c01dd5c67"
+    },
+    {
+      "version": "2.4.1",
+      "os": "windows",
+      "size": 27808768,
+      "sha512DigestHex": "bbb903abcb1648a2cbab252389a488d370cd2604222176e0fa1465117fb0b84a9f96638608c465f3fe04a10c3cd90446c5f10ddd596c22ec7157642bf2cbab3a"
+    },
+    {
+      "version": "2.4.1",
+      "os": "macos",
+      "size": 27349760,
+      "sha512DigestHex": "0be315b5c4301386eb5fa4b227cc8fb11c5987c7408f9296895d2fdb850b56cf0e28f42af1266c627f6548eb8e8c90374bfb725bc8becd57d379161e84e059cd"
+    },
+    {
+      "version": "2.4.1",
+      "os": "linux",
+      "size": 27267224,
+      "sha512DigestHex": "a5385cdfc5f5463208660be674ffe02f69c9ae65d1d91c060b2a9f81b3a9313978f2616fe34371fd02cc9e4cb3449eb28b32d359c9dd121c5a3ea0a1e89b746a"
+    },
+    {
+      "version": "2.5.0",
+      "os": "windows",
+      "size": 27836416,
+      "sha512DigestHex": "e0cc3f99361cc7d561742975642fd8b071ceca7c47a6951181d76c6ec087348dbd95bcac6fbacf255d16396bc739f47ec914e18297b3f66d66233f812c7692bc"
+    },
+    {
+      "version": "2.5.0",
+      "os": "macos",
+      "size": 27378432,
+      "sha512DigestHex": "1b1f66a22147b71f1d3ca29f895ddd4763555279d6dffb720044697cfa9e33c202471dd9d0db14e7a95f89f6084d4a35e30d7be53c3cdd9cb1b56dce763e7425"
+    },
+    {
+      "version": "2.5.0",
+      "os": "linux",
+      "size": 27295896,
+      "sha512DigestHex": "b1f25d94af56e1e774df336cddf3bcb54dc855935d131bf3fb8dc69aa9ab814f6e6dfefb684a5637c0b6f84f57586162b32b7402d87522c19fb66e717905825a"
+    },
+    {
+      "version": "2.6.0",
+      "os": "windows",
+      "size": 27875328,
+      "sha512DigestHex": "8f7079028b3c86ad9b2ef33b6840f7ab4c900d1468e32d6e26109f49838703b41ede4726141479dc053ec81fd82f8fbe33f94d4b865c5a5a798f36b211b0bf21"
+    },
+    {
+      "version": "2.6.0",
+      "os": "macos",
+      "size": 27415296,
+      "sha512DigestHex": "80b5d3199f78034b65bc9ab05977d91999dccb29528c3e9658a7e36b1a22bf5ed05b5d90d08ad1793baa74994ec8685386a22f9e407b3c0a4e06c5968738663c"
+    },
+    {
+      "version": "2.6.0",
+      "os": "linux",
+      "size": 27332760,
+      "sha512DigestHex": "c90d691c798466b3f820cc0738b96e030ab2683fe9ad1019692aec58f282e1cd6835c645d229f1a32d899713c97e2451d5e3b29e9468060711f3d08e2312afec"
+    },
+    {
+      "version": "2.6.1",
+      "os": "windows",
+      "size": 27875328,
+      "sha512DigestHex": "06f07a5d8cfdd942393959c21e1511a3d0de6f26d67be78b4dbfdacf021938db089ad4d4945cdeb130e6af4d4a87a93a579954d36a64dac7b58f6ade99c79de3"
+    },
+    {
+      "version": "2.6.1",
+      "os": "macos",
+      "size": 27415296,
+      "sha512DigestHex": "63461d8ef2c41a85b9ebb52fc566e44db8209d2ae750b7137d50529ff1c3861889e2a75ec380e5eaf5e4bf8094594b881d66fe572885bec2456bb33190fe653b"
+    },
+    {
+      "version": "2.6.1",
+      "os": "linux",
+      "size": 27332760,
+      "sha512DigestHex": "668cb4261010ac6bad7136c6a92fdd19c7064a0baf7adf1d11221240a8f3f3c595e74690f048d35ac7f0b5fb9d2753f11dd12a8821dbb39a93763f2332ec44c6"
+    },
+    {
+      "version": "2.6.2",
+      "os": "windows",
+      "size": 27961856,
+      "sha512DigestHex": "e087e9c3adb0be169d0b7bc352132075326e6af2bbea501c0c152c54f07b4dddd9813590a8d7c8b1d4eb058241127ce995f7dd0441095398abbd0c366a345e28"
+    },
+    {
+      "version": "2.6.2",
+      "os": "macos",
+      "size": 27501312,
+      "sha512DigestHex": "02dcd439ba1b6cf1562487478a1de68bafee6e7ff3a21248f20ad336cbe6e06b6e73e250d87a76c1384d003a5f50f85b350d9e91688b5810e65d1b45d56807ea"
+    },
+    {
+      "version": "2.6.2",
+      "os": "linux",
+      "size": 27414680,
+      "sha512DigestHex": "b57c031bda4a6de5d16f6262c9016ee1117ce84e30b439f68325fcdef58a5ee85e1f60b8d3172e498ea52cf3c0dba4d4ff5ff1bf92e8e99e331a6602d5f62e35"
     }
   ]
 }


### PR DESCRIPTION
DataConnectExecutableVersions.json updated with versions 2.3.0, 2.3.1, 2.4.0, 2.4.1, 2.5.0, 2.6.0, 2.6.1, and 2.6.2 by running:

```
./gradlew :firebase-dataconnect:connectors:updateJson -Pversions=2.3.0,2.3.1,2.4.0,2.4.1,2.5.0,2.6.0,2.6.1,2.6.2 -PdefaultVersion=2.6.2
```

As part of this upgrade, 2 test failures needed to be fixed because the `@check` directive on a field with side effects became illegal since cl/756896487. The fix in this PR adds a "query" field (which has no side effects) and, instead, attaches the `@check` directive to that.

This fixes the following 2 test failures in `OperationExecutionErrorsIntegrationTest`:
* `executeMutationFailsWithNonNullDataNonEmptyErrorsDecodingSucceeds`
* `executeMutationFailsWithNonNullDataNonEmptyErrorsDecodingFails`

The test failures looked like this:

```
io.kotest.assertions.MultiAssertionError: The following 2 assertions failed:

1) exception.message
"operation encountered errors during execution: [mutation.createPersonWithPartialFailure.person2: @check is disallowed on side-effect fields unless the operation has @transaction]" should contain the substring "ecxpjy4qfy" with non-abutting text
   at com.google.firebase.dataconnect.testutil.TestUtilsKt.shouldContainWithNonAbuttingText(TestUtils.kt:79)

2) exception.response.rawData
Expected [("person1", [("id", "com.google.firebase.dataconnect.OperationExecutionErrorsIntegrationTest.executeMutationFailsWithNonNullDataNonEmptyErrorsDecodingFails_vNGzY61U2l3DkpBiK4s1")]), ("person2", <null>)] but actual was null

   at com.google.firebase.dataconnect.testutil.DataConnectOperationExceptionTestUtilsKt.shouldSatisfy(DataConnectOperationExceptionTestUtils.kt:74)
	at com.google.firebase.dataconnect.testutil.DataConnectOperationExceptionTestUtilsKt.shouldSatisfy(DataConnectOperationExceptionTestUtils.kt:266)
	at com.google.firebase.dataconnect.OperationExecutionErrorsIntegrationTest$executeMutationFailsWithNonNullDataNonEmptyErrorsDecodingFails$1.invokeSuspend(OperationExecutionErrorsIntegrationTest.kt:224)
```
