### PR TITLE
[Ai] Move changelog entry to the correct section

### DIFF
--- a/firebase-ai/CHANGELOG.md
+++ b/firebase-ai/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 * [changed] Deprecate the `totalBillableCharacters` field (only usable with pre-2.0 models). (#7042)
+* [feature] Added support for extra schema properties like `title`, `minItems`, `maxItems`, `minimum`
+ and `maximum`. As well as support for the `anyOf` schema. (#7013)
 
 # 16.1.0
 * [fixed] Fixed `FirebaseAI.getInstance` StackOverflowException (#6971)
@@ -8,8 +10,7 @@
 * [changed] **Breaking Change**: Updated `SpeechConfig` to take in `Voice` class instead of `Voices` class.
     * **Action Required:** Update all references of `SpeechConfig` initialization to use `Voice` class.
 * [fixed] Fix incorrect model name in count token requests to the developer API backend
-* [feature] Added support for extra schema properties like `title`, `minItems`, `maxItems`, `minimum`
- and `maximum`. As well as support for the `anyOf` schema.
+
 
 # 16.0.0
 * [feature] Initial release of the Firebase AI SDK (`firebase-ai`). This SDK *replaces* the previous


### PR DESCRIPTION
The changes in #7013 mistakenly put the changelog entry for the change in the "16.1.0" section, when it should be part of the "Unreleased" section