### PR TITLE
Add flag to Sessions test app AndroidManifest to enable verbose Fireperf Sessions

### DIFF
--- a/firebase-sessions/test-app/src/main/AndroidManifest.xml
+++ b/firebase-sessions/test-app/src/main/AndroidManifest.xml
@@ -43,6 +43,11 @@
       android:process=":second"
       android:theme="@style/Theme.Widget_test_app.NoActionBar" />
 
+    <!--    Update value to 100.0 to always have a fireperf verbose session-->
+    <meta-data
+        android:name="sessions_sampling_percentage"
+        android:value="1.0" />
+
     <meta-data
       android:name="firebase_performance_logcat_enabled"
       android:value="true" />


### PR DESCRIPTION
This is based on https://github.com/firebase/firebase-android-sdk/blob/c1be5f977031f713fc20881ac39274629a23041c/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigurationConstants.java#L597