### PR TITLE
Temporarily remove CHANGELOG entry

### DIFF
--- a/firebase-ai/CHANGELOG.md
+++ b/firebase-ai/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Unreleased
 * [feature] added support for Imagen Editing, including inpainting, outpainting, control, style 
   transfer, and subject references (#7075)
-* [feature]  **Preview:** Added support for bidirectional streaming in Gemini Developer Api
 
 # 17.0.0
 * [feature] Added support for configuring the "thinking" budget when using Gemini


### PR DESCRIPTION
The backend won't be published until sometime next week, removing this until it's ready. No changes to the code are necessary as there are no public API changes and it'll still hit a runtime error.