### PR TITLE
fix(AI): Route audio to speaker instead of earpiece

### DIFF
--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/AudioHelper.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/AudioHelper.kt
@@ -163,7 +163,10 @@ internal class AudioHelper(
     fun build(): AudioHelper {
       val playbackTrack =
         AudioTrack(
-          AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION).build(),
+          AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_MEDIA)
+            .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+            .build(),
           AudioFormat.Builder()
             .setSampleRate(24000)
             .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)


### PR DESCRIPTION
The AudioHelper was configured to use `USAGE_VOICE_COMMUNICATION`, which routes audio through the earpiece. This is not ideal for the text-to-speech functionality of the AI SDK.

This change updates the `AudioAttributes` to use `USAGE_MEDIA` and `CONTENT_TYPE_SPEECH` to route the audio to the device's speaker.