### PR TITLE
appdistribution: fix flaky test due to race condtion in testing logic: checkForNewRelease_whenCalledMultipleTimes_onlyFetchesReleasesOnce

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TaskCache.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TaskCache.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.appdistribution.impl;
 
+import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.firebase.annotations.concurrent.Lightweight;
@@ -63,6 +64,20 @@ class TaskCache<T> {
           }
           TaskUtils.shadowTask(taskCompletionSource, cachedTask);
         });
+    return taskCompletionSource.getTask();
+  }
+
+  /**
+   * Returns a task that completes when this object's internal sequential executor has finished
+   * processing all enqueued operations.
+   * <p>
+   * This method should never be called in production code; however, it is useful in unit tests to
+   * ensure deterministic behavior.
+   */
+  @VisibleForTesting
+  Task<Void> newTaskForSequentialExecutorFlush() {
+    TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
+    sequentialExecutor.execute(() -> taskCompletionSource.setResult(null));
     return taskCompletionSource.getTask();
   }
 

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/NewReleaseFetcherTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/NewReleaseFetcherTest.java
@@ -112,6 +112,7 @@ public class NewReleaseFetcherTest {
 
     // Don't set the result until after calling twice, to make sure that the task from the first
     // call is still ongoing.
+    awaitTask(newReleaseFetcher.cachedCheckForNewRelease.newTaskForSequentialExecutorFlush());
     task.setResult(null);
     awaitTask(checkForNewReleaseTask1);
     awaitTask(checkForNewReleaseTask2);


### PR DESCRIPTION
This PR fixes the flaky test `checkForNewRelease_whenCalledMultipleTimes_onlyFetchesReleasesOnce` in `firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/NewReleaseFetcherTest.java` which flaked occasionally due to a race condition in the testing logic.

When the test flakily failed, the failure looked like this:

```
mockFirebaseAppDistributionTesterApiClient.fetchNewRelease();
Wanted 1 time:
-> at com.google.firebase.appdistribution.impl.FirebaseAppDistributionTesterApiClient.fetchNewRelease(FirebaseAppDistributionTesterApiClient.java:90)
But was 2 times:
-> at com.google.firebase.appdistribution.impl.NewReleaseFetcher.lambda$checkForNewRelease$2(NewReleaseFetcher.java:71)
-> at com.google.firebase.appdistribution.impl.NewReleaseFetcher.lambda$checkForNewRelease$2(NewReleaseFetcher.java:71)


org.mockito.exceptions.verification.TooManyActualInvocations: 
mockFirebaseAppDistributionTesterApiClient.fetchNewRelease();
Wanted 1 time:
-> at com.google.firebase.appdistribution.impl.FirebaseAppDistributionTesterApiClient.fetchNewRelease(FirebaseAppDistributionTesterApiClient.java:90)
But was 2 times:
-> at com.google.firebase.appdistribution.impl.NewReleaseFetcher.lambda$checkForNewRelease$2(NewReleaseFetcher.java:71)
-> at com.google.firebase.appdistribution.impl.NewReleaseFetcher.lambda$checkForNewRelease$2(NewReleaseFetcher.java:71)
```

This flake was easily reproduced by adding a 2-second sleep into the task enqueued on the `sequentialExecutor` by `TaskCache.getOrCreateTask()`:

```java
Task<T> getOrCreateTask(TaskProducer<T> producer) {
  ...
  sequentialExecutor.execute(
      () -> {
        try { Thread.sleep(2000); } catch (InterruptedException e) { }
        ...
      });
  ...
}
```

The fix was to force the test to wait for both runnables indirectly enqueued by the call to `checkForNewRelease()` to complete before completing the mocked task.

The test in question is: https://github.com/firebase/firebase-android-sdk/blob/6ba2d789ad864d38aa654bda6fc531d80d4e5871/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/NewReleaseFetcherTest.java#L101-L120

Here is the implementation of `TaskCache.getOrCreateTask()` into which the sleep was added to reproduce the flake: https://github.com/firebase/firebase-android-sdk/blob/6ba2d789ad864d38aa654bda6fc531d80d4e5871/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TaskCache.java#L57-L67
