### PR TITLE
FirebaseRemoteConfigTest.java: fix flaky test: realtime_stream_listen_backgrounded_disconnects

### DIFF
--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -1533,8 +1533,8 @@ public final class FirebaseRemoteConfigTest {
         .closeRealtimeHttpConnection(any(InputStream.class), any(InputStream.class));
     when(mockHttpURLConnection.getResponseCode()).thenReturn(200);
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
-    configRealtimeHttpClientSpy.setIsInBackground(true);
     flushScheduledTasks();
+    configRealtimeHttpClientSpy.setIsInBackground(true);
 
     verify(mockHttpURLConnection, times(1)).disconnect();
   }


### PR DESCRIPTION
This PR fixes the flaky test `realtime_stream_listen_backgrounded_disconnects` in `FirebaseRemoteConfigTest.java`. The flake was due to a race condition in the test.

The test called `ConfigRealtimeHttpClient.beginRealtimeHttpStream()` followed immediately by a call to `ConfigRealtimeHttpClient.setIsInBackground(true)`. It then ensured that `HttpURLConnection.disconnect()` was called by `setIsInBackground(true)`. The problem is that `beginRealtimeHttpStream()` sets the `HttpURLConnection` asynchronously and if `setIsInBackground(true)` is called _before_ it is set then its `disconnect()` method is never called. 

The flake is easily reproduced by adding a call to `Thread.sleep(500)` into the asynchronous task in `ConfigRealtimeHttpClient.beginRealtimeHttpStream()`: https://github.com/firebase/firebase-android-sdk/blob/a00e2bee73e1b95ca400482c67b6f64488691a84/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java#L534.

The fix in this PR simply moves the call to `flushScheduledTasks()` in the test from _after_ `setIsInBackground(true)` to _before_ `setIsInBackground(true)`. This ensures that `setIsInBackground(true)` runs _after_ the `HttpURLConnection` object is set, fixing the flake.