### PR TITLE
[Ai] Deprecate totalBillableCharacters

### DIFF
--- a/firebase-ai/CHANGELOG.md
+++ b/firebase-ai/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+* [changed] Deprecate the `totalBillableCharacters` field (only usable with pre-2.0 models). (#7042)
 
 # 16.1.0
 * [fixed] Fixed `FirebaseAI.getInstance` StackOverflowException (#6971)
@@ -9,7 +9,7 @@
     * **Action Required:** Update all references of `SpeechConfig` initialization to use `Voice` class.
 * [fixed] Fix incorrect model name in count token requests to the developer API backend
 * [feature] Added support for extra schema properties like `title`, `minItems`, `maxItems`, `minimum`
- and `maximum`. As well as support for the `anyOf` schema. 
+ and `maximum`. As well as support for the `anyOf` schema.
 
 # 16.0.0
 * [feature] Initial release of the Firebase AI SDK (`firebase-ai`). This SDK *replaces* the previous
@@ -28,4 +28,3 @@
 
  Note: This feature is in Public Preview, which means that it is not subject to any SLA or
  deprecation policy and could change in backwards-incompatible ways.
-

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/CountTokensResponse.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/CountTokensResponse.kt
@@ -29,9 +29,9 @@ import kotlinx.serialization.Serializable
  * @property totalBillableCharacters The total number of billable characters in the text input given
  * to the model as a prompt. **Important:** this property does not include billable image, video or
  * other non-text input. See
- * [Vertex AI pricing](https://cloud.google.com/vertex-ai/generative-ai/pricing) for details. 
+ * [Vertex AI pricing](https://cloud.google.com/vertex-ai/generative-ai/pricing) for details.
  * @property promptTokensDetails The breakdown, by modality, of how many tokens are consumed by the
- * prompt. 
+ * prompt.
  */
 public class CountTokensResponse(
   public val totalTokens: Int,

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/CountTokensResponse.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/CountTokensResponse.kt
@@ -29,10 +29,9 @@ import kotlinx.serialization.Serializable
  * @property totalBillableCharacters The total number of billable characters in the text input given
  * to the model as a prompt. **Important:** this property does not include billable image, video or
  * other non-text input. See
- * [Vertex AI pricing](https://cloud.google.com/vertex-ai/generative-ai/pricing) for details.
- * @deprecated This field is deprecated and will be removed in a future version.
+ * [Vertex AI pricing](https://cloud.google.com/vertex-ai/generative-ai/pricing) for details. 
  * @property promptTokensDetails The breakdown, by modality, of how many tokens are consumed by the
- * prompt.
+ * prompt. 
  */
 public class CountTokensResponse(
   public val totalTokens: Int,

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/CountTokensResponse.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/CountTokensResponse.kt
@@ -36,7 +36,8 @@ import kotlinx.serialization.Serializable
  */
 public class CountTokensResponse(
   public val totalTokens: Int,
-  @Deprecated("This field is deprecated and will be removed in a future version.") public val totalBillableCharacters: Int? = null,
+  @Deprecated("This field is deprecated and will be removed in a future version.")
+  public val totalBillableCharacters: Int? = null,
   public val promptTokensDetails: List<ModalityTokenCount> = emptyList(),
 ) {
   public operator fun component1(): Int = totalTokens

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/CountTokensResponse.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/CountTokensResponse.kt
@@ -30,12 +30,13 @@ import kotlinx.serialization.Serializable
  * to the model as a prompt. **Important:** this property does not include billable image, video or
  * other non-text input. See
  * [Vertex AI pricing](https://cloud.google.com/vertex-ai/generative-ai/pricing) for details.
+ * @deprecated This field is deprecated and will be removed in a future version.
  * @property promptTokensDetails The breakdown, by modality, of how many tokens are consumed by the
  * prompt.
  */
 public class CountTokensResponse(
   public val totalTokens: Int,
-  public val totalBillableCharacters: Int? = null,
+  @Deprecated("This field is deprecated and will be removed in a future version.") public val totalBillableCharacters: Int? = null,
   public val promptTokensDetails: List<ModalityTokenCount> = emptyList(),
 ) {
   public operator fun component1(): Int = totalTokens


### PR DESCRIPTION
I've marked the `totalBillableCharacters` field in `CountTokensResponse.kt` as deprecated. This includes adding the `@Deprecated` annotation and a corresponding KDoc `@deprecated` tag.

The field is planned to be removed in a future version of the SDK.