### PR TITLE
dataconnect: upgrade data connect emulator to 14.11.1

### DIFF
--- a/.github/workflows/dataconnect.yml
+++ b/.github/workflows/dataconnect.yml
@@ -34,7 +34,7 @@ env:
   FDC_JAVA_VERSION: ${{ inputs.javaVersion || '17' }}
   FDC_ANDROID_EMULATOR_API_LEVEL: ${{ inputs.androidEmulatorApiLevel || '34' }}
   FDC_NODEJS_VERSION: ${{ inputs.nodeJsVersion || '20' }}
-  FDC_FIREBASE_TOOLS_VERSION: ${{ inputs.firebaseToolsVersion || '14.11.0' }}
+  FDC_FIREBASE_TOOLS_VERSION: ${{ inputs.firebaseToolsVersion || '14.11.1' }}
   FDC_FIREBASE_TOOLS_DIR: /tmp/firebase-tools
   FDC_FIREBASE_COMMAND: /tmp/firebase-tools/node_modules/.bin/firebase
   FDC_PYTHON_VERSION: ${{ inputs.pythonVersion || '3.13' }}

--- a/.github/workflows/dataconnect_demo_app.yml
+++ b/.github/workflows/dataconnect_demo_app.yml
@@ -18,7 +18,7 @@ on:
 
 env:
   FDC_NODE_VERSION: ${{ inputs.nodeVersion || '20' }}
-  FDC_FIREBASE_TOOLS_VERSION: ${{ inputs.firebaseToolsVersion || '14.11.0' }}
+  FDC_FIREBASE_TOOLS_VERSION: ${{ inputs.firebaseToolsVersion || '14.11.1' }}
   FDC_JAVA_VERSION: ${{ inputs.javaVersion || '17' }}
   FDC_FIREBASE_TOOLS_DIR: ${{ github.workspace }}/firebase-tools
   FDC_FIREBASE_COMMAND: ${{ github.workspace }}/firebase-tools/node_modules/.bin/firebase

--- a/firebase-dataconnect/connectors/src/test/kotlin/com/google/firebase/dataconnect/connectors/demo/EnumValueUnknownUnitTest.kt
+++ b/firebase-dataconnect/connectors/src/test/kotlin/com/google/firebase/dataconnect/connectors/demo/EnumValueUnknownUnitTest.kt
@@ -22,6 +22,7 @@ import com.google.firebase.dataconnect.testutil.property.arbitrary.dataConnect
 import com.google.firebase.dataconnect.testutil.property.arbitrary.distinctPair
 import io.kotest.assertions.withClue
 import io.kotest.common.ExperimentalKotest
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
@@ -32,7 +33,6 @@ import io.kotest.property.arbitrary.of
 import io.kotest.property.assume
 import io.kotest.property.checkAll
 import kotlinx.coroutines.test.runTest
-import org.junit.Ignore
 import org.junit.Test
 
 @Suppress("ReplaceCallWithBinaryOperator")
@@ -47,16 +47,10 @@ class EnumValueUnknownUnitTest {
   }
 
   @Test
-  @Ignore(
-    "TODO(cl/785477120) Enable this test once a data connect emulator build that " +
-      "includes cl/785477120 is released, which will have a version >2.10.0 and " +
-      "a firebase-tools version >14.11.0"
-  )
   fun `value property should unconditionally be null`() = runTest {
     checkAll(propTestConfig, Arb.dataConnect.string()) { stringValue ->
       val enumValue = EnumValue.Unknown(stringValue)
-      // TODO(cl/785477120) Uncomment the line below when the test is re-enabled.
-      // enumValue.value.shouldBeNull()
+      enumValue.value.shouldBeNull()
     }
   }
 

--- a/firebase-dataconnect/gradleplugin/plugin/src/main/resources/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableVersions.json
+++ b/firebase-dataconnect/gradleplugin/plugin/src/main/resources/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableVersions.json
@@ -1,5 +1,5 @@
 {
-  "defaultVersion": "2.10.0",
+  "defaultVersion": "2.10.1",
   "versions": [
     {
       "version": "1.3.4",
@@ -900,6 +900,24 @@
       "os": "linux",
       "size": 29257912,
       "sha512DigestHex": "93e71bdc76510cf70410338f016819b97abe7a4b372ee52c0f59c0c58f23814c3f94cf2e6772dce5a8fbabda582f363cabb808b4284dfa142b6bc94d305088a4"
+    },
+    {
+      "version": "2.10.1",
+      "os": "windows",
+      "size": 29829632,
+      "sha512DigestHex": "0f2d7999b6e435ca3c8ed98ba421ccfe954acce7074759faf79c5a5c50cddec360be87a3c1cd2a459c33fd916e230bd673616281e47162748ac6ad70634257fc"
+    },
+    {
+      "version": "2.10.1",
+      "os": "macos",
+      "size": 29336416,
+      "sha512DigestHex": "f3eedb2afbb336934d59b2ce6593e8822e2dfc6d640ab65400ae9d38ff61a0ece1f7c44954058cbff2c9ef667536ea884a3f5487df5eb92c7423816e033a718d"
+    },
+    {
+      "version": "2.10.1",
+      "os": "linux",
+      "size": 29266104,
+      "sha512DigestHex": "669ec517e81c52157c6fec60f0aca2856b564c6181764bb3d80107481770289a1fac1c88cdc2fa1a1d246b2e5a5cd19a100444bcef53b7727886283cabea2ecb"
     }
   ]
 }


### PR DESCRIPTION
dataconnect: upgrade data connect emulator for codegen and testing to 2.10.1 (was 2.10.0) and, correspondingly, `firebase-tools` to 14.11.1 (was 14.11.0) in github actions workflows.

This upgrade picks up the following changes relevant to Kotlin:
* cl/785477120: Add `value` property to the `EnumValue` base interface.

With this upgrade, this PR also re-enables the unit test for the new `value` property in `EnumValueUnknownUnitTest.kt`.