### PR TITLE
[RC] Don't remove config-interop from the build

### DIFF
--- a/firebase-config/test-app/test-app.gradle.kts
+++ b/firebase-config/test-app/test-app.gradle.kts
@@ -54,9 +54,7 @@ dependencies {
   implementation(project(":firebase-crashlytics")) {
     exclude(group = "com.google.firebase", module = "firebase-config-interop")
   }
-  implementation(project(":firebase-config")) {
-    exclude(group = "com.google.firebase", module = "firebase-config-interop")
-  }
+  implementation(project(":firebase-config"))
 
   // This is required since a `project` dependency on frc does not expose the APIs of its
   // "implementation" dependencies. The alternative would be to make common an "api" dep of


### PR DESCRIPTION
Excluding interop causes the test-app to fail to run.

Internal b/430569929