### PR TITLE
Make the AQS Test App behave more typically for Perf start up

### DIFF
--- a/firebase-sessions/test-app/src/main/AndroidManifest.xml
+++ b/firebase-sessions/test-app/src/main/AndroidManifest.xml
@@ -28,7 +28,6 @@
       android:exported="true"
       android:label="@string/app_name"
       android:name=".MainActivity"
-      android:process=":main"
       android:theme="@style/Theme.Widget_test_app.NoActionBar">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />

--- a/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/TestApplication.kt
+++ b/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/TestApplication.kt
@@ -37,7 +37,12 @@ class TestApplication : MultiDexApplication() {
   override fun onCreate() {
     super.onCreate()
     Log.i(TAG, "TestApplication created on process: $myProcessName")
-    FirebaseApp.initializeApp(this)
+
+    // Initialize firebase for all processes except the default process
+    // The default process will get initialized automatically by FirebaseInitProvider
+    if (myProcessName != packageName) {
+      FirebaseApp.initializeApp(this)
+    }
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
       registerReceiver(


### PR DESCRIPTION
This changes the main activity to be on the default process, allowing the more typical FirebaseInitProvider initialization of Firebase. The other processes will still initialize manually 