### PR TITLE
[Common] Replace hardcoded SDK version with Config.OLDEST_SDK (2)

### DIFF
--- a/firebase-common/src/test/java/com/google/firebase/DataCollectionPreNDefaultEnabledTest.java
+++ b/firebase-common/src/test/java/com/google/firebase/DataCollectionPreNDefaultEnabledTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
 @RunWith(AndroidJUnit4.class)
-@Config(sdk = 21)
+@Config(sdk = Config.OLDEST_SDK)
 public class DataCollectionPreNDefaultEnabledTest {
 
   @Test

--- a/firebase-common/src/test/java/com/google/firebase/platforminfo/FirebasePlatformLoggingTest.java
+++ b/firebase-common/src/test/java/com/google/firebase/platforminfo/FirebasePlatformLoggingTest.java
@@ -87,7 +87,7 @@ public class FirebasePlatformLoggingTest {
   }
 
   @Test
-  @Config(sdk = Build.VERSION_CODES.LOLLIPOP_MR1)
+  @Config(sdk = Config.OLDEST_SDK)
   public void test_auto_atNotHighEnoughApiLevel() {
     ShadowPackageManager shadowPackageManager =
         shadowOf(ApplicationProvider.getApplicationContext().getPackageManager());
@@ -98,7 +98,7 @@ public class FirebasePlatformLoggingTest {
         app -> {
           UserAgentPublisher ua = app.get(UserAgentPublisher.class);
 
-          assertThat(ua.getUserAgent()).containsMatch(Pattern.compile("android-platform/($|\\s)"));
+          assertThat(ua.getUserAgent()).containsMatch(Pattern.compile("android-installer/($|\\s)"));
         });
   }
 


### PR DESCRIPTION
Tests will use the Config.OLDEST_SDK instead of a hardcoded SDK if the corresponding hardcoded SDK would be below our intended minSdk.

I'll also need to re-evaluate whether these tests are necessary to keep around, or if they are irrelevant when bumping the minSdk.

Related to cl/769912845