### PR TITLE
Update the version dependency of firebase sessions

### DIFF
--- a/firebase-perf/firebase-perf.gradle
+++ b/firebase-perf/firebase-perf.gradle
@@ -123,7 +123,7 @@ dependencies {
     api("com.google.firebase:firebase-installations:18.0.0") {
         exclude group: 'com.google.firebase', module: 'firebase-common-ktx'
     }
-    api(project(":firebase-sessions")) {
+    api("com.google.firebase:firebase-sessions:3.0.0") {
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-common-ktx'
         exclude group: 'com.google.firebase', module: 'firebase-components'


### PR DESCRIPTION
The current dependency was set to HEAD. This switches it back to 3.0.0.

This is needed for shipping it in an EAP.