### PR TITLE
[Storage] Replace hardcoded SDK version with Config.OLDEST_SDK

### DIFF
--- a/firebase-storage/src/test/java/com/google/firebase/storage/AdaptiveStreamBufferTest.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/AdaptiveStreamBufferTest.java
@@ -16,7 +16,6 @@ package com.google.firebase.storage;
 
 import static org.junit.Assert.assertArrayEquals;
 
-import android.os.Build;
 import com.google.firebase.storage.internal.AdaptiveStreamBuffer;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -30,7 +29,7 @@ import org.robolectric.annotation.Config;
 
 /** Tests for {@link AdaptiveStreamBuffer}. */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = Build.VERSION_CODES.LOLLIPOP_MR1)
+@Config(sdk = Config.OLDEST_SDK)
 public class AdaptiveStreamBufferTest {
 
   @Rule public RetryRule retryRule = new RetryRule(3);

--- a/firebase-storage/src/test/java/com/google/firebase/storage/DependencyTest.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/DependencyTest.java
@@ -14,7 +14,6 @@
 
 package com.google.firebase.storage;
 
-import android.os.Build;
 import com.google.android.gms.tasks.Task;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -29,7 +28,7 @@ import org.robolectric.annotation.Config;
 
 /** Tests for {@link FirebaseStorage}. */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = Build.VERSION_CODES.LOLLIPOP_MR1)
+@Config(sdk = Config.OLDEST_SDK)
 public class DependencyTest {
 
   @Rule public RetryRule retryRule = new RetryRule(3);

--- a/firebase-storage/src/test/java/com/google/firebase/storage/StorageReferenceTest.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/StorageReferenceTest.java
@@ -16,7 +16,6 @@ package com.google.firebase.storage;
 
 import static com.google.firebase.common.testutil.Assert.assertThrows;
 
-import android.os.Build;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
@@ -38,7 +37,7 @@ import org.robolectric.annotation.Config;
 
 /** Tests for {@link FirebaseStorage}. */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = Build.VERSION_CODES.LOLLIPOP_MR1)
+@Config(sdk = Config.OLDEST_SDK)
 public class StorageReferenceTest {
 
   @Rule public RetryRule retryRule = new RetryRule(3);

--- a/firebase-storage/src/test/java/com/google/firebase/storage/StreamProgressWrapperTest.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/StreamProgressWrapperTest.java
@@ -16,7 +16,6 @@ package com.google.firebase.storage;
 
 import static com.google.firebase.common.testutil.Assert.assertThrows;
 
-import android.os.Build;
 import com.google.firebase.storage.StreamDownloadTask.StreamProgressWrapper;
 import com.google.firebase.storage.network.MockInputStreamHelper;
 import java.io.ByteArrayInputStream;
@@ -35,7 +34,7 @@ import org.robolectric.annotation.Config;
 
 /** Tests for {@link StreamProgressWrapper}. */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = Build.VERSION_CODES.LOLLIPOP_MR1)
+@Config(sdk = Config.OLDEST_SDK)
 @SuppressWarnings("ResultOfMethodCallIgnored")
 public class StreamProgressWrapperTest {
 


### PR DESCRIPTION
Tests will use the Config.OLDEST_SDK instead of a hardcoded SDK if the corresponding hardcoded SDK would be below our inteded minSdk.

As a pending work is re-evaluate whether these tests are necessary to keep around, or if they are irrelevant when bumping the minSdk.

Related to cl/769913191