### PR TITLE
Update the behaviour of the FirebasePerformanceSessionSubcriber to better match early initialization in AQS.

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformance.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformance.java
@@ -37,15 +37,12 @@ import com.google.firebase.perf.logging.ConsoleUrlGenerator;
 import com.google.firebase.perf.logging.FirebaseSessionsEnforcementCheck;
 import com.google.firebase.perf.metrics.HttpMetric;
 import com.google.firebase.perf.metrics.Trace;
-import com.google.firebase.perf.session.FirebasePerformanceSessionSubscriber;
 import com.google.firebase.perf.session.SessionManager;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.util.Constants;
 import com.google.firebase.perf.util.ImmutableBundle;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.remoteconfig.RemoteConfigComponent;
-import com.google.firebase.sessions.api.FirebaseSessionsDependencies;
-import com.google.firebase.sessions.api.SessionSubscriber;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.net.URL;
@@ -95,8 +92,6 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
   // Extracting the metadata from the application context is expensive and so we only extract it
   // once during initialization and cache it.
   private final ImmutableBundle mMetadataBundle;
-
-  private final SessionSubscriber sessionSubscriber;
 
   /** Valid HttpMethods for manual network APIs */
   @StringDef({
@@ -171,7 +166,6 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
       this.mPerformanceCollectionForceEnabledState = false;
       this.configResolver = configResolver;
       this.mMetadataBundle = new ImmutableBundle(new Bundle());
-      this.sessionSubscriber = new FirebasePerformanceSessionSubscriber(false);
       return;
     }
     FirebaseSessionsEnforcementCheck.setEnforcement(BuildConfig.ENFORCE_LEGACY_SESSIONS);
@@ -189,8 +183,6 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
     sessionManager.setApplicationContext(appContext);
 
     mPerformanceCollectionForceEnabledState = configResolver.getIsPerformanceCollectionEnabled();
-    sessionSubscriber = new FirebasePerformanceSessionSubscriber(isPerformanceCollectionEnabled());
-    FirebaseSessionsDependencies.register(sessionSubscriber);
 
     if (logger.isLogcatEnabled() && isPerformanceCollectionEnabled()) {
       logger.info(
@@ -465,10 +457,5 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
   @VisibleForTesting
   Boolean getPerformanceCollectionForceEnabledState() {
     return mPerformanceCollectionForceEnabledState;
-  }
-
-  @VisibleForTesting
-  SessionSubscriber getSessionSubscriber() {
-    return sessionSubscriber;
   }
 }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/FirebasePerformanceSessionSubscriber.kt
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/FirebasePerformanceSessionSubscriber.kt
@@ -16,17 +16,20 @@
 
 package com.google.firebase.perf.session
 
+import com.google.firebase.perf.config.ConfigResolver
 import com.google.firebase.perf.logging.FirebaseSessionsEnforcementCheck
 import com.google.firebase.sessions.api.SessionSubscriber
 
-class FirebasePerformanceSessionSubscriber(override val isDataCollectionEnabled: Boolean) :
-  SessionSubscriber {
+class FirebasePerformanceSessionSubscriber(val configResolver: ConfigResolver) : SessionSubscriber {
 
   override val sessionSubscriberName: SessionSubscriber.Name = SessionSubscriber.Name.PERFORMANCE
 
+  override val isDataCollectionEnabled: Boolean
+    get() = configResolver.isPerformanceCollectionEnabled == true
+
   override fun onSessionChanged(sessionDetails: SessionSubscriber.SessionDetails) {
     val currentPerfSession = SessionManager.getInstance().perfSession()
-    // TODO(b/394127311): Add logic to deal with app start gauges.
+    // TODO(b/394127311): Add logic to deal with app start gauges if necessary.
     FirebaseSessionsEnforcementCheck.checkSession(currentPerfSession, "onSessionChanged")
 
     val updatedSession = PerfSession.createWithId(sessionDetails.sessionId)

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
@@ -54,6 +54,7 @@ public class SessionManager {
   private SessionManager() {
     // session should quickly updated by session subscriber.
     this(GaugeManager.getInstance(), PerfSession.createWithId(null));
+    FirebaseSessionsEnforcementCheck.checkSession(perfSession, "SessionManager()");
   }
 
   @VisibleForTesting


### PR DESCRIPTION
This sets the subscriber in FirebasePerfEarly - allowing AQS to send a session sooner.

The removal of `SessionManager.getInstance().initializeGaugeCollection();` seems like the right solution given an AQS will be created ASAP.