### PR TITLE
[Ai] Use correct release notes name

### DIFF
--- a/firebase-ai/firebase-ai.gradle.kts
+++ b/firebase-ai/firebase-ai.gradle.kts
@@ -28,7 +28,7 @@ firebaseLibrary {
   testLab.enabled = false
   publishJavadoc = true
   releaseNotes {
-    name.set("{{firebase_ai}}")
+    name.set("{{firebase_ai_logic}}")
     versionName.set("ai")
     hasKTX.set(false)
   }


### PR DESCRIPTION
The release notes were being generated with the outdated {{firebase_ai}} instead of the correct {{firebase_ai_logic}}.

Reference cl/773420536