### PR TITLE
[Config] Add unused vars for some call sites

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
@@ -37,6 +37,7 @@ import java.util.Date;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -248,11 +249,11 @@ public class ConfigAutoFetch {
 
     // Randomize fetch to occur between 0 - 4 seconds.
     int timeTillFetch = random.nextInt(4);
-    scheduledExecutorService.schedule(
+    ScheduledFuture<?> unused = scheduledExecutorService.schedule(
         new Runnable() {
           @Override
           public void run() {
-            fetchLatestConfig(remainingAttempts, targetVersion);
+            Task<Void> unused = fetchLatestConfig(remainingAttempts, targetVersion);
           }
         },
         timeTillFetch,

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
@@ -249,15 +249,16 @@ public class ConfigAutoFetch {
 
     // Randomize fetch to occur between 0 - 4 seconds.
     int timeTillFetch = random.nextInt(4);
-    ScheduledFuture<?> unused = scheduledExecutorService.schedule(
-        new Runnable() {
-          @Override
-          public void run() {
-            Task<Void> unused = fetchLatestConfig(remainingAttempts, targetVersion);
-          }
-        },
-        timeTillFetch,
-        TimeUnit.SECONDS);
+    ScheduledFuture<?> unused =
+        scheduledExecutorService.schedule(
+            new Runnable() {
+              @Override
+              public void run() {
+                Task<Void> unused = fetchLatestConfig(remainingAttempts, targetVersion);
+              }
+            },
+            timeTillFetch,
+            TimeUnit.SECONDS);
   }
 
   @VisibleForTesting

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -382,15 +382,16 @@ public class ConfigRealtimeHttpClient {
 
     if (httpRetriesRemaining > 0) {
       httpRetriesRemaining--;
-      ScheduledFuture<?> unused = scheduledExecutorService.schedule(
-          new Runnable() {
-            @Override
-            public void run() {
-              beginRealtimeHttpStream();
-            }
-          },
-          retryMilliseconds,
-          TimeUnit.MILLISECONDS);
+      ScheduledFuture<?> unused =
+          scheduledExecutorService.schedule(
+              new Runnable() {
+                @Override
+                public void run() {
+                  beginRealtimeHttpStream();
+                }
+              },
+              retryMilliseconds,
+              TimeUnit.MILLISECONDS);
     } else if (!isInBackground) {
       propagateErrors(
           new FirebaseRemoteConfigClientException(

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -57,6 +57,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -381,7 +382,7 @@ public class ConfigRealtimeHttpClient {
 
     if (httpRetriesRemaining > 0) {
       httpRetriesRemaining--;
-      scheduledExecutorService.schedule(
+      ScheduledFuture<?> unused = scheduledExecutorService.schedule(
           new Runnable() {
             @Override
             public void run() {


### PR DESCRIPTION
The `unused` vars were added to address a warning raised by errorprone about ignoring returned types.

(internal) See b/424298831