### PR TITLE
dataconnect: DataConnectExecutableVersions.json updated with versions 2.6.3, 2.7.0, 2.7.1, 2.8.0, 2.9.0, and 2.9.1

### DIFF
--- a/firebase-dataconnect/gradleplugin/plugin/src/main/resources/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableVersions.json
+++ b/firebase-dataconnect/gradleplugin/plugin/src/main/resources/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableVersions.json
@@ -1,5 +1,5 @@
 {
-  "defaultVersion": "2.6.2",
+  "defaultVersion": "2.9.1",
   "versions": [
     {
       "version": "1.3.4",
@@ -774,6 +774,114 @@
       "os": "linux",
       "size": 27414680,
       "sha512DigestHex": "b57c031bda4a6de5d16f6262c9016ee1117ce84e30b439f68325fcdef58a5ee85e1f60b8d3172e498ea52cf3c0dba4d4ff5ff1bf92e8e99e331a6602d5f62e35"
+    },
+    {
+      "version": "2.6.3",
+      "os": "windows",
+      "size": 27975168,
+      "sha512DigestHex": "d861063bbbed7124157615740043ca876253e95dc9dde2450872ce63fd8ca468e0d7048527f3a507935ec83222f6380339e317a247f916a396cf88f408b1a30f"
+    },
+    {
+      "version": "2.6.3",
+      "os": "macos",
+      "size": 27517696,
+      "sha512DigestHex": "1e9953d36096057fa9a1c9d7766dd75be0b114ff037b722a69fadfe41748f94dae3d4124fed20451f6837165cc54e1ff35dbeb39572216077ea0ed843f113a5b"
+    },
+    {
+      "version": "2.6.3",
+      "os": "linux",
+      "size": 27431064,
+      "sha512DigestHex": "a476f897137d622c81eb7fd4690887ae9198fd32d122adbb97416dc372e81db5dec61c9a157f6b71c1b076354d05e936b7df297c8a6e8116a272bddc883c7efa"
+    },
+    {
+      "version": "2.7.0",
+      "os": "windows",
+      "size": 28001280,
+      "sha512DigestHex": "3dc81cabfafae18348d010c823659fae3c2c4e5b4eecb662bb8fbcd59541118e411fe6c35d56e403b38cfe4b91ec3ad1882ddfb3efec10de47640b47f9c1e5b8"
+    },
+    {
+      "version": "2.7.0",
+      "os": "macos",
+      "size": 27542272,
+      "sha512DigestHex": "ef0d462b8835a6861f05fad11ebc6b43edfbf75499295a356f7dfb1e81a911e924248fbef1cdbdc0b82c1183308f52887eafaf00fd1da20122db38ddafdfb50a"
+    },
+    {
+      "version": "2.7.0",
+      "os": "linux",
+      "size": 27451544,
+      "sha512DigestHex": "d6d789ad65ec246848dd9a3fe8afe34913a71c1c727bc9ea0e43c5843bf5713fb0662eb451a04f6a93ce1fb44f908426d54a046ca807cfa5318882a43c7f8fd8"
+    },
+    {
+      "version": "2.7.1",
+      "os": "windows",
+      "size": 28067328,
+      "sha512DigestHex": "b33f4047ef9ee7255a388bd99b4e486fb50e4ffd047622c51c35cd3f4f7133b2f64d9325c7e40392e01a1e2c020d6ddce99743eef001e5ef6c85eda8eeb035fc"
+    },
+    {
+      "version": "2.7.1",
+      "os": "macos",
+      "size": 27607808,
+      "sha512DigestHex": "08e76650fbd8ba571df04c367c82ba9cf7a93d6e3017cf1cf293f2b1082ef396a73d132c70d44fae7c91ed172d27e16905005fc6e9c6d88335831961b5cce025"
+    },
+    {
+      "version": "2.7.1",
+      "os": "linux",
+      "size": 27521176,
+      "sha512DigestHex": "6bd233ef3df884b4625688f431bfb15a1e0915c647b7e77ecdb5ae7180cf99f23a6af238616a1ddd66ac8a33b630600be3313e64d8fb2bb0a125764152b9b8e2"
+    },
+    {
+      "version": "2.8.0",
+      "os": "windows",
+      "size": 29769216,
+      "sha512DigestHex": "5c5df997e4f872e5b620cce3b541fc06745bff6425e61b5e1a2ec4565a0d53020a5808c8f006045c5a73a79d1c01ccb31ee9058a68da4741f5fac4daf6b0dbab"
+    },
+    {
+      "version": "2.8.0",
+      "os": "macos",
+      "size": 29279072,
+      "sha512DigestHex": "1d8b1c0aca490ec5870a46ffc2e8b0ff4ed6c4b1f7502a329628257f7dd34c24c04e085dc5b348f06a2bb9a942eb312d30390cc40b98e6e3519eff928b9d5b2f"
+    },
+    {
+      "version": "2.8.0",
+      "os": "linux",
+      "size": 29208760,
+      "sha512DigestHex": "4d48c969c513d63835650b701649e2c82855cb361344b9b1017941c522fbd4f79f442fe83232a03150b5aff6ed87e957084a05d2eaf276a8003e1cda3e17689d"
+    },
+    {
+      "version": "2.9.0",
+      "os": "windows",
+      "size": 27875328,
+      "sha512DigestHex": "06f07a5d8cfdd942393959c21e1511a3d0de6f26d67be78b4dbfdacf021938db089ad4d4945cdeb130e6af4d4a87a93a579954d36a64dac7b58f6ade99c79de3"
+    },
+    {
+      "version": "2.9.0",
+      "os": "macos",
+      "size": 27415296,
+      "sha512DigestHex": "63461d8ef2c41a85b9ebb52fc566e44db8209d2ae750b7137d50529ff1c3861889e2a75ec380e5eaf5e4bf8094594b881d66fe572885bec2456bb33190fe653b"
+    },
+    {
+      "version": "2.9.0",
+      "os": "linux",
+      "size": 27332760,
+      "sha512DigestHex": "668cb4261010ac6bad7136c6a92fdd19c7064a0baf7adf1d11221240a8f3f3c595e74690f048d35ac7f0b5fb9d2753f11dd12a8821dbb39a93763f2332ec44c6"
+    },
+    {
+      "version": "2.9.1",
+      "os": "windows",
+      "size": 29797888,
+      "sha512DigestHex": "094ee4becd213e7391a2c9f49579942651ffd027bb6c2b5194a3da10c29b348f982549e7021c3852d76aed6ff40ce6a4e8667097a8a49eb098a6ab0cbc90f5f7"
+    },
+    {
+      "version": "2.9.1",
+      "os": "macos",
+      "size": 29307744,
+      "sha512DigestHex": "ede2712733628210b523917e9b77383075eb650cf81600b380bd9d142b6e20c500212984c9d66447abb38cfd57ba16665b1a57878ed17e950d5c4ef73fdf5e6c"
+    },
+    {
+      "version": "2.9.1",
+      "os": "linux",
+      "size": 29233336,
+      "sha512DigestHex": "e320752834236d4b1cb67fa41c70e11f5b374832ffb4e2be31a06f6860ec389833fad62b3070d3ec16ea40fcf719bee8855acacb0627d943f0b8807cecaed564"
     }
   ]
 }


### PR DESCRIPTION
DataConnectExecutableVersions.json updated with versions 2.6.3, 2.7.0, 2.7.1, 2.8.0, 2.9.0, and 2.9.1 by running:

```
./gradlew :firebase-dataconnect:connectors:updateJson -Pversions=2.6.3,2.7.0,2.7.1,2.8.0,2.9.0,2.9.1 -PdefaultVersion=2.9.1```