### PR TITLE
[Readme] Update supported Android Studio version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ https://firebase.google.com.
 
 ## Getting Started
 
-* Install the latest Android Studio (should be 3.0.1 or later)
+* Install the latest Android Studio (should be Meerkat | 2024.3.1 or later)
 * Clone the repo (`git clone --recurse-submodules git@github.com:firebase/firebase-android-sdk.git`)
     * When cloning the repo, it is important to get the submodules as well. If
     you have already cloned the repo without the submodules, you can update the


### PR DESCRIPTION
The README.md was using an extremelly outdated version of Android Studio as reference. Now it points to a version that supports API level 36, according to https://developer.android.com/build/releases/gradle-plugin#api-level-support