### PR TITLE
Fix cold starts incorrectly using the previous firstSessionId

### DIFF
--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SharedSessionRepositoryTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SharedSessionRepositoryTest.kt
@@ -127,9 +127,7 @@ class SharedSessionRepositoryTest {
     fakeDataStore.close()
 
     assertThat(sharedSessionRepository.localSessionData.sessionDetails)
-      .isEqualTo(
-        SessionDetails(SESSION_ID_1, SESSION_ID_INIT, 1, fakeTimeProvider.currentTime().us)
-      )
+      .isEqualTo(SessionDetails(SESSION_ID_1, SESSION_ID_1, 0, fakeTimeProvider.currentTime().us))
   }
 
   @Test


### PR DESCRIPTION
Fix cold starts incorrectly using the previous firstSessionId and sessionIndex

This came up during the dogfooding session

When a cold start happens, we must always create a new session. Before this fix, it would preserve the current session's firstSesisonId and sessionIndex when that session hadn't expired. But a cold start is regardless of the current session expiring