### PR TITLE
ci_tests.yml: ensure that upload artifact name is calculated before uploading the artifacts

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -72,6 +72,7 @@ jobs:
         run: |
           ./gradlew ${{matrix.module}}:check withErrorProne
       - name: Compute upload file name
+        if: always()
         run: |
           MODULE=${{matrix.module}}
           echo "ARTIFACT_NAME=${MODULE//:/_}" >> $GITHUB_ENV


### PR DESCRIPTION
The unit tests steps in `.github/workflows/ci_tests.yml` had a small bug: if the tests failed then the following step, which calculated the name of the artifact to upload, was skipped, causing the upload artifacts step to use an empty string as the artifact name, resulting in the wrong artifact name.

I first noticed this issue in https://github.com/firebase/firebase-android-sdk/actions/runs/16682145664/job/47223202941?pr=7215 where the "Upload Test Results" step curiously failed with the error "Conflict: an artifact with this name already exists on the workflow run". It turns out this was because there were more than one jobs that failed and both tried to use the same artifact name because the artifact name environment variable was not set.

This PR fixes the issue by simply ensuring that the step to calculate the artifact name is run unconditionally.