### PR TITLE
dataconnect: fix flaky test: collect_gets_notified_of_per_data_deserializer_successes

### DIFF
--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/QuerySubscriptionIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/QuerySubscriptionIntegrationTest.kt
@@ -670,7 +670,7 @@ class QuerySubscriptionIntegrationTest : DataConnectIntegrationTestBase() {
      * in a row based on other asynchronous operations but testing for "distinctness" will consider
      * those two failures as "distinct" when the test wants them to be treated as "equal".
      *
-     * Googlers see b/399380932 for full details and history of the flaky test that this fixes.
+     * See https://github.com/firebase/firebase-android-sdk/pull/7210 for a full explanation.
      */
     fun areEquivalentQuerySubscriptionResults(
       old: QuerySubscriptionResult<*, *>,


### PR DESCRIPTION
This PR fixes a persistent flakiness in a the `collect_gets_notified_of_per_data_deserializer_successes` integration test. It fixes it by refining how `distinctUntilChanged` processes error states within Kotlin Flows. The core change involves providing a custom equality comparator that correctly identifies and deduplicates consecutive decoding failures, thereby stabilizing the test's behavior.


### Highlights

* **Test Stability Fix**: Addressed a flakiness issue in the `collect_gets_notified_of_per_data_deserializer_successes` integration test. The test was failing intermittently because the `distinctUntilChanged` operator was not correctly deduplicating consecutive error states that were logically equivalent but not strictly equal.
* **Custom Flow Equality**: Implemented a custom comparison function, `areEquivalentQuerySubscriptionResults`, for the `distinctUntilChanged` operator on `QuerySubscriptionResult` flows. This function ensures that two `QuerySubscriptionResult` instances are considered equivalent if they are strictly equal, or if both represent a failure due to server response decoding issues.
* **Error Identification Helpers**: Introduced new utility extension functions (`isDecodingServerResponseFailed`) to accurately identify `DataConnectOperationException` instances that specifically indicate a failure in decoding the server response.

Googlers see b/399380932 for more details.