### PR TITLE
dataconnect: DataConnectExecutableVersions.json updated with version 2.10.0

### DIFF
--- a/firebase-dataconnect/gradleplugin/plugin/src/main/resources/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableVersions.json
+++ b/firebase-dataconnect/gradleplugin/plugin/src/main/resources/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableVersions.json
@@ -1,5 +1,5 @@
 {
-  "defaultVersion": "2.9.1",
+  "defaultVersion": "2.10.0",
   "versions": [
     {
       "version": "1.3.4",
@@ -882,6 +882,24 @@
       "os": "linux",
       "size": 29233336,
       "sha512DigestHex": "e320752834236d4b1cb67fa41c70e11f5b374832ffb4e2be31a06f6860ec389833fad62b3070d3ec16ea40fcf719bee8855acacb0627d943f0b8807cecaed564"
+    },
+    {
+      "version": "2.10.0",
+      "os": "windows",
+      "size": 29824000,
+      "sha512DigestHex": "fb430463430af8781c9b1c40488c3abf9362df076be43e966d54cf7d1d8cc39436cc7fc361c3ba45105b58ec6d10021456cb22f7ac050905a06d86127c22c5cb"
+    },
+    {
+      "version": "2.10.0",
+      "os": "macos",
+      "size": 29332320,
+      "sha512DigestHex": "9c4aa8d4dbea8bde36a53e1477d557c6a31dc16ca25ded38a0b06a5a4849222779be6bf6559c0e3c7f89970c3e9aeda5cbc15573a0832bd83c8d463294bc7f4f"
+    },
+    {
+      "version": "2.10.0",
+      "os": "linux",
+      "size": 29257912,
+      "sha512DigestHex": "93e71bdc76510cf70410338f016819b97abe7a4b372ee52c0f59c0c58f23814c3f94cf2e6772dce5a8fbabda582f363cabb808b4284dfa142b6bc94d305088a4"
     }
   ]
 }


### PR DESCRIPTION
DataConnectExecutableVersions.json updated with version 2.10.0 by running:

```
./gradlew :firebase-dataconnect:connectors:updateJson -Pversions=2.10.0 -PdefaultVersion=2.10.0
```

Notably, this updated version adds official support for user-defined enums.