### PR TITLE
Remove VisibleForTesting from SDK production code

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java
@@ -77,7 +77,7 @@ public class ConfigFetchHandler {
    *
    * <p>Defined here since {@link HttpURLConnection} does not provide this code.
    */
-  @VisibleForTesting static final int HTTP_TOO_MANY_REQUESTS = 429;
+  static final int HTTP_TOO_MANY_REQUESTS = 429;
 
   /**
    * First-open time key name in GA user-properties. First-open time is a predefined user-dimension

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigSharedPrefsClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigSharedPrefsClient.java
@@ -373,7 +373,6 @@ public class ConfigSharedPrefsClient {
   // Realtime exponential backoff logic.
   // -----------------------------------------------------------------
 
-  @VisibleForTesting
   public RealtimeBackoffMetadata getRealtimeBackoffMetadata() {
     synchronized (realtimeBackoffMetadataLock) {
       return new RealtimeBackoffMetadata(
@@ -394,7 +393,6 @@ public class ConfigSharedPrefsClient {
     }
   }
 
-  @VisibleForTesting
   public void setRealtimeBackoffEndTime(Date backoffEndTime) {
     synchronized (realtimeBackoffMetadataLock) {
       frcSharedPrefs
@@ -415,7 +413,6 @@ public class ConfigSharedPrefsClient {
    * <p>The purpose of this class is to avoid race conditions when retrieving backoff metadata
    * values separately.
    */
-  @VisibleForTesting
   public static class RealtimeBackoffMetadata {
     private int numFailedStreams;
     private Date backoffEndTime;


### PR DESCRIPTION
Some methods are currently marked with `@VisibleForTestingOnly` but are being used directly within the SDK code. This annotation is intended to restrict usage to tests, and its presence causes errors when integrating the SDK into internal systems via copybara.

Internal Tracking: b/429425834