### PR TITLE
[Ai] Fix integration test constructor usage

### DIFF
--- a/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/ToolTests.kt
+++ b/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/ToolTests.kt
@@ -304,7 +304,7 @@ class ToolTests {
               ToolConfig(
                 functionCallingConfig = FunctionCallingConfig(FunctionCallingConfig.Mode.ANY)
               ),
-            tools = listOf(Tool(functions.toList())),
+            tools = listOf(Tool.functionDeclarations(functions.toList())),
           )
       return model
     }


### PR DESCRIPTION
The test is using the `internal` constructor instead of relying on the public factory method which caused it fail with the new grounding functionality.