### PR TITLE
dataconnect: demo: build.gradle.kts: update dependencies

### DIFF
--- a/firebase-dataconnect/demo/build.gradle.kts
+++ b/firebase-dataconnect/demo/build.gradle.kts
@@ -19,10 +19,10 @@ import java.nio.charset.StandardCharsets
 
 plugins {
   // Use whichever versions of these dependencies suit your application.
-  // The versions shown here were the latest versions as of May 09, 2025.
+  // The versions shown here were the latest versions as of June 10, 2025.
   // Note, however, that the version of kotlin("plugin.serialization") _must_,
   // in general, match the version of kotlin("android").
-  id("com.android.application") version "8.9.2"
+  id("com.android.application") version "8.10.1"
   id("com.google.gms.google-services") version "4.4.2"
   val kotlinVersion = "2.1.10"
   kotlin("android") version kotlinVersion
@@ -35,14 +35,17 @@ plugins {
 
 dependencies {
   // Use whichever versions of these dependencies suit your application.
-  // The versions shown here were the latest versions as of May 09, 2025.
-  implementation("com.google.firebase:firebase-dataconnect:16.0.1")
+  // The versions shown here were the latest versions as of June 10, 2025.
+
+  // Data Connect
+  implementation(platform("com.google.firebase:firebase-bom:33.15.0"))
+  implementation("com.google.firebase:firebase-dataconnect")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.1")
-  implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.8.0")
-  implementation("androidx.appcompat:appcompat:1.7.0")
+  implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.8.1")
+  implementation("androidx.appcompat:appcompat:1.7.1")
   implementation("androidx.activity:activity-ktx:1.10.1")
-  implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.0")
+  implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.1")
   implementation("com.google.android.material:material:1.12.0")
 
   // The following code in this "dependencies" block can be omitted from customer


### PR DESCRIPTION
Update the dependencies used in the Data Connect demo application's build file. The primary change involves adopting the recommended practice of using the Firebase Bill of Materials (BoM) to manage the version of the `firebase-dataconnect` library. Additionally, several other key library versions are updated to more recent releases.

### Highlights

* **Dependency Management**: Switched the `firebase-dataconnect` dependency in the demo app's `build.gradle.kts` to use the Firebase Bill of Materials (BoM) version `33.15.0` instead of specifying an explicit version for the individual library.
* **Dependency Updates**: Updated several other dependencies in the demo app, including the Android Gradle Plugin (`8.10.1`), `kotlinx-serialization-core` (`1.8.1`), `androidx.appcompat` (`1.7.1`), and `androidx.lifecycle:lifecycle-viewmodel-ktx` (`2.9.1`).
