### PR TITLE
Notify Sessions when a fatal crash occurs

### DIFF
--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -43,6 +43,7 @@ import com.google.firebase.crashlytics.internal.model.StaticSessionData;
 import com.google.firebase.crashlytics.internal.persistence.FileStore;
 import com.google.firebase.crashlytics.internal.settings.Settings;
 import com.google.firebase.crashlytics.internal.settings.SettingsProvider;
+import com.google.firebase.sessions.api.CrashEventReceiver;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FilenameFilter;
@@ -215,6 +216,11 @@ class CrashlyticsController {
                 doWriteAppExceptionMarker(timestampMillis);
                 doCloseSessions(settingsProvider);
                 doOpenSession(new CLSUUID().getSessionId(), isOnDemand);
+
+                // Notify the Firebase Sessions SDK that a fatal crash has occurred.
+                if (!isOnDemand) {
+                  CrashEventReceiver.notifyCrashOccurred();
+                }
 
                 // If automatic data collection is disabled, we'll need to wait until the next run
                 // of the app.

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -190,6 +190,11 @@ class CrashlyticsController {
     Logger.getLogger()
         .d("Handling uncaught " + "exception \"" + ex + "\" from thread " + thread.getName());
 
+    // Notify the Firebase Sessions SDK that a fatal crash has occurred.
+    if (!isOnDemand) {
+      CrashEventReceiver.notifyCrashOccurred();
+    }
+
     // Capture the time that the crash occurs and close over it so that the time doesn't
     // reflect when we get around to executing the task later.
     final long timestampMillis = System.currentTimeMillis();
@@ -216,11 +221,6 @@ class CrashlyticsController {
                 doWriteAppExceptionMarker(timestampMillis);
                 doCloseSessions(settingsProvider);
                 doOpenSession(new CLSUUID().getSessionId(), isOnDemand);
-
-                // Notify the Firebase Sessions SDK that a fatal crash has occurred.
-                if (!isOnDemand) {
-                  CrashEventReceiver.notifyCrashOccurred();
-                }
 
                 // If automatic data collection is disabled, we'll need to wait until the next run
                 // of the app.

--- a/firebase-sessions/api.txt
+++ b/firebase-sessions/api.txt
@@ -1,6 +1,11 @@
 // Signature format: 3.0
 package com.google.firebase.sessions.api {
 
+  public final class CrashEventReceiver {
+    method public static void notifyCrashOccurred();
+    field public static final com.google.firebase.sessions.api.CrashEventReceiver INSTANCE;
+  }
+
   public final class FirebaseSessionsDependencies {
     method public static void addDependency(com.google.firebase.sessions.api.SessionSubscriber.Name subscriberName);
     method public static void register(com.google.firebase.sessions.api.SessionSubscriber subscriber);

--- a/firebase-sessions/gradle.properties
+++ b/firebase-sessions/gradle.properties
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version=2.1.3
+version=2.2.0
 latestReleasedVersion=2.1.2

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsComponent.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsComponent.kt
@@ -70,6 +70,7 @@ internal interface FirebaseSessionsComponent {
   val sessionFirelogPublisher: SessionFirelogPublisher
   val sessionGenerator: SessionGenerator
   val sessionsSettings: SessionsSettings
+  val sharedSessionRepository: SharedSessionRepository
 
   @Component.Builder
   interface Builder {

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SharedSessionRepository.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SharedSessionRepository.kt
@@ -34,6 +34,8 @@ import kotlinx.coroutines.launch
 
 /** Repository to persist session data to be shared between all app processes. */
 internal interface SharedSessionRepository {
+  val isInForeground: Boolean
+
   fun appBackground()
 
   fun appForeground()
@@ -58,6 +60,9 @@ constructor(
 ) : SharedSessionRepository {
   /** Local copy of the session data. Can get out of sync, must be double-checked in datastore. */
   internal lateinit var localSessionData: SessionData
+
+  override var isInForeground = false
+    private set
 
   /**
    * Either notify the subscribers with general multi-process supported session or fallback local
@@ -95,6 +100,7 @@ constructor(
   }
 
   override fun appBackground() {
+    isInForeground = false
     if (!::localSessionData.isInitialized) {
       Log.d(TAG, "App backgrounded, but local SessionData not initialized")
       return
@@ -115,6 +121,7 @@ constructor(
   }
 
   override fun appForeground() {
+    isInForeground = true
     if (!::localSessionData.isInitialized) {
       Log.d(TAG, "App foregrounded, but local SessionData not initialized")
       return

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SharedSessionRepository.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SharedSessionRepository.kt
@@ -18,7 +18,9 @@ package com.google.firebase.sessions
 
 import android.util.Log
 import androidx.datastore.core.DataStore
+import com.google.firebase.Firebase
 import com.google.firebase.annotations.concurrent.Background
+import com.google.firebase.app
 import com.google.firebase.sessions.FirebaseSessions.Companion.TAG
 import com.google.firebase.sessions.api.FirebaseSessionsDependencies
 import com.google.firebase.sessions.api.SessionSubscriber
@@ -35,6 +37,11 @@ internal interface SharedSessionRepository {
   fun appBackground()
 
   fun appForeground()
+
+  companion object {
+    val instance: SharedSessionRepository
+      get() = Firebase.app[FirebaseSessionsComponent::class.java].sharedSessionRepository
+  }
 }
 
 @Singleton

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/api/CrashEventReceiver.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/api/CrashEventReceiver.kt
@@ -16,6 +16,7 @@
 
 package com.google.firebase.sessions.api
 
+import androidx.annotation.VisibleForTesting
 import com.google.firebase.sessions.SharedSessionRepository
 
 /**
@@ -25,6 +26,7 @@ import com.google.firebase.sessions.SharedSessionRepository
  * crash has occurred.
  */
 object CrashEventReceiver {
+  @VisibleForTesting internal lateinit var sharedSessionRepository: SharedSessionRepository
 
   /**
    * Notifies the Firebase Sessions SDK that a fatal crash has occurred.
@@ -38,8 +40,10 @@ object CrashEventReceiver {
   @JvmStatic
   fun notifyCrashOccurred() {
     try {
+      if (!::sharedSessionRepository.isInitialized) {
+        sharedSessionRepository = SharedSessionRepository.instance
+      }
       // Treat a foreground crash as if the app went to the background, and update session state.
-      val sharedSessionRepository = SharedSessionRepository.instance
       if (sharedSessionRepository.isInForeground) {
         sharedSessionRepository.appBackground()
       }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/api/CrashEventReceiver.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/api/CrashEventReceiver.kt
@@ -38,8 +38,11 @@ object CrashEventReceiver {
   @JvmStatic
   fun notifyCrashOccurred() {
     try {
-      // Treat the crash as if the app went to the background, and update session state.
-      SharedSessionRepository.instance.appBackground()
+      // Treat a foreground crash as if the app went to the background, and update session state.
+      val sharedSessionRepository = SharedSessionRepository.instance
+      if (sharedSessionRepository.isInForeground) {
+        sharedSessionRepository.appBackground()
+      }
     } catch (_: Exception) {
       // Catch and suppress any exception to avoid crashing during crash handling.
       // This can occur if Firebase or the SDK are in an unexpected state (e.g. FirebaseApp deleted)

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/api/CrashEventReceiver.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/api/CrashEventReceiver.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.sessions.api
+
+import com.google.firebase.sessions.SharedSessionRepository
+
+/**
+ * Internal API used by Firebase Crashlytics to notify the Firebase Sessions SDK of fatal crashes.
+ *
+ * This object provides a static-like entry point that Crashlytics calls to inform Sessions a fatal
+ * crash has occurred.
+ */
+object CrashEventReceiver {
+
+  /**
+   * Notifies the Firebase Sessions SDK that a fatal crash has occurred.
+   *
+   * This method should be called by Firebase Crashlytics as soon as it detects a fatal crash. It
+   * safely processes the crash notification, treating the crash as a background event, to ensure
+   * that the session state is updated correctly.
+   *
+   * @see SharedSessionRepository.appBackground
+   */
+  @JvmStatic
+  fun notifyCrashOccurred() {
+    try {
+      // Treat the crash as if the app went to the background, and update session state.
+      SharedSessionRepository.instance.appBackground()
+    } catch (_: Exception) {
+      // Catch and suppress any exception to avoid crashing during crash handling.
+      // This can occur if Firebase or the SDK are in an unexpected state (e.g. FirebaseApp deleted)
+      // No action needed, avoid interfering with the crash reporting process.
+    }
+  }
+}

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/api/CrashEventReceiverTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/api/CrashEventReceiverTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.sessions.api
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.FirebaseApp
+import com.google.firebase.concurrent.TestOnlyExecutors
+import com.google.firebase.sessions.SessionData
+import com.google.firebase.sessions.SessionDetails
+import com.google.firebase.sessions.SessionFirelogPublisherImpl
+import com.google.firebase.sessions.SessionGenerator
+import com.google.firebase.sessions.SharedSessionRepositoryImpl
+import com.google.firebase.sessions.SharedSessionRepositoryTest.Companion.SESSION_ID_INIT
+import com.google.firebase.sessions.settings.SessionsSettings
+import com.google.firebase.sessions.testing.FakeDataStore
+import com.google.firebase.sessions.testing.FakeEventGDTLogger
+import com.google.firebase.sessions.testing.FakeFirebaseApp
+import com.google.firebase.sessions.testing.FakeFirebaseInstallations
+import com.google.firebase.sessions.testing.FakeProcessDataManager
+import com.google.firebase.sessions.testing.FakeSettingsProvider
+import com.google.firebase.sessions.testing.FakeTimeProvider
+import com.google.firebase.sessions.testing.FakeUuidGenerator
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+class CrashEventReceiverTest {
+  @Test
+  fun notifyCrashOccurredOnForegroundOnly() = runTest {
+    // Setup
+    val fakeFirebaseApp = FakeFirebaseApp()
+    val fakeEventGDTLogger = FakeEventGDTLogger()
+    val firebaseInstallations = FakeFirebaseInstallations("FaKeFiD", "FakeAuthToken")
+    val fakeTimeProvider = FakeTimeProvider()
+    val sessionGenerator = SessionGenerator(fakeTimeProvider, FakeUuidGenerator())
+    val localSettingsProvider = FakeSettingsProvider(true, null, 100.0)
+    val remoteSettingsProvider = FakeSettingsProvider(true, null, 100.0)
+    val sessionsSettings = SessionsSettings(localSettingsProvider, remoteSettingsProvider)
+    val publisher =
+      SessionFirelogPublisherImpl(
+        fakeFirebaseApp.firebaseApp,
+        firebaseInstallations,
+        sessionsSettings,
+        eventGDTLogger = fakeEventGDTLogger,
+        TestOnlyExecutors.background().asCoroutineDispatcher() + coroutineContext,
+      )
+    val fakeDataStore =
+      FakeDataStore(
+        SessionData(
+          SessionDetails(SESSION_ID_INIT, SESSION_ID_INIT, 0, fakeTimeProvider.currentTime().ms),
+          fakeTimeProvider.currentTime(),
+        )
+      )
+    val sharedSessionRepository =
+      SharedSessionRepositoryImpl(
+        sessionsSettings = sessionsSettings,
+        sessionGenerator = sessionGenerator,
+        sessionFirelogPublisher = publisher,
+        timeProvider = fakeTimeProvider,
+        sessionDataStore = fakeDataStore,
+        processDataManager = FakeProcessDataManager(),
+        backgroundDispatcher =
+          TestOnlyExecutors.background().asCoroutineDispatcher() + coroutineContext,
+      )
+    CrashEventReceiver.sharedSessionRepository = sharedSessionRepository
+
+    runCurrent()
+
+    // Process starts in the background
+    assertThat(sharedSessionRepository.isInForeground).isFalse()
+
+    // This will not update background time since the process is already in the background
+    CrashEventReceiver.notifyCrashOccurred()
+    assertThat(sharedSessionRepository.localSessionData.backgroundTime)
+      .isEqualTo(fakeTimeProvider.currentTime())
+
+    // Wait a bit, then bring the process to foreground
+    fakeTimeProvider.addInterval(31.minutes)
+    sharedSessionRepository.appForeground()
+
+    runCurrent()
+
+    // The background time got cleared
+    assertThat(sharedSessionRepository.localSessionData.backgroundTime).isNull()
+
+    // Wait a bit, then notify of a crash
+    fakeTimeProvider.addInterval(3.seconds)
+    CrashEventReceiver.notifyCrashOccurred()
+
+    runCurrent()
+
+    // Verify the background time got updated
+    assertThat(sharedSessionRepository.localSessionData.backgroundTime)
+      .isEqualTo(fakeTimeProvider.currentTime())
+
+    // Clean up
+    fakeDataStore.close()
+    FirebaseApp.clearInstancesForTest()
+  }
+}

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/api/CrashEventReceiverTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/api/CrashEventReceiverTest.kt
@@ -92,9 +92,10 @@ class CrashEventReceiverTest {
     assertThat(sharedSessionRepository.isInForeground).isFalse()
 
     // This will not update background time since the process is already in the background
+    val originalBackgroundTime = fakeTimeProvider.currentTime()
     CrashEventReceiver.notifyCrashOccurred()
     assertThat(sharedSessionRepository.localSessionData.backgroundTime)
-      .isEqualTo(fakeTimeProvider.currentTime())
+      .isEqualTo(originalBackgroundTime)
 
     // Wait a bit, then bring the process to foreground
     fakeTimeProvider.addInterval(31.minutes)
@@ -107,13 +108,13 @@ class CrashEventReceiverTest {
 
     // Wait a bit, then notify of a crash
     fakeTimeProvider.addInterval(3.seconds)
+    val newBackgroundTime = fakeTimeProvider.currentTime()
     CrashEventReceiver.notifyCrashOccurred()
 
     runCurrent()
 
     // Verify the background time got updated
-    assertThat(sharedSessionRepository.localSessionData.backgroundTime)
-      .isEqualTo(fakeTimeProvider.currentTime())
+    assertThat(sharedSessionRepository.localSessionData.backgroundTime).isEqualTo(newBackgroundTime)
 
     // Clean up
     fakeDataStore.close()

--- a/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/MyServiceA.kt
+++ b/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/MyServiceA.kt
@@ -29,7 +29,7 @@ class MyServiceA : Service() {
     Log.i(TAG, "Service A action: ${intent?.action} on process: $myProcessName")
 
     // Send actions from adb shell this way, so it can start the process if needed:
-    // am startservice -n com.google.firebase.testing.sessions/.MyServiceA -a PING
+    // am startservice --user 0 -n com.google.firebase.testing.sessions/.MyServiceA -a PING
     when (intent?.action) {
       "PING" -> ping()
       "CRASH" -> crash()


### PR DESCRIPTION
Notify Sessions when a fatal crash occurs. Sessions will treat it like a background event. This will preserve session background time when a process ends due to a crash