### PR TITLE
dataconnect: emulator.sh: add fancy command-line argument parsing to improve devx

### DIFF
--- a/firebase-dataconnect/emulator/emulator.sh
+++ b/firebase-dataconnect/emulator/emulator.sh
@@ -16,18 +16,121 @@
 
 set -euo pipefail
 
-# Uncomment the line below to use a custom Data Connect Emulator binary
-#export DATACONNECT_EMULATOR_BINARY_PATH='...'
+readonly SCRIPT_DIR="$(dirname "$0")"
+readonly SELF_EXECUTABLE="$0"
+readonly LOG_PREFIX="[$0] "
+readonly DEFAULT_POSTGRESQL_STRING='postgresql://postgres:postgres@localhost:5432?sslmode=disable'
 
-export FIREBASE_DATACONNECT_POSTGRESQL_STRING='postgresql://postgres:postgres@localhost:5432?sslmode=disable'
-echo "[$0] export FIREBASE_DATACONNECT_POSTGRESQL_STRING='$FIREBASE_DATACONNECT_POSTGRESQL_STRING'"
+function main {
+  parse_args "$@"
 
-readonly FIREBASE_ARGS=(
-  firebase
-  --debug
-  emulators:start
-  --only auth,dataconnect
-)
+  log "FIREBASE_DATACONNECT_POSTGRESQL_STRING=${FIREBASE_DATACONNECT_POSTGRESQL_STRING:-<undefined>}"
+  log "DATACONNECT_EMULATOR_BINARY_PATH=${DATACONNECT_EMULATOR_BINARY_PATH:-<undefined>}"
 
-echo "[$0] Running command: ${FIREBASE_ARGS[*]}"
-exec "${FIREBASE_ARGS[@]}"
+  readonly FIREBASE_ARGS=(
+    firebase
+    --debug
+    emulators:start
+    --only auth,dataconnect
+  )
+
+  log "Running command: ${FIREBASE_ARGS[*]}"
+  exec "${FIREBASE_ARGS[@]}"
+}
+
+function parse_args {
+  local emulator_binary=''
+  local postgresql_string="${DEFAULT_POSTGRESQL_STRING}"
+  local wipe_and_restart_postgres_pod=0
+
+  local OPTIND=1
+  local OPTERR=0
+  while getopts ":c:p:hw" arg ; do
+    case "$arg" in
+      c) emulator_binary="${OPTARG}" ;;
+      p) postgresql_string="${OPTARG}" ;;
+      w) wipe_and_restart_postgres_pod=1 ;;
+      h)
+        print_help
+        exit 0
+        ;;
+      :)
+        echo "ERROR: missing value after option: -${OPTARG}" >&2
+        echo "Run with -h for help" >&2
+        exit 2
+        ;;
+      ?)
+        echo "ERROR: unrecognized option: -${OPTARG}" >&2
+        echo "Run with -h for help" >&2
+        exit 2
+        ;;
+      *)
+        echo "INTERNAL ERROR: unknown argument: $arg" >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  if [[ ! -z $emulator_binary ]] ; then
+    export DATACONNECT_EMULATOR_BINARY_PATH="${emulator_binary}"
+  fi
+
+  if [[ ! -z $postgresql_string ]] ; then
+    export FIREBASE_DATACONNECT_POSTGRESQL_STRING="${postgresql_string}"
+  fi
+
+  if [[ $wipe_and_restart_postgres_pod == "1" ]] ; then
+    local wipe_args="${SCRIPT_DIR}/wipe_postgres_db.sh"
+    log "Running command: ${wipe_args[*]}"
+    "${wipe_args[@]}"
+
+    local start_args="${SCRIPT_DIR}/start_postgres_pod.sh"
+    log "Running command: ${start_args[*]}"
+    "${start_args[@]}"
+  fi
+}
+
+function print_help {
+  echo "Firebase Data Connect Emulator Launcher Helper"
+  echo
+  echo "This script provides a convenient way to launch the Firebase Data Connect"
+  echo "and Firebase Authentication emulators in a way that is amenable for running"
+  echo "the integration tests."
+  echo
+  echo "Syntax: ${SELF_EXECUTABLE} [options]"
+  echo
+  echo "Options:"
+  echo "  -c <data_connect_emulator_binary_path>"
+  echo "    Uses the Data Connect Emulator binary at the given path. If not specified, "
+  echo "    or if specified as the empty string, then the emulator binary is downloaded."
+  echo
+  echo "  -p <postgresql_connection_string>"
+  echo "    Uses the given string to connect to the PostgreSQL server. If not specified "
+  echo "    the the default value of \"${DEFAULT_POSTGRESQL_STRING}\" is used."
+  echo "    If specified as the empty string then an ephemeral PGLite server is used."
+  echo
+  echo "  -w"
+  echo "    If specified, then a local PostgreSQL container is wiped and restarted"
+  echo "    before launching the emulators. This is accomplished by running the scripts"
+  echo "    ./wipe_postgres_db.sh followed by ./start_postgres_pod.sh."
+  echo
+  echo "  -h"
+  echo "    Print this help screen and exit, as if successful."
+  echo
+  echo "Environment Variables:"
+  echo "  DATACONNECT_EMULATOR_BINARY_PATH"
+  echo "    This variable will be set to the value of the -c argument prior to launching"
+  echo "    the emulators. If the -c argument is not given then the value of this environment"
+  echo "    variable will be used as if it had been specified to the -c argument."
+  echo
+  echo "  FIREBASE_DATACONNECT_POSTGRESQL_STRING"
+  echo "    This variable will be set to the value of the -p argument prior to launching"
+  echo "    the emulators. If the -p argument is not given then the value of this environment"
+  echo "    variable will be set to \"${DEFAULT_POSTGRESQL_STRING}\"."
+}
+
+function log {
+  echo "${LOG_PREFIX}$*"
+}
+
+main "$@"


### PR DESCRIPTION
This PR enhances Data Connect's `emulator.sh` script by introducing robust command-line argument parsing. This improves the developer experience when launching the Firebase Data Connect and Authentication emulators for local development, offering easier control over the Data Connect Emulator binary and PostgreSQL database configuration.

This change does _not_ affect customers at all; this script is only used for development of the data connect sdk itself.

### Highlights

* **Enhanced Command-Line Argument Parsing**: The `emulator.sh` script now supports command-line arguments (`-c`, `-p`, `-w`, `-h`).
* **Custom Emulator Binary Support**: Users can specify a custom Data Connect Emulator binary path using the `-c` option, allowing for local development with specific emulator versions.
* **Flexible PostgreSQL Configuration**: The PostgreSQL connection string can now be customized via the `-p` option, enabling connections to different PostgreSQL instances or the use of an ephemeral PGLite server.
* **PostgreSQL Database Management**: A new `-w` option has been added to automatically wipe and restart the local PostgreSQL container before launching the emulators.
* **Improved Script Structure and Help**: The script has been refactored into modular functions (`main`, `parse_args`, `print_help`, `log`) and includes a comprehensive help message accessible via the `-h` option.