### PR TITLE
Suppress noisy "Claiming file ..." log messages unless `--info` is specified to Gradle

### DIFF
--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/ci/AffectedProjectFinder.java
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/ci/AffectedProjectFinder.java
@@ -107,7 +107,7 @@ public class AffectedProjectFinder {
     while (itr.hasNext()) {
       String file = itr.next();
       if (file.startsWith(relativePath)) {
-        System.out.println("Claiming file " + file + " for project " + project);
+        project.getLogger().info("Claiming file {} for project {}", file, project);
         itr.remove();
         projects.add(project);
       }


### PR DESCRIPTION
This PR suppresses the "Claiming file ..." log messages unless `--info` is specified to the `gradlew` command line. These log messages are normally irrelevant and pollute the gradle output, obscuring warnings and errors.

e.g.

```
Claiming file firebase-dataconnect/connectors/src/androidTest/kotlin/com/google/firebase/dataconnect/connectors/demo/EnumIntegrationTest.kt for project project ':firebase-dataconnect:connectors'
Claiming file firebase-dataconnect/testutil/src/test/kotlin/com/google/firebase/dataconnect/testutil/ListContainingNullUnitTest.kt for project project ':firebase-dataconnect:testutil'
Claiming file firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/ListContainingNull.kt for project project ':firebase-dataconnect:testutil'
Claiming file firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/misc.kt for project project ':firebase-dataconnect:testutil'
Claiming file firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/EnumIntegrationTest.kt for project project ':firebase-dataconnect'
```