### PR TITLE
[Ai] Fix `anyOf` refdoc

### DIFF
--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/Schema.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/Schema.kt
@@ -309,14 +309,12 @@ internal constructor(
      *
      * Example: A field that can hold either a simple userID or a more detailed user object.
      *
-     * Schema.anyOf( listOf( Schema.integer(description = "User ID"), Schema.obj(mapOf(
-     *
      * ```
+     * Schema.anyOf( listOf( Schema.integer(description = "User ID"), Schema.obj( mapOf(
      *     "userID" to Schema.integer(description = "User ID"),
      *     "username" to Schema.string(description = "Username")
+     * )))
      * ```
-     *
-     * )) )
      *
      * @param schemas The list of valid schemas which could be here
      */


### PR DESCRIPTION
The sample code was not correctly enclosed in backticks (`), causing the code to be incorrectly rendered.