### PR TITLE
dataconnect: demo: build.gradle.kts: add ability to specify the Data Connect emulator executable to use

### DIFF
--- a/.github/workflows/dataconnect_demo_app.yml
+++ b/.github/workflows/dataconnect_demo_app.yml
@@ -109,7 +109,7 @@ jobs:
           --no-daemon \
           ${{ (inputs.gradleInfoLog && '--info') || '' }} \
           --profile \
-          -PdataConnect.minimalApp.firebaseCommand=${{ env.FDC_FIREBASE_COMMAND }} \
+          -PdataConnect.demo.firebaseCommand=${{ env.FDC_FIREBASE_COMMAND }} \
           assemble test
 
       - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1

--- a/firebase-dataconnect/demo/build.gradle.kts
+++ b/firebase-dataconnect/demo/build.gradle.kts
@@ -277,9 +277,7 @@ run {
       outputDirectory = layout.buildDirectory.dir("dataConnect/generatedSources")
 
       firebaseCommand =
-        project.providers
-          .gradleProperty("dataConnect.demo.firebaseCommand")
-          .orElse("firebase")
+        project.providers.gradleProperty("dataConnect.demo.firebaseCommand").orElse("firebase")
 
       nodeExecutableDirectory =
         project.providers.gradleProperty("dataConnect.demo.nodeExecutableDirectory").map {
@@ -287,9 +285,9 @@ run {
         }
 
       dataConnectEmulatorExecutable =
-        project.providers
-          .gradleProperty("dataConnect.demo.dataConnectEmulatorExecutable")
-          .map { projectDirectory.file(it) }
+        project.providers.gradleProperty("dataConnect.demo.dataConnectEmulatorExecutable").map {
+          projectDirectory.file(it)
+        }
 
       val path = providers.environmentVariable("PATH")
       firebaseToolsVersion =

--- a/firebase-dataconnect/demo/build.gradle.kts
+++ b/firebase-dataconnect/demo/build.gradle.kts
@@ -19,10 +19,10 @@ import java.nio.charset.StandardCharsets
 
 plugins {
   // Use whichever versions of these dependencies suit your application.
-  // The versions shown here were the latest versions as of May 09, 2025.
+  // The versions shown here were the latest versions as of June 10, 2025.
   // Note, however, that the version of kotlin("plugin.serialization") _must_,
   // in general, match the version of kotlin("android").
-  id("com.android.application") version "8.9.2"
+  id("com.android.application") version "8.10.1"
   id("com.google.gms.google-services") version "4.4.2"
   val kotlinVersion = "2.1.10"
   kotlin("android") version kotlinVersion
@@ -35,14 +35,17 @@ plugins {
 
 dependencies {
   // Use whichever versions of these dependencies suit your application.
-  // The versions shown here were the latest versions as of May 09, 2025.
-  implementation("com.google.firebase:firebase-dataconnect:16.0.1")
+  // The versions shown here were the latest versions as of June 10, 2025.
+
+  // Data Connect
+  implementation(platform("com.google.firebase:firebase-bom:33.15.0"))
+  implementation("com.google.firebase:firebase-dataconnect")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.1")
-  implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.8.0")
-  implementation("androidx.appcompat:appcompat:1.7.0")
+  implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.8.1")
+  implementation("androidx.appcompat:appcompat:1.7.1")
   implementation("androidx.activity:activity-ktx:1.10.1")
-  implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.0")
+  implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.1")
   implementation("com.google.android.material:material:1.12.0")
 
   // The following code in this "dependencies" block can be omitted from customer

--- a/firebase-dataconnect/demo/build.gradle.kts
+++ b/firebase-dataconnect/demo/build.gradle.kts
@@ -124,6 +124,11 @@ abstract class DataConnectGenerateSourcesTask : DefaultTask() {
 
   @get:Input @get:Optional abstract val nodeExecutableDirectory: Property<String>
 
+  @get:InputFile
+  @get:Optional
+  @get:PathSensitive(PathSensitivity.ABSOLUTE)
+  abstract val dataConnectEmulatorExecutable: RegularFileProperty
+
   @get:OutputDirectory abstract val outputDirectory: DirectoryProperty
 
   @get:Internal abstract val workDirectory: DirectoryProperty
@@ -140,6 +145,7 @@ abstract class DataConnectGenerateSourcesTask : DefaultTask() {
     val firebaseToolsVersion: String = firebaseToolsVersion.get()
     val firebaseCommand: String = firebaseCommand.get()
     val nodeExecutableDirectory: String? = nodeExecutableDirectory.orNull
+    val dataConnectEmulatorExecutable: File? = dataConnectEmulatorExecutable.orNull?.asFile
     val outputDirectory: File = outputDirectory.get().asFile
     val workDirectory: File = workDirectory.get().asFile
 
@@ -147,6 +153,7 @@ abstract class DataConnectGenerateSourcesTask : DefaultTask() {
     logger.info("firebaseToolsVersion: {}", firebaseToolsVersion)
     logger.info("firebaseCommand: {}", firebaseCommand)
     logger.info("nodeExecutableDirectory: {}", nodeExecutableDirectory)
+    logger.info("dataConnectEmulatorExecutable: {}", dataConnectEmulatorExecutable)
     logger.info("outputDirectory: {}", outputDirectory.absolutePath)
     logger.info("workDirectory: {}", workDirectory.absolutePath)
 
@@ -170,6 +177,7 @@ abstract class DataConnectGenerateSourcesTask : DefaultTask() {
               this,
               firebaseCommand = firebaseCommand,
               nodeExecutableDirectory = nodeExecutableDirectory,
+              dataConnectEmulatorExecutable = dataConnectEmulatorExecutable,
               path = providerFactory.environmentVariable("PATH").orNull,
             )
             args("--debug", "dataconnect:sdk:generate")
@@ -197,6 +205,7 @@ abstract class DataConnectGenerateSourcesTask : DefaultTask() {
       execSpec: ExecSpec,
       firebaseCommand: String,
       nodeExecutableDirectory: String?,
+      dataConnectEmulatorExecutable: File?,
       path: String?,
     ) {
       execSpec.setCommandLine(firebaseCommand)
@@ -214,6 +223,10 @@ abstract class DataConnectGenerateSourcesTask : DefaultTask() {
 
       if (newPath !== null) {
         execSpec.environment("PATH", newPath)
+      }
+
+      if (dataConnectEmulatorExecutable !== null) {
+        execSpec.environment("DATACONNECT_EMULATOR_BINARY_PATH", dataConnectEmulatorExecutable)
       }
     }
   }
@@ -265,13 +278,18 @@ run {
 
       firebaseCommand =
         project.providers
-          .gradleProperty("dataConnect.minimalApp.firebaseCommand")
+          .gradleProperty("dataConnect.demo.firebaseCommand")
           .orElse("firebase")
 
       nodeExecutableDirectory =
-        project.providers.gradleProperty("dataConnect.minimalApp.nodeExecutableDirectory").map {
+        project.providers.gradleProperty("dataConnect.demo.nodeExecutableDirectory").map {
           projectDirectory.dir(it).asFile.absolutePath
         }
+
+      dataConnectEmulatorExecutable =
+        project.providers
+          .gradleProperty("dataConnect.demo.dataConnectEmulatorExecutable")
+          .map { projectDirectory.file(it) }
 
       val path = providers.environmentVariable("PATH")
       firebaseToolsVersion =
@@ -281,6 +299,7 @@ run {
               this,
               firebaseCommand = firebaseCommand.get(),
               nodeExecutableDirectory = nodeExecutableDirectory.orNull,
+              dataConnectEmulatorExecutable = dataConnectEmulatorExecutable.orNull?.asFile,
               path = path.orNull,
             )
             args("--version")

--- a/firebase-dataconnect/demo/build.gradle.kts
+++ b/firebase-dataconnect/demo/build.gradle.kts
@@ -226,7 +226,10 @@ abstract class DataConnectGenerateSourcesTask : DefaultTask() {
       }
 
       if (dataConnectEmulatorExecutable !== null) {
-        execSpec.environment("DATACONNECT_EMULATOR_BINARY_PATH", dataConnectEmulatorExecutable)
+        execSpec.environment(
+          "DATACONNECT_EMULATOR_BINARY_PATH",
+          dataConnectEmulatorExecutable.absolutePath,
+        )
       }
     }
   }

--- a/firebase-dataconnect/demo/gradle.properties
+++ b/firebase-dataconnect/demo/gradle.properties
@@ -5,3 +5,21 @@ org.gradle.caching=true
 android.useAndroidX=true
 
 org.gradle.jvmargs=-Xmx2g
+
+// The path of the "firebase" command to use.
+// If not specified, then "firebase" is used, resolved using the PATH environment variable.
+// See build.gradle.kts for details.
+//dataConnect.demo.firebaseCommand=/path/to/firebase
+
+// The path of the directory containing the "node" and "npm" commands.
+// This directory will be prepended to the PATH before running the "firebase" command
+// and may be useful to override the "node" and "npm" executables that get used by it.
+// See build.gradle.kts for details.
+//dataConnect.demo.nodeExecutableDirectory=/path/to/node/bin
+
+// The Data Connect emulator executable to use.
+// If set, the `DATACONNECT_EMULATOR_BINARY_PATH` environment variable will be set before calling
+// the "firebase" command to instruct it to use the specified Data Connect emulator rather than
+// downloading an official version and using it.
+// See build.gradle.kts for details.
+//dataConnect.demo.dataConnectEmulatorExecutable=/path/to/cli


### PR DESCRIPTION
Enhance the Data Connect demo's Gradle build configuration by introducing a new option to explicitly define the path to the Data Connect emulator executable. This provides flexibility for developers who may need to use a specific version or a locally-built emulator binary instead of relying on the one automatically managed by the Firebase CLI.

### Highlights

* **Emulator Executable Path**: Added ability to specify the path to the Data Connect emulator executable via a new Gradle property (`dataConnect.demo.dataConnectEmulatorExecutable`). This allows overriding the default emulator used by the `firebase` command.
* **Environment Variable**: When the custom emulator path is provided, the build script now sets the `DATACONNECT_EMULATOR_BINARY_PATH` environment variable before executing the `firebase` command, instructing it to use the specified binary.
* **Gradle Property Naming**: Updated the Gradle property names used in the demo build from `dataConnect.minimalApp.*` to `dataConnect.demo.*` for consistency.
