### PR TITLE
Firestore: use Integer.compare() and Long.compare() instead Firestore bespoke implementations

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -2,6 +2,9 @@
 * [fixed] Further improved performance of UTF-8 string ordering logic,
   which had degraded in v25.1.2 and received some improvements in v25.1.3.
   [#7053](//github.com/firebase/firebase-android-sdk/issues/7053)
+* [changed] Use `Integer.compare()` (which was added in Android API 19) to compare integers instead
+  of Firestore's bespoke implementation, since minSdkVersion has been greater than 19 for some time.
+  [#NNNN](//github.com/firebase/firebase-android-sdk/pull/NNNN)
 
 
 # 25.1.4

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -4,7 +4,7 @@
   [#7053](//github.com/firebase/firebase-android-sdk/issues/7053)
 * [changed] Use `Integer.compare()` (which was added in Android API 19) to compare integers instead
   of Firestore's bespoke implementation, since minSdkVersion has been greater than 19 for some time.
-  [#NNNN](//github.com/firebase/firebase-android-sdk/pull/NNNN)
+  [#7109](//github.com/firebase/firebase-android-sdk/pull/7109)
 
 
 # 25.1.4

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -2,8 +2,8 @@
 * [fixed] Further improved performance of UTF-8 string ordering logic,
   which had degraded in v25.1.2 and received some improvements in v25.1.3.
   [#7053](//github.com/firebase/firebase-android-sdk/issues/7053)
-* [changed] Use `Integer.compare()` (which was added in Android API 19) to compare integers instead
-  of Firestore's bespoke implementation, since minSdkVersion has been greater than 19 for some time.
+* [changed] Use `Integer.compare()` and `Long.compare()` (which were added in Android API 19)
+  instead of Firestore's bespoke implementations, since minSdkVersion is greater than 19.
   [#7109](//github.com/firebase/firebase-android-sdk/pull/7109)
 
 

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -2,8 +2,8 @@
 * [fixed] Further improved performance of UTF-8 string ordering logic,
   which had degraded in v25.1.2 and received some improvements in v25.1.3.
   [#7053](//github.com/firebase/firebase-android-sdk/issues/7053)
-* [changed] Use `Integer.compare()` and `Long.compare()` (which were added in Android API 19)
-  instead of Firestore's bespoke implementations, since minSdkVersion is greater than 19.
+* [changed] Use the `compare()` methods defined in standard `Integer`, `Long`, and `Character`
+  classes instead of Firestore's bespoke implementations.
   [#7109](//github.com/firebase/firebase-android-sdk/pull/7109)
 
 

--- a/firebase-firestore/src/main/java/com/google/cloud/datastore/core/number/NumberComparisonHelper.java
+++ b/firebase-firestore/src/main/java/com/google/cloud/datastore/core/number/NumberComparisonHelper.java
@@ -50,7 +50,7 @@ public final class NumberComparisonHelper {
     }
 
     long doubleAsLong = (long) doubleValue;
-    int cmp = compareLongs(doubleAsLong, longValue);
+    int cmp = Long.compare(doubleAsLong, longValue);
     if (cmp != 0) {
       return cmp;
     }
@@ -58,11 +58,6 @@ public final class NumberComparisonHelper {
     // At this point the long representations are equal but this could be due to rounding.
     double longAsDouble = (double) longValue;
     return firestoreCompareDoubles(doubleValue, longAsDouble);
-  }
-
-  /** Compares longs. */
-  public static int compareLongs(long leftLong, long rightLong) {
-    return Long.compare(leftLong, rightLong);
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/View.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/View.java
@@ -17,7 +17,6 @@ package com.google.firebase.firestore.core;
 import static com.google.firebase.firestore.core.Query.LimitType.LIMIT_TO_FIRST;
 import static com.google.firebase.firestore.core.Query.LimitType.LIMIT_TO_LAST;
 import static com.google.firebase.firestore.util.Assert.hardAssert;
-import static com.google.firebase.firestore.util.Util.compareIntegers;
 
 import androidx.annotation.Nullable;
 import com.google.firebase.database.collection.ImmutableSortedMap;
@@ -301,7 +300,7 @@ public class View {
     Collections.sort(
         viewChanges,
         (DocumentViewChange o1, DocumentViewChange o2) -> {
-          int typeComp = compareIntegers(View.changeTypeOrder(o1), View.changeTypeOrder(o2));
+          int typeComp = Integer.compare(View.changeTypeOrder(o1), View.changeTypeOrder(o2));
           if (typeComp != 0) {
             return typeComp;
           }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/DocumentReference.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/DocumentReference.java
@@ -14,8 +14,6 @@
 
 package com.google.firebase.firestore.local;
 
-import static com.google.firebase.firestore.util.Util.compareIntegers;
-
 import com.google.firebase.firestore.model.DocumentKey;
 import java.util.Comparator;
 
@@ -60,12 +58,12 @@ class DocumentReference {
           return keyComp;
         }
 
-        return compareIntegers(o1.targetOrBatchId, o2.targetOrBatchId);
+        return Integer.compare(o1.targetOrBatchId, o2.targetOrBatchId);
       };
 
   static final Comparator<DocumentReference> BY_TARGET =
       (o1, o2) -> {
-        int targetComp = compareIntegers(o1.targetOrBatchId, o2.targetOrBatchId);
+        int targetComp = Integer.compare(o1.targetOrBatchId, o2.targetOrBatchId);
 
         if (targetComp != 0) {
           return targetComp;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteMutationQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteMutationQueue.java
@@ -30,7 +30,6 @@ import com.google.firebase.firestore.model.mutation.Mutation;
 import com.google.firebase.firestore.model.mutation.MutationBatch;
 import com.google.firebase.firestore.remote.WriteStream;
 import com.google.firebase.firestore.util.Consumer;
-import com.google.firebase.firestore.util.Util;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.MessageLite;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteMutationQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteMutationQueue.java
@@ -324,7 +324,7 @@ final class SQLiteMutationQueue implements MutationQueue {
       Collections.sort(
           result,
           (MutationBatch lhs, MutationBatch rhs) ->
-              Util.compareIntegers(lhs.getBatchId(), rhs.getBatchId()));
+              Integer.compare(lhs.getBatchId(), rhs.getBatchId()));
     }
     return result;
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/BasePath.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/BasePath.java
@@ -100,7 +100,7 @@ public abstract class BasePath<B extends BasePath<B>> implements Comparable<B> {
       }
       i++;
     }
-    return Util.compareIntegers(myLength, theirLength);
+    return Integer.compare(myLength, theirLength);
   }
 
   private static int compareSegments(String lhs, String rhs) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Values.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Values.java
@@ -214,7 +214,7 @@ public class Values {
     int rightType = typeOrder(right);
 
     if (leftType != rightType) {
-      return Util.compareIntegers(leftType, rightType);
+      return Integer.compare(leftType, rightType);
     }
 
     switch (leftType) {
@@ -305,7 +305,7 @@ public class Values {
     if (cmp != 0) {
       return cmp;
     }
-    return Util.compareIntegers(left.getNanos(), right.getNanos());
+    return Integer.compare(left.getNanos(), right.getNanos());
   }
 
   private static int compareReferences(String leftPath, String rightPath) {
@@ -319,7 +319,7 @@ public class Values {
         return cmp;
       }
     }
-    return Util.compareIntegers(leftSegments.length, rightSegments.length);
+    return Integer.compare(leftSegments.length, rightSegments.length);
   }
 
   private static int compareGeoPoints(LatLng left, LatLng right) {
@@ -338,7 +338,7 @@ public class Values {
         return cmp;
       }
     }
-    return Util.compareIntegers(left.getValuesCount(), right.getValuesCount());
+    return Integer.compare(left.getValuesCount(), right.getValuesCount());
   }
 
   private static int compareMaps(MapValue left, MapValue right) {
@@ -372,7 +372,7 @@ public class Values {
     ArrayValue rightArrayValue = rightMap.get(Values.VECTOR_MAP_VECTORS_KEY).getArrayValue();
 
     int lengthCompare =
-        Util.compareIntegers(leftArrayValue.getValuesCount(), rightArrayValue.getValuesCount());
+        Integer.compare(leftArrayValue.getValuesCount(), rightArrayValue.getValuesCount());
     if (lengthCompare != 0) {
       return lengthCompare;
     }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Values.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Values.java
@@ -291,7 +291,7 @@ public class Values {
     } else if (left.getValueTypeCase() == Value.ValueTypeCase.INTEGER_VALUE) {
       long leftLong = left.getIntegerValue();
       if (right.getValueTypeCase() == Value.ValueTypeCase.INTEGER_VALUE) {
-        return Util.compareLongs(leftLong, right.getIntegerValue());
+        return Long.compare(leftLong, right.getIntegerValue());
       } else if (right.getValueTypeCase() == Value.ValueTypeCase.DOUBLE_VALUE) {
         return -1 * Util.compareMixed(right.getDoubleValue(), leftLong);
       }
@@ -301,7 +301,7 @@ public class Values {
   }
 
   private static int compareTimestamps(Timestamp left, Timestamp right) {
-    int cmp = Util.compareLongs(left.getSeconds(), right.getSeconds());
+    int cmp = Long.compare(left.getSeconds(), right.getSeconds());
     if (cmp != 0) {
       return cmp;
     }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Util.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Util.java
@@ -105,7 +105,7 @@ public class Util {
       final char rightChar = right.charAt(i);
       if (leftChar != rightChar) {
         return (isSurrogate(leftChar) == isSurrogate(rightChar))
-            ? Integer.compare(leftChar, rightChar)
+            ? Character.compare(leftChar, rightChar)
             : isSurrogate(leftChar) ? 1 : -1;
       }
     }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Util.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Util.java
@@ -73,20 +73,6 @@ public class Util {
     }
   }
 
-  /**
-   * Utility function to compare integers. Note that we can't use Integer.compare because it's only
-   * available after Android 19.
-   */
-  public static int compareIntegers(int i1, int i2) {
-    if (i1 < i2) {
-      return -1;
-    } else if (i1 > i2) {
-      return 1;
-    } else {
-      return 0;
-    }
-  }
-
   /** Compare strings in UTF-8 encoded byte order */
   public static int compareUtf8Strings(String left, String right) {
     // noinspection StringEquality
@@ -119,7 +105,7 @@ public class Util {
       final char rightChar = right.charAt(i);
       if (leftChar != rightChar) {
         return (isSurrogate(leftChar) == isSurrogate(rightChar))
-            ? Util.compareIntegers(leftChar, rightChar)
+            ? Integer.compare(leftChar, rightChar)
             : isSurrogate(leftChar) ? 1 : -1;
       }
     }
@@ -274,7 +260,7 @@ public class Util {
       }
       // Byte values are equal, continue with comparison
     }
-    return Util.compareIntegers(left.length, right.length);
+    return Integer.compare(left.length, right.length);
   }
 
   public static int compareByteStrings(ByteString left, ByteString right) {
@@ -290,7 +276,7 @@ public class Util {
       }
       // Byte values are equal, continue with comparison
     }
-    return Util.compareIntegers(left.size(), right.size());
+    return Integer.compare(left.size(), right.size());
   }
 
   public static StringBuilder repeatSequence(

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Util.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Util.java
@@ -115,14 +115,6 @@ public class Util {
     return Integer.compare(left.length(), right.length());
   }
 
-  /**
-   * Utility function to compare longs. Note that we can't use Long.compare because it's only
-   * available after Android 19.
-   */
-  public static int compareLongs(long i1, long i2) {
-    return NumberComparisonHelper.compareLongs(i1, i2);
-  }
-
   /** Utility function to compare doubles (using Firestore semantics for NaN). */
   public static int compareDoubles(double i1, double i2) {
     return NumberComparisonHelper.firestoreCompareDoubles(i1, i2);

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/util/UtilTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/util/UtilTest.java
@@ -108,7 +108,7 @@ public class UtilTest {
       ByteString b2 = ByteString.copyFromUtf8(s2);
       int expected = Util.compareByteStrings(b1, b2);
 
-      if (actual == expected) {
+      if (Integer.signum(actual) == Integer.signum(expected)) {
         passCount++;
       } else {
         errors.add(
@@ -117,9 +117,12 @@ public class UtilTest {
                 + "\", s2=\""
                 + s2
                 + "\") returned "
+                + signName(actual)
+                + " ("
                 + actual
+                + ")"
                 + ", but expected "
-                + expected
+                + signName(expected)
                 + " (i="
                 + i
                 + ", s1.length="
@@ -139,6 +142,16 @@ public class UtilTest {
         sb.append("\nerrors[").append(i).append("]: ").append(errors.get(i));
       }
       fail(sb.toString());
+    }
+  }
+
+  private static String signName(int value) {
+    if (value < 0) {
+      return "a negative value";
+    } else if (value > 0) {
+      return "a positive value";
+    } else {
+      return "0";
     }
   }
 


### PR DESCRIPTION
This PR replaces the bespoke `Util.compareIntegers()` and `Util.compareLongs()` methods with standard Java `Integer.compare()`, `Long.compare()` and `Character.compare()` methods. It also updates the tests to validate comparisons based on sign rather than exact values, as these tests were previously brittle, erroneously failing due to `Character.compare()` returning values other than `1`, `0`, and `-1`.

The `Util.compareIntegers()` and `Util.compareLongs()` methods were originally added because they required minSdkVersion of 19 or greater which, at the time, was not the case. However, minSdkVersion has been 21 for some time now (and is increasing to 23 in the foreseeable future) so there is no longer any need for the bespoke implementations.

### Highlights

- Replaced all calls to `Util.compareIntegers()` and `Util.compareLongs()` with `Integer.compare()`, `Long.compare()`, or `Character.compare()`, as appropriate.
- Removed redundant `compareIntegers` and `compareLongs` methods from `Util` and `NumberComparisonHelper`.
- Updated `UtilTest` to assert via `Integer.signum()` instead of testing exact equality with `1`, `0`, or `-1`.