### PR TITLE
[Infra] Reduce noise produced by test unit workflow

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -172,3 +172,5 @@ jobs:
         if: always()
         with:
           files: "artifacts/**/*.xml"
+          comment_mode: off
+          compare_to_earlier_commit: false


### PR DESCRIPTION
We use `EnricoMi/publish-unit-test-result-action`, and we are reconfiguring it to stop publishing comments, and comparing between runs since the numbers it report are not correct in our case.