### PR TITLE
dataconnect: upgrade data connect emulator to 2.11.0 and firebase-tools to 14.12.0

### DIFF
--- a/.github/workflows/dataconnect.yml
+++ b/.github/workflows/dataconnect.yml
@@ -34,7 +34,7 @@ env:
   FDC_JAVA_VERSION: ${{ inputs.javaVersion || '17' }}
   FDC_ANDROID_EMULATOR_API_LEVEL: ${{ inputs.androidEmulatorApiLevel || '34' }}
   FDC_NODEJS_VERSION: ${{ inputs.nodeJsVersion || '20' }}
-  FDC_FIREBASE_TOOLS_VERSION: ${{ inputs.firebaseToolsVersion || '14.11.1' }}
+  FDC_FIREBASE_TOOLS_VERSION: ${{ inputs.firebaseToolsVersion || '14.12.0' }}
   FDC_FIREBASE_TOOLS_DIR: /tmp/firebase-tools
   FDC_FIREBASE_COMMAND: /tmp/firebase-tools/node_modules/.bin/firebase
   FDC_PYTHON_VERSION: ${{ inputs.pythonVersion || '3.13' }}

--- a/.github/workflows/dataconnect_demo_app.yml
+++ b/.github/workflows/dataconnect_demo_app.yml
@@ -18,7 +18,7 @@ on:
 
 env:
   FDC_NODE_VERSION: ${{ inputs.nodeVersion || '20' }}
-  FDC_FIREBASE_TOOLS_VERSION: ${{ inputs.firebaseToolsVersion || '14.11.1' }}
+  FDC_FIREBASE_TOOLS_VERSION: ${{ inputs.firebaseToolsVersion || '14.12.0' }}
   FDC_JAVA_VERSION: ${{ inputs.javaVersion || '17' }}
   FDC_FIREBASE_TOOLS_DIR: ${{ github.workspace }}/firebase-tools
   FDC_FIREBASE_COMMAND: ${{ github.workspace }}/firebase-tools/node_modules/.bin/firebase

--- a/firebase-dataconnect/connectors/src/androidTest/kotlin/com/google/firebase/dataconnect/connectors/demo/EnumIntegrationTest.kt
+++ b/firebase-dataconnect/connectors/src/androidTest/kotlin/com/google/firebase/dataconnect/connectors/demo/EnumIntegrationTest.kt
@@ -44,7 +44,6 @@ import io.kotest.property.checkAll
 import io.kotest.property.exhaustive.enum
 import java.util.UUID
 import kotlinx.coroutines.test.runTest
-import org.junit.Ignore
 import org.junit.Test
 
 class EnumIntegrationTest : DemoConnectorIntegrationTestBase() {
@@ -484,7 +483,7 @@ class EnumIntegrationTest : DemoConnectorIntegrationTestBase() {
     checkAll(Exhaustive.enum<N5ekmae3jn>()) { enumValue ->
       val tagValue = Arb.dataConnect.tag().next(randomSource())
       val key = connector.enumKeyInsert.execute(enumValue) { tag = tagValue }.data.key
-      key.asClue { it.enumValue shouldBe enumValue }
+      key.asClue { it.enumValue shouldBe Known(enumValue) }
       val queryResult = connector.enumKeyGetByKey.execute(key)
       queryResult.asClue {
         val item = it.data.item.shouldNotBeNull()
@@ -498,11 +497,6 @@ class EnumIntegrationTest : DemoConnectorIntegrationTestBase() {
   //////////////////////////////////////////////////////////////////////////////////////////////////
 
   @Test
-  @Ignore(
-    "TODO(cl/785956954) Re-enable this test once testing against a data connect " +
-      "emulator that fixes serialization when more than one user-defined enum type " +
-      "in the data"
-  )
   fun multipleEnumColumns() = runTest {
     checkAll(NUM_ITERATIONS, Arb.enum<N5ekmae3jn>(), Arb.enum<S7yayynb25>()) { enum1, enum2 ->
       val key = connector.multipleEnumColumnsInsert.execute(enum1, enum2).data.key

--- a/firebase-dataconnect/gradleplugin/plugin/src/main/resources/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableVersions.json
+++ b/firebase-dataconnect/gradleplugin/plugin/src/main/resources/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableVersions.json
@@ -1,5 +1,5 @@
 {
-  "defaultVersion": "2.10.1",
+  "defaultVersion": "2.11.0",
   "versions": [
     {
       "version": "1.3.4",
@@ -918,6 +918,24 @@
       "os": "linux",
       "size": 29266104,
       "sha512DigestHex": "669ec517e81c52157c6fec60f0aca2856b564c6181764bb3d80107481770289a1fac1c88cdc2fa1a1d246b2e5a5cd19a100444bcef53b7727886283cabea2ecb"
+    },
+    {
+      "version": "2.11.0",
+      "os": "windows",
+      "size": 29719040,
+      "sha512DigestHex": "45627a2c13de13da17c340f0940609e7745bd86dda080316f47ce13378445070390daa2548a1658493fd2567d9fa4ad2d0162f8fec6127b7d4d414a8d575bcd5"
+    },
+    {
+      "version": "2.11.0",
+      "os": "macos",
+      "size": 29234016,
+      "sha512DigestHex": "b224ada8dd36839435e613bc085b819635659728d07f50a22b0c40abcb3112e1f418a66041c59aee10920e5a846a783e27ed344779f98cd5005faff475e2a035"
+    },
+    {
+      "version": "2.11.0",
+      "os": "linux",
+      "size": 29159608,
+      "sha512DigestHex": "af3bad81cc0c0d822a75381db06d4b191c64dd73abdcbd368830e736574b7212d22a3a87c74ce52adee3ca9630876da7b600f8c31f1498d4a76359e51f872a39"
     }
   ]
 }


### PR DESCRIPTION
This PR upgrades the Data Connect emulator version used for Data Connect SDK builds and github actions to 2.11.0 (was 2.10.1). It also upgrades the firebase-tools version to 14.12.0 (was 14.11.1) (release notes: https://github.com/firebase/firebase-tools/releases/tag/v14.12.0).

This picks up the following changes related to Kotlin:

- [changed] Kotlin codegen: Use `EnumValue` wrapper for enums in "Key" types. This facilitates graceful handling of primary keys with an enum component whose value is not known, which would have previously resulted in an exception when received from the server.
- [fixed] Kotlin codegen: Issue where serialization with more than one user-defined enum type in the variables or data would serialize the wrong enum sometimes.

The integration tests are also updated by this PR in response to minor codegen changes.