### PR TITLE
Bump up minor version for Fireperf for AQS

### DIFF
--- a/firebase-perf/CHANGELOG.md
+++ b/firebase-perf/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Unreleased
+* [changed] Updated `firebase-sessions` dependency to v3.0.0
+* [fixed] Fixed the issues around unifying the sessions in `firebase-sessions` 
+  and`firebase-performance`.
+
+# 22.0.0
 * [changed] **Breaking Change**: Updated minSdkVersion to API level 23 or higher.
 * [removed] **Breaking Change**: Stopped releasing the deprecated Kotlin extensions
   (KTX) module and removed it from the Firebase Android BoM. Instead, use the KTX APIs

--- a/firebase-perf/gradle.properties
+++ b/firebase-perf/gradle.properties
@@ -15,7 +15,7 @@
 #
 #
 
-version=22.0.0
+version=22.1.0
 latestReleasedVersion=21.0.5
 android.enableUnitTestBinaryResources=true
 

--- a/firebase-perf/src/test/java/com/google/firebase/perf/session/gauges/GaugeManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/session/gauges/GaugeManagerTest.java
@@ -402,6 +402,7 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
+  // TODO(b/394127311): Investigate flaky test.
   public void testDuplicateGaugeLoggingIsAvoided() {
     int priorGaugeCounter = GaugeCounter.count();
     PerfSession fakeSession = createTestSession(1);

--- a/firebase-perf/src/test/java/com/google/firebase/perf/transport/TransportManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/transport/TransportManagerTest.java
@@ -219,6 +219,7 @@ public class TransportManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
+  // TODO(b/394127311): Investigate flaky test.
   public void
       logMultipleEvents_transportNotInitialized_validEventsGetLoggedInOrderAfterInitialization() {
     initializeTransport(false);


### PR DESCRIPTION
- The `fireperf-aqs` branch was rebased on `main` yesterday.
- This PR bumps up the version to be a minor version bump.