### PR TITLE
Fix: Workflow trigger updated to run only on PRs to main

### DIFF
--- a/.github/workflows/metalava-semver-check.yml
+++ b/.github/workflows/metalava-semver-check.yml
@@ -2,6 +2,8 @@ name: Metalava SemVer Check
 
 on:
   pull_request:
+    branches:
+      - main
 
 jobs:
   semver-check:


### PR DESCRIPTION
The metalava-semver-check.yml workflow was previously configured to run on all pull requests. This change updates the trigger to only run on pull requests that target the `main` branch.