### PR TITLE
Fix: Make metalavaSemver depend on copyApiTxtFile

### DIFF
--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/FirebaseAndroidLibraryPlugin.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/FirebaseAndroidLibraryPlugin.kt
@@ -161,13 +161,14 @@ class FirebaseAndroidLibraryPlugin : BaseFirebaseLibraryPlugin() {
       )
     }
 
-    project.tasks.register<CopyApiTask>("copyApiTxtFile") {
-      apiTxtFile.set(project.file("api.txt"))
-      output.set(project.file("new_api.txt"))
-    }
+    val copyApiTxtFileTask =
+      project.tasks.register<CopyApiTask>("copyApiTxtFile") {
+        apiTxtFile.set(project.file("api.txt"))
+        output.set(project.file("new_api.txt"))
+      }
 
     project.tasks.register<SemVerTask>("metalavaSemver") {
-      apiTxtFile.set(project.file("new_api.txt"))
+      apiTxtFile.set(copyApiTxtFileTask.flatMap { it.output })
       otherApiFile.set(project.file("api.txt"))
       currentVersionString.value(firebaseLibrary.version)
       previousVersionString.value(firebaseLibrary.previousVersion)


### PR DESCRIPTION
Explicitly wire the output of the copyApiTxtFile task (new_api.txt) to the input of the metalavaSemver task, ensuring the file is present before metalavaSemver runs.