### PR TITLE
Add RECORD_AUDIO permission check for Bidi Live API

### DIFF
--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/LiveGenerativeModel.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/LiveGenerativeModel.kt
@@ -16,6 +16,7 @@
 
 package com.google.firebase.ai
 
+import android.content.Context
 import com.google.firebase.FirebaseApp
 import com.google.firebase.ai.common.APIController
 import com.google.firebase.ai.common.AppCheckHeaderProvider
@@ -48,6 +49,7 @@ import kotlinx.serialization.json.JsonObject
 @PublicPreviewAPI
 public class LiveGenerativeModel
 internal constructor(
+  private val context: Context,
   private val modelName: String,
   @Blocking private val blockingDispatcher: CoroutineContext,
   private val config: LiveGenerationConfig? = null,
@@ -69,6 +71,7 @@ internal constructor(
     appCheckTokenProvider: InteropAppCheckTokenProvider? = null,
     internalAuthProvider: InternalAuthProvider? = null,
   ) : this(
+    firebaseApp.applicationContext,
     modelName,
     blockingDispatcher,
     config,
@@ -110,7 +113,11 @@ internal constructor(
       val receivedJson = JSON.parseToJsonElement(receivedJsonStr)
 
       return if (receivedJson is JsonObject && "setupComplete" in receivedJson) {
-        LiveSession(session = webSession, blockingDispatcher = blockingDispatcher)
+        LiveSession(
+          context = context,
+          session = webSession,
+          blockingDispatcher = blockingDispatcher
+        )
       } else {
         webSession.close()
         throw ServiceConnectionHandshakeFailedException("Unable to connect to the server")

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/common/Exceptions.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/common/Exceptions.kt
@@ -134,6 +134,10 @@ internal class UnknownException(message: String, cause: Throwable? = null) :
 internal class ContentBlockedException(message: String, cause: Throwable? = null) :
   FirebaseCommonAIException(message, cause)
 
+/** The request is missing a permission that is required to perform the requested operation. */
+internal class PermissionMissingException(message: String, cause: Throwable? = null) :
+  FirebaseCommonAIException(message, cause)
+
 internal fun makeMissingCaseException(
   source: String,
   ordinal: Int

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveSession.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveSession.kt
@@ -17,6 +17,7 @@
 package com.google.firebase.ai.type
 
 import android.Manifest
+import android.Manifest.permission.RECORD_AUDIO
 import android.content.Context
 import android.content.pm.PackageManager
 import android.media.AudioFormat
@@ -97,8 +98,7 @@ internal constructor(
   public suspend fun startAudioConversation(
     functionCallHandler: ((FunctionCallPart) -> FunctionResponsePart)? = null
   ) {
-    if (
-      context.checkSelfPermission(Manifest.permission.RECORD_AUDIO) !=
+    if (context.checkSelfPermission(Manifest.permission.RECORD_AUDIO) !=
         PackageManager.PERMISSION_GRANTED
     ) {
       throw PermissionMissingException("Missing RECORD_AUDIO")

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveSession.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveSession.kt
@@ -22,6 +22,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.media.AudioFormat
 import android.media.AudioTrack
+import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresPermission
 import com.google.firebase.ai.common.JSON
@@ -98,11 +99,13 @@ internal constructor(
   public suspend fun startAudioConversation(
     functionCallHandler: ((FunctionCallPart) -> FunctionResponsePart)? = null
   ) {
-    if (
-      context.checkSelfPermission(Manifest.permission.RECORD_AUDIO) !=
-        PackageManager.PERMISSION_GRANTED
-    ) {
-      throw PermissionMissingException("Missing RECORD_AUDIO")
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      if (
+        context.checkSelfPermission(Manifest.permission.RECORD_AUDIO) !=
+          PackageManager.PERMISSION_GRANTED
+      ) {
+        throw PermissionMissingException("Missing RECORD_AUDIO")
+      }
     }
 
     FirebaseAIException.catchAsync {

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveSession.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveSession.kt
@@ -98,7 +98,8 @@ internal constructor(
   public suspend fun startAudioConversation(
     functionCallHandler: ((FunctionCallPart) -> FunctionResponsePart)? = null
   ) {
-    if (context.checkSelfPermission(Manifest.permission.RECORD_AUDIO) !=
+    if (
+      context.checkSelfPermission(Manifest.permission.RECORD_AUDIO) !=
         PackageManager.PERMISSION_GRANTED
     ) {
       throw PermissionMissingException("Missing RECORD_AUDIO")

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveSession.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveSession.kt
@@ -97,7 +97,8 @@ internal constructor(
   public suspend fun startAudioConversation(
     functionCallHandler: ((FunctionCallPart) -> FunctionResponsePart)? = null
   ) {
-    if (context.checkSelfPermission(Manifest.permission.RECORD_AUDIO) !=
+    if (
+      context.checkSelfPermission(Manifest.permission.RECORD_AUDIO) !=
         PackageManager.PERMISSION_GRANTED
     ) {
       throw PermissionMissingException("Missing RECORD_AUDIO")

--- a/firebase-ai/src/test/java/com/google/firebase/ai/type/LiveSessionTest.kt
+++ b/firebase-ai/src/test/java/com/google/firebase/ai/type/LiveSessionTest.kt
@@ -35,7 +35,7 @@ import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.`when`
 import org.mockito.junit.MockitoJUnitRunner
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class, PublicPreviewAPI::class)
 @RunWith(MockitoJUnitRunner::class)
 class LiveSessionTest {
 

--- a/firebase-ai/src/test/java/com/google/firebase/ai/type/LiveSessionTest.kt
+++ b/firebase-ai/src/test/java/com/google/firebase/ai/type/LiveSessionTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.firebase.ai.type
 
 import android.Manifest

--- a/firebase-ai/src/test/java/com/google/firebase/ai/type/LiveSessionTest.kt
+++ b/firebase-ai/src/test/java/com/google/firebase/ai/type/LiveSessionTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright 2025 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.google.firebase.ai.type
 
 import android.Manifest
@@ -63,7 +47,9 @@ class LiveSessionTest {
   @Test
   fun `startAudioConversation with RECORD_AUDIO permission proceeds normally`() = runTest {
     // Arrange
-    `when`(mockContext.checkSelfPermission(Manifest.permission.RECORD_AUDIO))
+    `when`(
+        mockContext.checkSelfPermission(Manifest.permission.RECORD_AUDIO)
+      )
       .thenReturn(PackageManager.PERMISSION_GRANTED)
 
     // Act & Assert
@@ -75,7 +61,9 @@ class LiveSessionTest {
   fun `startAudioConversation without RECORD_AUDIO permission throws PermissionMissingException`() =
     runTest {
       // Arrange
-      `when`(mockContext.checkSelfPermission(Manifest.permission.RECORD_AUDIO))
+      `when`(
+          mockContext.checkSelfPermission(Manifest.permission.RECORD_AUDIO)
+        )
         .thenReturn(PackageManager.PERMISSION_DENIED)
 
       // Act & Assert

--- a/firebase-ai/src/test/java/com/google/firebase/ai/type/LiveSessionTest.kt
+++ b/firebase-ai/src/test/java/com/google/firebase/ai/type/LiveSessionTest.kt
@@ -63,9 +63,7 @@ class LiveSessionTest {
   @Test
   fun `startAudioConversation with RECORD_AUDIO permission proceeds normally`() = runTest {
     // Arrange
-    `when`(
-        mockContext.checkSelfPermission(Manifest.permission.RECORD_AUDIO)
-      )
+    `when`(mockContext.checkSelfPermission(Manifest.permission.RECORD_AUDIO))
       .thenReturn(PackageManager.PERMISSION_GRANTED)
 
     // Act & Assert
@@ -77,9 +75,7 @@ class LiveSessionTest {
   fun `startAudioConversation without RECORD_AUDIO permission throws PermissionMissingException`() =
     runTest {
       // Arrange
-      `when`(
-          mockContext.checkSelfPermission(Manifest.permission.RECORD_AUDIO)
-        )
+      `when`(mockContext.checkSelfPermission(Manifest.permission.RECORD_AUDIO))
         .thenReturn(PackageManager.PERMISSION_DENIED)
 
       // Act & Assert

--- a/firebase-ai/src/test/java/com/google/firebase/ai/type/LiveSessionTest.kt
+++ b/firebase-ai/src/test/java/com/google/firebase/ai/type/LiveSessionTest.kt
@@ -1,0 +1,76 @@
+package com.google.firebase.ai.type
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import com.google.firebase.ai.common.PermissionMissingException
+import io.ktor.client.plugins.websocket.ClientWebSocketSession
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.`when`
+import org.mockito.junit.MockitoJUnitRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(MockitoJUnitRunner::class)
+class LiveSessionTest {
+
+  @Mock private lateinit var mockContext: Context
+  @Mock private lateinit var mockPackageManager: PackageManager
+  @Mock private lateinit var mockSession: ClientWebSocketSession
+  @Mock private lateinit var mockAudioHelper: AudioHelper
+
+  private lateinit var testDispatcher: CoroutineContext
+  private lateinit var liveSession: LiveSession
+
+  @Before
+  fun setUp() {
+    testDispatcher = UnconfinedTestDispatcher()
+    `when`(mockContext.packageManager).thenReturn(mockPackageManager)
+
+    // Mock AudioHelper.build() to return our mockAudioHelper
+    // Need to use mockStatic for static methods
+    mockStatic(AudioHelper::class.java).use { mockedAudioHelper ->
+      mockedAudioHelper.`when`<AudioHelper> { AudioHelper.build() }.thenReturn(mockAudioHelper)
+      liveSession = LiveSession(mockContext, mockSession, testDispatcher, null)
+    }
+  }
+
+  @Test
+  fun `startAudioConversation with RECORD_AUDIO permission proceeds normally`() = runTest {
+    // Arrange
+    `when`(
+        mockContext.checkSelfPermission(Manifest.permission.RECORD_AUDIO)
+      )
+      .thenReturn(PackageManager.PERMISSION_GRANTED)
+
+    // Act & Assert
+    // No exception should be thrown
+    liveSession.startAudioConversation()
+  }
+
+  @Test
+  fun `startAudioConversation without RECORD_AUDIO permission throws PermissionMissingException`() =
+    runTest {
+      // Arrange
+      `when`(
+          mockContext.checkSelfPermission(Manifest.permission.RECORD_AUDIO)
+        )
+        .thenReturn(PackageManager.PERMISSION_DENIED)
+
+      // Act & Assert
+      val exception =
+        assertThrows(PermissionMissingException::class.java) {
+          runTest { liveSession.startAudioConversation() }
+        }
+      assertEquals("Missing RECORD_AUDIO", exception.message)
+    }
+}


### PR DESCRIPTION
Added a check for the RECORD_AUDIO permission in the AI Logic SDK for Bidi (Live API) within the `LiveSession.startAudioConversation()` method.

If the permission is missing, a `PermissionMissingException` is thrown with the message "Missing RECORD_AUDIO".

Also added unit tests to verify the new permission check behavior.