### PR TITLE
dataconnect: tests: fix unparseableDash() in LocalDateSerializerUnitTest.kt et al

### DIFF
--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/serializers/JavaTimeLocalDateSerializerUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/serializers/JavaTimeLocalDateSerializerUnitTest.kt
@@ -222,7 +222,8 @@ class JavaTimeLocalDateSerializerUnitTest {
     }
 
     fun Arb.Companion.unparseableDash(): Arb<String> {
-      val invalidString = string(1..5, codepoints.filterNot { it.value == '-'.code })
+      val invalidString =
+        string(1..5, codepoints.filterNot { it.value == '-'.code || Character.isDigit(it.value) })
       return arbitrary { rs ->
         val flags = Array(3) { rs.random.nextBoolean() }
         if (!flags[0]) {

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/serializers/KotlinxDatetimeLocalDateSerializerUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/serializers/KotlinxDatetimeLocalDateSerializerUnitTest.kt
@@ -225,7 +225,8 @@ class KotlinxDatetimeLocalDateSerializerUnitTest {
     }
 
     fun Arb.Companion.unparseableDash(): Arb<String> {
-      val invalidString = string(1..5, codepoints.filterNot { it.value == '-'.code })
+      val invalidString =
+        string(1..5, codepoints.filterNot { it.value == '-'.code || Character.isDigit(it.value) })
       return arbitrary { rs ->
         val flags = Array(3) { rs.random.nextBoolean() }
         if (!flags[0]) {

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/serializers/LocalDateSerializerUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/serializers/LocalDateSerializerUnitTest.kt
@@ -206,10 +206,7 @@ class LocalDateSerializerUnitTest {
 
     fun Arb.Companion.unparseableDash(): Arb<String> {
       val invalidString =
-        string(
-          1..5,
-          codepoints.filterNot { it.value == '-'.code || it.value in '0'.code..'9'.code }
-        )
+        string(1..5, codepoints.filterNot { it.value == '-'.code || Character.isDigit(it.value) })
       return arbitrary { rs ->
         val flags = Array(3) { rs.random.nextBoolean() }
         if (!flags[0]) {


### PR DESCRIPTION
This PR refines the test data generation for `LocalDateSerializer` unit tests across various date/time library integrations, enhancing the reliability of tests designed to validate the handling of unparseable date strings by preventing the generation of test data that could inadvertently be interpreted as valid numeric components.

The `unparseableDash()` function in `LocalDateSerializer` unit tests has been updated to ensure that the generated "invalid" strings do not contain any digit characters. This prevents scenarios where digits could combine with adjacent characters to unexpectedly form a valid integer. The fix is applied consistently across `JavaTimeLocalDateSerializerUnitTest.kt`, `KotlinxDatetimeLocalDateSerializerUnitTest.kt`, and `LocalDateSerializerUnitTest.kt`.

Note that this bug had already been fixed in `LocalDateSerializerUnitTest.kt` in https://github.com/firebase/firebase-android-sdk/pull/6839 but forgot to also apply the fix to `JavaTimeLocalDateSerializerUnitTest.kt` and `KotlinxDatetimeLocalDateSerializerUnitTest.kt`. This PR brings all 3 tests files into sync, using the same logic.