### PR TITLE
dataconnect: emulator.sh: add flag to use the same data connect emulator as the gradle build

### DIFF
--- a/firebase-dataconnect/emulator/emulator.sh
+++ b/firebase-dataconnect/emulator/emulator.sh
@@ -75,7 +75,7 @@ function parse_args {
     if [[ ! -e $gradle_emulator_binary ]] ; then
       log_error_and_exit "emulator binary from gradle does not exist: ${gradle_emulator_binary}"
     fi
-    export DATACONNECT_EMULATOR_BINARY_PATH="${gradle_emulator_binaries[0]}"
+    export DATACONNECT_EMULATOR_BINARY_PATH="${gradle_emulator_binary}"
   fi
 
   export FIREBASE_DATACONNECT_POSTGRESQL_STRING="${postgresql_string}"

--- a/firebase-dataconnect/emulator/emulator.sh
+++ b/firebase-dataconnect/emulator/emulator.sh
@@ -58,13 +58,26 @@ function parse_args {
         exit 2
         ;;
       *)
-        echo "INTERNAL ERROR: unknown argument: $arg" >&2
-        exit 1
+        log_error_and_exit "INTERNAL ERROR: unknown argument: $arg"
         ;;
     esac
   done
 
-  export DATACONNECT_EMULATOR_BINARY_PATH="${emulator_binary}"
+  if [[ $emulator_binary != "gradle" ]] ; then
+    export DATACONNECT_EMULATOR_BINARY_PATH="${emulator_binary}"
+  else
+    run_command "${SCRIPT_DIR}/../../gradlew" -p "${SCRIPT_DIR}/../.." --configure-on-demand :firebase-dataconnect:connectors:downloadDebugDataConnectExecutable
+    local gradle_emulator_binaries=("${SCRIPT_DIR}"/../connectors/build/intermediates/dataconnect/debug/executable/*)
+    if [[ ${#gradle_emulator_binaries[@]} -ne 1 ]]; then
+      log_error_and_exit "expected exactly 1 emulator binary from gradle, but got ${#gradle_emulator_binaries[@]}: ${gradle_emulator_binaries[*]}"
+    fi
+    local gradle_emulator_binary="${gradle_emulator_binaries[@]}"
+    if [[ ! -e $gradle_emulator_binary ]] ; then
+      log_error_and_exit "emulator binary from gradle does not exist: ${gradle_emulator_binary}"
+    fi
+    export DATACONNECT_EMULATOR_BINARY_PATH="${gradle_emulator_binaries[0]}"
+  fi
+
   export FIREBASE_DATACONNECT_POSTGRESQL_STRING="${postgresql_string}"
   export DATA_CONNECT_PREVIEW="${preview_flags}"
 
@@ -90,8 +103,9 @@ function print_help {
   echo
   echo "Options:"
   echo "  -c <data_connect_emulator_binary_path>"
-  echo "    Uses the Data Connect Emulator binary at the given path. If not specified, "
-  echo "    or if specified as the empty string, then the emulator binary is downloaded."
+  echo "    Uses the Data Connect Emulator binary at the given path. A value of \"gradle\" "
+  echo "    will use the same CLI as the Gradle build. If not specified, or if specified "
+  echo "    as the empty string, then the emulator binary is downloaded."
   echo
   echo "  -p <postgresql_connection_string>"
   echo "    Uses the given string to connect to the PostgreSQL server. If not specified "
@@ -114,6 +128,11 @@ function print_help {
 
 function log {
   echo "${LOG_PREFIX}$*"
+}
+
+function log_error_and_exit {
+  echo "${LOG_PREFIX}ERROR: $*" >&2
+  exit 1
 }
 
 main "$@"

--- a/firebase-dataconnect/emulator/emulator.sh
+++ b/firebase-dataconnect/emulator/emulator.sh
@@ -37,9 +37,10 @@ function parse_args {
 
   local OPTIND=1
   local OPTERR=0
-  while getopts ":c:p:v:hw" arg ; do
+  while getopts ":c:p:v:hwg" arg ; do
     case "$arg" in
       c) emulator_binary="${OPTARG}" ;;
+      g) emulator_binary="gradle" ;;
       p) postgresql_string="${OPTARG}" ;;
       v) preview_flags="${OPTARG}" ;;
       w) wipe_and_restart_postgres_pod=1 ;;
@@ -106,6 +107,9 @@ function print_help {
   echo "    Uses the Data Connect Emulator binary at the given path. A value of \"gradle\" "
   echo "    will use the same CLI as the Gradle build. If not specified, or if specified "
   echo "    as the empty string, then the emulator binary is downloaded."
+  echo
+  echo "  -g"
+  echo "    Shorthand for: -c gradle"
   echo
   echo "  -p <postgresql_connection_string>"
   echo "    Uses the given string to connect to the PostgreSQL server. If not specified "

--- a/firebase-dataconnect/emulator/emulator.sh
+++ b/firebase-dataconnect/emulator/emulator.sh
@@ -105,7 +105,7 @@ function print_help {
   echo "Options:"
   echo "  -c <data_connect_emulator_binary_path>"
   echo "    Uses the Data Connect Emulator binary at the given path. A value of \"gradle\" "
-  echo "    will use the same CLI as the Gradle build. If not specified, or if specified "
+  echo "    will use the same binary as the Gradle build. If not specified, or if specified "
   echo "    as the empty string, then the emulator binary is downloaded."
   echo
   echo "  -g"


### PR DESCRIPTION
This PR enhances the Data Connect `emulator.sh` script by adding support for the special value `gradle` to the `-c` flag, causing it to use the same data connect emulator binary as the Gradle build. The new `-g` flag was added as a convenient shorthand.

### Highlights

* **Enhanced Emulator Binary Selection**: The `emulator.sh` script now supports a special value of "gradle" for the `-c` command-line argument, or `-g` as a shorthand. When this value is provided, the script will automatically execute the necessary Gradle task to download the Data Connect emulator binary and then use that specific binary, ensuring consistency with the Gradle build's environment.
* **Improved Error Handling**: A new utility function, `log_error_and_exit`, has been introduced within `emulator.sh` to standardize error logging and script termination, replacing direct `echo` and `exit` calls for error conditions.
* **Updated Documentation**: The command-line help message for the `-c` option in `emulator.sh` has been updated to clearly document the new "gradle" functionality, guiding users on how to leverage this feature.
