### PR TITLE
[Infra] Missing minSdk bumps

### DIFF
--- a/firebase-appdistribution-api/firebase-appdistribution-api.gradle
+++ b/firebase-appdistribution-api/firebase-appdistribution-api.gradle
@@ -31,7 +31,7 @@ android {
     compileSdkVersion project.compileSdkVersion
     
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion project.minSdkVersion
         targetSdkVersion project.targetSdkVersion
         multiDexEnabled true
         versionName version

--- a/firebase-storage/test-app/test-app.gradle
+++ b/firebase-storage/test-app/test-app.gradle
@@ -21,7 +21,7 @@ android {
 
   defaultConfig {
     applicationId "com.example.storage"
-    minSdkVersion 16
+    minSdkVersion project.minSdkVersion
     targetSdkVersion project.targetSdkVersion
     versionCode 1
     versionName "1.0"


### PR DESCRIPTION
firebase-appdistribution-api wasn't bumped and it's causing build failures.

`firebase-storage/test-app` was still running on a unsupported version (16).