### PR TITLE
FirebaseModelDownloaderTest.java: fix flake due to race condition in getModel_updateBackground_localExists_UpdateFound

### DIFF
--- a/firebase-ml-modeldownloader/src/test/java/com/google/firebase/ml/modeldownloader/FirebaseModelDownloaderTest.java
+++ b/firebase-ml-modeldownloader/src/test/java/com/google/firebase/ml/modeldownloader/FirebaseModelDownloaderTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -540,7 +541,8 @@ public class FirebaseModelDownloaderTest {
     verify(mockPrefs, times(2)).getCustomModelDetails(eq(MODEL_NAME));
     assertThat(task.isComplete()).isTrue();
     assertEquals(customModel, customModelLoaded);
-    verify(mockEventLogger)
+
+    verify(mockEventLogger, timeout(5000L))
         .logDownloadEventWithErrorCode(
             UPDATE_CUSTOM_MODEL_URL, false, DownloadStatus.UPDATE_AVAILABLE, ErrorCode.NO_ERROR);
   }


### PR DESCRIPTION
This PR fixes a flake in the test `getModel_updateBackground_localExists_UpdateFound` of `FirebaseModelDownloaderTest.java`.

When the test flakes, the failure looks like this:

```
Wanted but not invoked:
firebaseMlLogger.logDownloadEventWithErrorCode(
    CustomModel{name=MODEL_NAME_1, modelHash=upHash564, fileSize=100, downloadUrl=https://project.firebase.com/modelName/23424.jpg, downloadUrlExpiry=604810},
    false,
    UPDATE_AVAILABLE,
    NO_ERROR
);
-> at com.google.firebase.ml.modeldownloader.internal.FirebaseMlLogger.logDownloadEventWithErrorCode(FirebaseMlLogger.java:127)
Actually, there were zero interactions with this mock.
```

This failure is easily reproducible by adding a 2-second sleep into runnable enqueued on the `bgExecutor` by `FirebaseModelDownloader.getCustomModelTask()`:

```java
...
return incomingModelDetails.continueWithTask(
    bgExecutor,
    incomingModelDetailTask -> {
      Thread.sleep(2000); // add this sleep to cause the test to fail 100% of the time
...
```

The problem is that the task enqueued on the `bgExecutor` is discarded and left to run when the `bgExecutor` schedules it; however, the test assumes that the task will have run to the point where it notifies the `eventLogger` by the time the Mockito `verify()` method is invoked. This assumption is not necessarily true.

The flake is fixed by this PR by simply adding a 5-second timeout to the `verify()` call, providing a generous allowance for the asynchronous task to notify the listener. This still isn't a deterministic fix; however, it fixes the flake in all but the most extreme situations where the background task takes more than 5 seconds to execute.

Here is the problematic test: https://github.com/firebase/firebase-android-sdk/blob/6ba2d789ad864d38aa654bda6fc531d80d4e5871/firebase-ml-modeldownloader/src/test/java/com/google/firebase/ml/modeldownloader/FirebaseModelDownloaderTest.java#L526-L546

Here is where you can add `Thread.sleep(2000)` to cause the flake to occur 100% of the time: https://github.com/firebase/firebase-android-sdk/blob/6ba2d789ad864d38aa654bda6fc531d80d4e5871/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/FirebaseModelDownloader.java#L268-L271