### PR TITLE
[AI] Improve error messaging for LiveServerMessageSerializer

### DIFF
--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveServerMessage.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveServerMessage.kt
@@ -181,7 +181,7 @@ internal object LiveServerMessageSerializer :
       "toolCall" in jsonObject -> LiveServerToolCall.InternalWrapper.serializer()
       "toolCallCancellation" in jsonObject ->
         LiveServerToolCallCancellation.InternalWrapper.serializer()
-      else -> throw SerializationException("Unknown LiveServerMessage response type: $jsonObject.")
+      else -> throw SerializationException("Unknown LiveServerMessage response type. Keys found: ${jsonObject.keys}")
     }
   }
 }

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveServerMessage.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveServerMessage.kt
@@ -181,7 +181,10 @@ internal object LiveServerMessageSerializer :
       "toolCall" in jsonObject -> LiveServerToolCall.InternalWrapper.serializer()
       "toolCallCancellation" in jsonObject ->
         LiveServerToolCallCancellation.InternalWrapper.serializer()
-      else -> throw SerializationException("Unknown LiveServerMessage response type. Keys found: ${jsonObject.keys}")
+      else ->
+        throw SerializationException(
+          "Unknown LiveServerMessage response type. Keys found: ${jsonObject.keys}"
+        )
     }
   }
 }

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveServerMessage.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveServerMessage.kt
@@ -181,10 +181,7 @@ internal object LiveServerMessageSerializer :
       "toolCall" in jsonObject -> LiveServerToolCall.InternalWrapper.serializer()
       "toolCallCancellation" in jsonObject ->
         LiveServerToolCallCancellation.InternalWrapper.serializer()
-      else ->
-        throw SerializationException(
-          "The given subclass of LiveServerMessage (${javaClass.simpleName}) is not supported in the serialization yet."
-        )
+      else -> throw SerializationException("Unknown LiveServerMessage response type: $jsonObject.")
     }
   }
 }


### PR DESCRIPTION
The error message should include the actual content of the message that couldn't be de-serialized instead of class around java class names, which are not useful before de-serialization succeds.