### PR TITLE
dataconnect: re-enable tests for user-defined enums as primary keys.

### DIFF
--- a/firebase-dataconnect/connectors/src/androidTest/kotlin/com/google/firebase/dataconnect/connectors/demo/EnumIntegrationTest.kt
+++ b/firebase-dataconnect/connectors/src/androidTest/kotlin/com/google/firebase/dataconnect/connectors/demo/EnumIntegrationTest.kt
@@ -433,7 +433,7 @@ class EnumIntegrationTest : DemoConnectorIntegrationTestBase() {
     N5ekmae3jn.entries.forEach { enumValue ->
       val tagValue = Arb.dataConnect.tag().next(rs)
       val key = connector.enumKeyInsert.execute(enumValue) { tag = tagValue }.data.key
-      withClue(key) { key.enumValue shouldBe Known(enumValue) }
+      withClue(key) { key.enumValue shouldBe enumValue }
       val queryResult = connector.enumKeyGetByKey.execute(key).data
       withClue(queryResult) { queryResult.item?.tag shouldBe tagValue }
     }

--- a/firebase-dataconnect/connectors/src/androidTest/kotlin/com/google/firebase/dataconnect/connectors/demo/EnumIntegrationTest.kt
+++ b/firebase-dataconnect/connectors/src/androidTest/kotlin/com/google/firebase/dataconnect/connectors/demo/EnumIntegrationTest.kt
@@ -429,18 +429,13 @@ class EnumIntegrationTest : DemoConnectorIntegrationTestBase() {
   //////////////////////////////////////////////////////////////////////////////////////////////////
 
   @Test
-  @Ignore(
-    "TODO(b/432793533) Re-enable this test once the emulator crash " +
-      "caused by the \"EnumKey_GetByKey\" query is fixed."
-  )
   fun enumAsPrimaryKey() = runTest {
     N5ekmae3jn.entries.forEach { enumValue ->
       val tagValue = Arb.dataConnect.tag().next(rs)
       val key = connector.enumKeyInsert.execute(enumValue) { tag = tagValue }.data.key
       withClue(key) { key.enumValue shouldBe Known(enumValue) }
-      // TODO(b/432793533): Uncomment once the "EnumKey_GetByKey" query is uncommented.
-      // val queryResult = connector.enumKeyGetByKey.execute(key).data
-      // withClue(queryResult) { queryResult.item?.tag shouldBe tagValue }
+      val queryResult = connector.enumKeyGetByKey.execute(key).data
+      withClue(queryResult) { queryResult.item?.tag shouldBe tagValue }
     }
   }
 

--- a/firebase-dataconnect/emulator/dataconnect/connector/demo/demo_ops.gql
+++ b/firebase-dataconnect/emulator/dataconnect/connector/demo/demo_ops.gql
@@ -1778,10 +1778,9 @@ mutation EnumKey_Insert($enumValue: N5ekmae3jn!, $tag: String) @auth(level: PUBL
   key: enumKey_insert(data: { enumValue: $enumValue, tag: $tag })
 }
 
-# TODO(b/432793533) Uncomment once the emulator crash caused by this query is fixed.
-#query EnumKey_GetByKey($key: EnumKey_Key!) @auth(level: PUBLIC) {
-#  item: enumKey(key: $key) { tag }
-#}
+query EnumKey_GetByKey($key: EnumKey_Key!) @auth(level: PUBLIC) {
+  item: enumKey(key: $key) { tag }
+}
 
 ###############################################################################
 # Operations for table: type MultipleEnumColumns

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/EnumIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/EnumIntegrationTest.kt
@@ -35,7 +35,6 @@ import io.kotest.property.checkAll
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializer
-import org.junit.Ignore
 import org.junit.Test
 
 class EnumIntegrationTest : DataConnectIntegrationTestBase() {
@@ -605,10 +604,6 @@ class EnumIntegrationTest : DataConnectIntegrationTestBase() {
   //////////////////////////////////////////////////////////////////////////////////////////////////
 
   @Test
-  @Ignore(
-    "TODO(b/432793533) Re-enable this test once the emulator crash " +
-      "caused by the \"EnumKey_GetByKey\" query is fixed."
-  )
   fun enumAsPrimaryKey() = runTest {
     N5ekmae3jn.entries.forEach { enumValue ->
       val tag = Arb.dataConnect.tag().next(rs)


### PR DESCRIPTION
The data connect emulator v2.10.1 has the fix for the crash b/432793533 and was included in firebase-tools release https://github.com/firebase/firebase-tools/releases/tag/v14.11.1

Googlers see b/432793533 for details.