### PR TITLE
dataconnect: demo: add support for data connect preview flags and update dependencies

### DIFF
--- a/firebase-dataconnect/demo/build.gradle.kts
+++ b/firebase-dataconnect/demo/build.gradle.kts
@@ -197,9 +197,9 @@ abstract class DataConnectGenerateSourcesTask : DefaultTask() {
             args("--debug", "dataconnect:sdk:generate")
             workingDir(inputDirectory)
             isIgnoreExitValue = false
-            if (logStream !== null) {
-              standardOutput = logStream
-              errorOutput = logStream
+            logStream?.let {
+              standardOutput = it
+              errorOutput = it
             }
           }
         }
@@ -225,31 +225,16 @@ abstract class DataConnectGenerateSourcesTask : DefaultTask() {
     ) {
       execSpec.setCommandLine(firebaseCommand)
 
-      val newPath: String? =
-        if (nodeExecutableDirectory === null) {
-          null
-        } else {
-          if (path === null) {
-            nodeExecutableDirectory
-          } else {
-            nodeExecutableDirectory + File.pathSeparator + path
-          }
-        }
-
-      if (newPath !== null) {
+      nodeExecutableDirectory?.let {
+        val newPath = if (path === null) it else (it + File.pathSeparator + path)
         execSpec.environment("PATH", newPath)
       }
 
-      if (dataConnectEmulatorExecutable !== null) {
-        execSpec.environment(
-          "DATACONNECT_EMULATOR_BINARY_PATH",
-          dataConnectEmulatorExecutable.absolutePath,
-        )
+      dataConnectEmulatorExecutable?.let {
+        execSpec.environment("DATACONNECT_EMULATOR_BINARY_PATH", it.absolutePath)
       }
 
-      if (dataConnectPreviewFlags !== null) {
-        execSpec.environment("DATA_CONNECT_PREVIEW", dataConnectPreviewFlags)
-      }
+      dataConnectPreviewFlags?.let { execSpec.environment("DATA_CONNECT_PREVIEW", it) }
     }
   }
 }

--- a/firebase-dataconnect/demo/build.gradle.kts
+++ b/firebase-dataconnect/demo/build.gradle.kts
@@ -138,6 +138,8 @@ abstract class DataConnectGenerateSourcesTask : DefaultTask() {
   @get:PathSensitive(PathSensitivity.ABSOLUTE)
   abstract val dataConnectEmulatorExecutable: RegularFileProperty
 
+  @get:Input @get:Optional abstract val dataConnectPreviewFlags: Property<String>
+
   @get:OutputDirectory abstract val outputDirectory: DirectoryProperty
 
   @get:Internal abstract val workDirectory: DirectoryProperty
@@ -155,6 +157,7 @@ abstract class DataConnectGenerateSourcesTask : DefaultTask() {
     val firebaseCommand: String = firebaseCommand.get()
     val nodeExecutableDirectory: String? = nodeExecutableDirectory.orNull
     val dataConnectEmulatorExecutable: File? = dataConnectEmulatorExecutable.orNull?.asFile
+    val dataConnectPreviewFlags: String? = dataConnectPreviewFlags.orNull
     val outputDirectory: File = outputDirectory.get().asFile
     val workDirectory: File = workDirectory.get().asFile
 
@@ -163,6 +166,7 @@ abstract class DataConnectGenerateSourcesTask : DefaultTask() {
     logger.info("firebaseCommand: {}", firebaseCommand)
     logger.info("nodeExecutableDirectory: {}", nodeExecutableDirectory)
     logger.info("dataConnectEmulatorExecutable: {}", dataConnectEmulatorExecutable)
+    logger.info("dataConnectPreviewFlags: {}", dataConnectPreviewFlags)
     logger.info("outputDirectory: {}", outputDirectory.absolutePath)
     logger.info("workDirectory: {}", workDirectory.absolutePath)
 
@@ -187,6 +191,7 @@ abstract class DataConnectGenerateSourcesTask : DefaultTask() {
               firebaseCommand = firebaseCommand,
               nodeExecutableDirectory = nodeExecutableDirectory,
               dataConnectEmulatorExecutable = dataConnectEmulatorExecutable,
+              dataConnectPreviewFlags = dataConnectPreviewFlags,
               path = providerFactory.environmentVariable("PATH").orNull,
             )
             args("--debug", "dataconnect:sdk:generate")
@@ -215,6 +220,7 @@ abstract class DataConnectGenerateSourcesTask : DefaultTask() {
       firebaseCommand: String,
       nodeExecutableDirectory: String?,
       dataConnectEmulatorExecutable: File?,
+      dataConnectPreviewFlags: String?,
       path: String?,
     ) {
       execSpec.setCommandLine(firebaseCommand)
@@ -239,6 +245,10 @@ abstract class DataConnectGenerateSourcesTask : DefaultTask() {
           "DATACONNECT_EMULATOR_BINARY_PATH",
           dataConnectEmulatorExecutable.absolutePath,
         )
+      }
+
+      if (dataConnectPreviewFlags !== null) {
+        execSpec.environment("DATA_CONNECT_PREVIEW", dataConnectPreviewFlags)
       }
     }
   }
@@ -301,6 +311,9 @@ run {
           projectDirectory.file(it)
         }
 
+      dataConnectPreviewFlags =
+        project.providers.gradleProperty("dataConnect.demo.dataConnectPreviewFlags")
+
       val path = providers.environmentVariable("PATH")
       firebaseToolsVersion =
         providers
@@ -310,6 +323,7 @@ run {
               firebaseCommand = firebaseCommand.get(),
               nodeExecutableDirectory = nodeExecutableDirectory.orNull,
               dataConnectEmulatorExecutable = dataConnectEmulatorExecutable.orNull?.asFile,
+              dataConnectPreviewFlags = dataConnectPreviewFlags.orNull,
               path = path.orNull,
             )
             args("--version")

--- a/firebase-dataconnect/demo/build.gradle.kts
+++ b/firebase-dataconnect/demo/build.gradle.kts
@@ -19,35 +19,35 @@ import java.nio.charset.StandardCharsets
 
 plugins {
   // Use whichever versions of these dependencies suit your application.
-  // The versions shown here were the latest versions as of June 10, 2025.
+  // The versions shown here were the latest versions as of July 17, 2025.
   // Note, however, that the version of kotlin("plugin.serialization") _must_,
   // in general, match the version of kotlin("android").
-  id("com.android.application") version "8.11.0"
-  id("com.google.gms.google-services") version "4.4.2"
+  id("com.android.application") version "8.11.1"
+  id("com.google.gms.google-services") version "4.4.3"
   val kotlinVersion = "2.1.10"
   kotlin("android") version kotlinVersion
   kotlin("plugin.serialization") version kotlinVersion
 
   // The following code in this "plugins" block can be omitted from customer
   // facing documentation as it is an implementation detail of this application.
-  id("com.diffplug.spotless") version "7.0.0.BETA4"
+  id("com.diffplug.spotless") version "7.1.0"
 
   id("org.jetbrains.dokka") version "2.0.0"
 }
 
 dependencies {
   // Use whichever versions of these dependencies suit your application.
-  // The versions shown here were the latest versions as of June 10, 2025.
+  // The versions shown here were the latest versions as of July 17, 2025.
 
   // Data Connect
-  implementation(platform("com.google.firebase:firebase-bom:33.15.0"))
+  implementation(platform("com.google.firebase:firebase-bom:33.16.0"))
   implementation("com.google.firebase:firebase-dataconnect")
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.1")
-  implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.8.1")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
+  implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.9.0")
   implementation("androidx.appcompat:appcompat:1.7.1")
   implementation("androidx.activity:activity-ktx:1.10.1")
-  implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.1")
+  implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.2")
   implementation("com.google.android.material:material:1.12.0")
 
   // The following code in this "dependencies" block can be omitted from customer
@@ -70,10 +70,10 @@ dokka {
 
 android {
   namespace = "com.google.firebase.dataconnect.minimaldemo"
-  compileSdk = 35
+  compileSdk = 36
   defaultConfig {
     minSdk = 23
-    targetSdk = 35
+    targetSdk = 36
     versionCode = 1
     versionName = "1.0"
   }

--- a/firebase-dataconnect/demo/gradle.properties
+++ b/firebase-dataconnect/demo/gradle.properties
@@ -29,3 +29,8 @@ org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 // downloading an official version and using it.
 // See build.gradle.kts for details.
 //dataConnect.demo.dataConnectEmulatorExecutable=/path/to/cli
+
+// A comma-separated list of "preview flags" to specify to the Data Connect emulator and codegen.
+// This is used to enable features that are not (yet) intended for end-user consumption.
+// See build.gradle.kts for details.
+//dataConnect.demo.dataConnectPreviewFlags=flag1,flag2,flag3


### PR DESCRIPTION
This PR performs some maintenance of the Data Connect demo application. It introduces a mechanism to pass 'preview flags' to the Data Connect cli, updates the dependencies to the latest versions, and improves some null-handling logic to be more Kotlin-idiomatic.

### Highlights

* **Data Connect Preview Flags Support**: Introduced a new Gradle property, `dataConnect.demo.dataConnectPreviewFlags`, allowing the specification of preview flags for the Data Connect emulator and code generation. These flags are passed as a `DATA_CONNECT_PREVIEW` environment variable to the Firebase CLI.
* **Dependency Updates**: Updated numerous dependencies for the Data Connect demo, including Android Gradle Plugin, Google Services, Firebase BOM, Kotlin Coroutines, Kotlin Serialization, and AndroidX Lifecycle, to their latest versions.
* **Android SDK Version Bump**: Upgraded the Android `compileSdk` and `targetSdk` versions from API level 35 to 36.
* **Kotlin Idiomatic Refactoring**: Refactored several null checks in the Gradle build script to use idiomatic Kotlin `?.let` for improved readability and safety.

<details>
<summary><b>Changelog</b></summary>

* **firebase-dataconnect/demo/build.gradle.kts**
    * Updated various build and runtime dependencies, including `com.android.application` (8.11.0 -> 8.11.1), `com.google.gms.google-services` (4.4.2 -> 4.4.3), `com.diffplug.spotless` (7.0.0.BETA4 -> 7.1.0), `firebase-bom` (33.15.0 -> 33.16.0), `kotlinx-coroutines-core` (1.10.1 -> 1.10.2), `kotlinx-coroutines-android` (1.10.1 -> 1.10.2), `kotlinx-serialization-core` (1.8.1 -> 1.9.0), and `androidx.lifecycle:lifecycle-viewmodel-ktx` (2.9.1 -> 2.9.2).
    * Bumped `compileSdk` and `targetSdk` versions from 35 to 36.
    * Added a new `dataConnectPreviewFlags` property to the `DataConnectGenerateSourcesTask` (line 141).
    * Modified the `DataConnectGenerateSourcesTask` to read the `dataConnectPreviewFlags` (line 160) and pass them as a `DATA_CONNECT_PREVIEW` environment variable to the Firebase CLI during SDK generation (line 237).
    * Refactored `if (logStream !== null)` to `logStream?.let { ... }` (lines 195-197 to 200-202) and similar null checks for `nodeExecutableDirectory` and `dataConnectEmulatorExecutable` (lines 222-242 to 228-235) to use the more concise and idiomatic Kotlin `?.let` syntax.
* **firebase-dataconnect/demo/gradle.properties**
    * Added a commented-out example entry for `dataConnect.demo.dataConnectPreviewFlags` with a descriptive comment, explaining its purpose for enabling preview features.
</details>
