### PR TITLE
[Installations] Remove duplicated interop declaration

### DIFF
--- a/firebase-installations/firebase-installations.gradle
+++ b/firebase-installations/firebase-installations.gradle
@@ -55,7 +55,6 @@ dependencies {
     api 'com.google.firebase:firebase-annotations:16.2.0'
     api("com.google.firebase:firebase-common:21.0.0")
     api("com.google.firebase:firebase-components:18.0.0")
-    api 'com.google.firebase:firebase-installations-interop:17.1.0'
     api("com.google.firebase:firebase-installations-interop:17.1.1")
 
     implementation libs.kotlin.stdlib


### PR DESCRIPTION
The dependency on com.google.firebase:firebase-installations-interop twice, and once with the wrong version