### PR TITLE
Resolve metalava semver using outdated version info

### DIFF
--- a/.github/workflows/metalava-semver-check.yml
+++ b/.github/workflows/metalava-semver-check.yml
@@ -11,8 +11,10 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Checkout PR
+      - name: Checkout main
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.base_ref }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
@@ -24,10 +26,10 @@ jobs:
       - name: Copy new api.txt files
         run: ./gradlew copyApiTxtFile
 
-      - name: Checkout main
+      - name: Checkout PR
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.base_ref }}
+          ref: ${{ github.head_ref || github.ref_name }}
           clean: false
 
       - name: Run Metalava SemVer check

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/FirebaseAndroidLibraryPlugin.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/FirebaseAndroidLibraryPlugin.kt
@@ -163,12 +163,12 @@ class FirebaseAndroidLibraryPlugin : BaseFirebaseLibraryPlugin() {
 
     project.tasks.register<CopyApiTask>("copyApiTxtFile") {
       apiTxtFile.set(project.file("api.txt"))
-      output.set(project.file("new_api.txt"))
+      output.set(project.file("old_api.txt"))
     }
 
     project.tasks.register<SemVerTask>("metalavaSemver") {
-      apiTxtFile.set(project.file("new_api.txt"))
-      otherApiFile.set(project.file("api.txt"))
+      apiTxtFile.set(project.file("api.txt"))
+      otherApiFile.set(project.file("old_api.txt"))
       currentVersionString.value(firebaseLibrary.version)
       previousVersionString.value(firebaseLibrary.previousVersion)
     }

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/FirebaseJavaLibraryPlugin.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/FirebaseJavaLibraryPlugin.kt
@@ -106,12 +106,12 @@ class FirebaseJavaLibraryPlugin : BaseFirebaseLibraryPlugin() {
 
     project.tasks.register<CopyApiTask>("copyApiTxtFile") {
       apiTxtFile.set(project.file("api.txt"))
-      output.set(project.file("new_api.txt"))
+      output.set(project.file("old_api.txt"))
     }
 
     project.tasks.register<SemVerTask>("metalavaSemver") {
-      apiTxtFile.set(project.file("new_api.txt"))
-      otherApiFile.set(project.file("api.txt"))
+      apiTxtFile.set(project.file("api.txt"))
+      otherApiFile.set(project.file("old_api.txt"))
       currentVersionString.value(firebaseLibrary.version)
       previousVersionString.value(firebaseLibrary.previousVersion)
     }


### PR DESCRIPTION
Returns to older behavior of returning to the PR branch to run the check, to make sure gradle.properties version is updated.