### PR TITLE
Update session sorting to swap the first session if it's legacy.

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/logging/FirebaseSessionsEnforcementCheck.kt
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/logging/FirebaseSessionsEnforcementCheck.kt
@@ -17,10 +17,6 @@
 package com.google.firebase.perf.logging
 
 import com.google.firebase.perf.session.isLegacy
-import com.google.firebase.perf.v1.NetworkRequestMetric
-import com.google.firebase.perf.v1.TraceMetric
-import java.util.Collections
-import com.google.firebase.perf.v1.PerfSession as ProtoPerfSession
 
 class FirebaseSessionsEnforcementCheck {
   companion object {
@@ -29,34 +25,10 @@ class FirebaseSessionsEnforcementCheck {
     private var logger: AndroidLogger = AndroidLogger.getInstance()
 
     @JvmStatic
-    fun filterLegacySessions(trace: TraceMetric): TraceMetric {
-      val updatedTrace = trace.toBuilder().clearPerfSessions()
-      filterLegacySessions(trace.perfSessionsList).forEach { updatedTrace.addPerfSessions(it) }
-      return updatedTrace.build()
-    }
-
-    @JvmStatic
-    fun filterLegacySessions(networkRequestMetric: NetworkRequestMetric): NetworkRequestMetric {
-      val updatedNetworkRequestMetric = networkRequestMetric.toBuilder().clearPerfSessions()
-      filterLegacySessions(networkRequestMetric.perfSessionsList).forEach { updatedNetworkRequestMetric.addPerfSessions(it) }
-      return updatedNetworkRequestMetric.build()
-    }
-
-    @JvmStatic
     fun checkSession(sessionId: String, failureMessage: String) {
       if (sessionId.isLegacy()) {
-        logger.verbose("legacy session ${sessionId}: $failureMessage")
+        logger.verbose("Legacy Session ${sessionId}: $failureMessage")
         assert(!enforcement) { failureMessage }
-      }
-    }
-
-    private fun filterLegacySessions(sessions: List<ProtoPerfSession>): List<ProtoPerfSession> {
-      return if (sessions.count() > 0 && sessions[0].sessionId.isLegacy()) {
-        val updatedSessions = sessions.toMutableList<ProtoPerfSession>()
-        Collections.swap(updatedSessions, 0, 1)
-        updatedSessions
-      } else {
-        sessions
       }
     }
   }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/logging/FirebaseSessionsEnforcementCheck.kt
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/logging/FirebaseSessionsEnforcementCheck.kt
@@ -26,8 +26,10 @@ class FirebaseSessionsEnforcementCheck {
     private var logger: AndroidLogger = AndroidLogger.getInstance()
 
     @JvmStatic
-    fun checkSession(sessions: List<ProtoPerfSession>, failureMessage: String) {
-      sessions.forEach { checkSession(it.sessionId, failureMessage) }
+    fun checkSessionsList(sessions: List<ProtoPerfSession>, failureMessage: String) {
+      if (sessions.count { it.sessionId.isLegacy() } == sessions.size) {
+        sessions.forEach { checkSession(it.sessionId, failureMessage) }
+      }
     }
 
     @JvmStatic

--- a/firebase-perf/src/main/java/com/google/firebase/perf/logging/FirebaseSessionsEnforcementCheck.kt
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/logging/FirebaseSessionsEnforcementCheck.kt
@@ -17,12 +17,18 @@
 package com.google.firebase.perf.logging
 
 import com.google.firebase.perf.session.isLegacy
+import com.google.firebase.perf.v1.PerfSession as ProtoPerfSession
 
 class FirebaseSessionsEnforcementCheck {
   companion object {
     /** When enabled, failed preconditions will cause assertion errors for debugging. */
     @JvmStatic var enforcement: Boolean = false
     private var logger: AndroidLogger = AndroidLogger.getInstance()
+
+    @JvmStatic
+    fun checkSession(sessions: List<ProtoPerfSession>, failureMessage: String) {
+      sessions.forEach { checkSession(it.sessionId, failureMessage) }
+    }
 
     @JvmStatic
     fun checkSession(sessionId: String, failureMessage: String) {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/logging/FirebaseSessionsEnforcementCheck.kt
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/logging/FirebaseSessionsEnforcementCheck.kt
@@ -19,6 +19,7 @@ package com.google.firebase.perf.logging
 import com.google.firebase.perf.session.isLegacy
 import com.google.firebase.perf.v1.NetworkRequestMetric
 import com.google.firebase.perf.v1.TraceMetric
+import java.util.Collections
 import com.google.firebase.perf.v1.PerfSession as ProtoPerfSession
 
 class FirebaseSessionsEnforcementCheck {
@@ -50,12 +51,12 @@ class FirebaseSessionsEnforcementCheck {
     }
 
     private fun filterLegacySessions(sessions: List<ProtoPerfSession>): List<ProtoPerfSession> {
-      val updatedSessions = sessions.filter { !it.sessionId.isLegacy() }
-      return if(updatedSessions.isEmpty()) {
-        assert(!enforcement) { "No session besides a legacy session present. "}
-        sessions
-      } else {
+      return if (sessions.count() > 0 && sessions[0].sessionId.isLegacy()) {
+        val updatedSessions = sessions.toMutableList<ProtoPerfSession>()
+        Collections.swap(updatedSessions, 0, 1)
         updatedSessions
+      } else {
+        sessions
       }
     }
   }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/logging/FirebaseSessionsEnforcementCheck.kt
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/logging/FirebaseSessionsEnforcementCheck.kt
@@ -33,7 +33,7 @@ class FirebaseSessionsEnforcementCheck {
     @JvmStatic
     fun checkSession(sessionId: String, failureMessage: String) {
       if (sessionId.isLegacy()) {
-        logger.verbose("Legacy Session ${sessionId}: $failureMessage")
+        logger.verbose("Contains Legacy Session ${sessionId}: $failureMessage")
         assert(!enforcement) { failureMessage }
       }
     }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/logging/FirebaseSessionsEnforcementCheck.kt
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/logging/FirebaseSessionsEnforcementCheck.kt
@@ -52,6 +52,7 @@ class FirebaseSessionsEnforcementCheck {
     private fun filterLegacySessions(sessions: List<ProtoPerfSession>): List<ProtoPerfSession> {
       val updatedSessions = sessions.filter { !it.sessionId.isLegacy() }
       return if(updatedSessions.isEmpty()) {
+        assert(!enforcement) { "No session besides a legacy session present. "}
         sessions
       } else {
         updatedSessions

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/FirebasePerformanceSessionSubscriber.kt
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/FirebasePerformanceSessionSubscriber.kt
@@ -17,7 +17,7 @@
 package com.google.firebase.perf.session
 
 import com.google.firebase.perf.config.ConfigResolver
-import com.google.firebase.perf.logging.FirebaseSessionsEnforcementCheck
+import com.google.firebase.perf.logging.FirebaseSessionsEnforcementCheck.Companion.checkSession
 import com.google.firebase.sessions.api.SessionSubscriber
 
 class FirebasePerformanceSessionSubscriber(val configResolver: ConfigResolver) : SessionSubscriber {
@@ -30,7 +30,7 @@ class FirebasePerformanceSessionSubscriber(val configResolver: ConfigResolver) :
   override fun onSessionChanged(sessionDetails: SessionSubscriber.SessionDetails) {
     val currentPerfSession = SessionManager.getInstance().perfSession()
     // TODO(b/394127311): Add logic to deal with app start gauges if necessary.
-    FirebaseSessionsEnforcementCheck.checkSession(currentPerfSession, "onSessionChanged")
+    checkSession(currentPerfSession.sessionId(), "onSessionChanged called on Legacy Session ID.")
 
     val updatedSession = PerfSession.createWithId(sessionDetails.sessionId)
     SessionManager.getInstance().updatePerfSession(updatedSession)

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/FirebasePerformanceSessionSubscriber.kt
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/FirebasePerformanceSessionSubscriber.kt
@@ -30,7 +30,7 @@ class FirebasePerformanceSessionSubscriber(val configResolver: ConfigResolver) :
   override fun onSessionChanged(sessionDetails: SessionSubscriber.SessionDetails) {
     val currentPerfSession = SessionManager.getInstance().perfSession()
     // TODO(b/394127311): Add logic to deal with app start gauges if necessary.
-    checkSession(currentPerfSession.sessionId(), "onSessionChanged called on Legacy Session ID.")
+    checkSession(currentPerfSession.sessionId(), "Existing session in onSessionChanged().")
 
     val updatedSession = PerfSession.createWithId(sessionDetails.sessionId)
     SessionManager.getInstance().updatePerfSession(updatedSession)

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
@@ -14,6 +14,8 @@
 
 package com.google.firebase.perf.session;
 
+import static com.google.firebase.perf.session.FirebaseSessionsHelperKt.isLegacy;
+
 import android.os.Parcel;
 import android.os.Parcelable;
 import androidx.annotation.NonNull;
@@ -129,8 +131,15 @@ public class PerfSession implements Parcelable {
       }
     }
 
+    // TODO(b/394127311): Added as part of legacy sessions. Remove this in a future release.
     if (!foundVerboseSession) {
-      perfSessions[0] = perfSessionAtIndexZero;
+      if (isLegacy(perfSessionAtIndexZero.getSessionId()) && sessions.size() > 1) {
+        // Swaps the first session ID that's a legacy session ID with the second in the list.
+        perfSessions[0] = perfSessions[1];
+        perfSessions[1] = perfSessionAtIndexZero;
+      } else {
+        perfSessions[0] = perfSessionAtIndexZero;
+      }
     }
 
     return perfSessions;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
@@ -46,8 +46,6 @@ public class SessionManager {
 
   /** Returns the currently active PerfSession. */
   public final PerfSession perfSession() {
-    FirebaseSessionsEnforcementCheck.checkSession(perfSession, "PerfSession.perfSession()");
-
     return perfSession;
   }
 
@@ -55,7 +53,6 @@ public class SessionManager {
     // Creates a legacy session by default. This is a safety net to allow initializing
     // SessionManager - but the current implementation replaces it immediately.
     this(GaugeManager.getInstance(), PerfSession.createWithId(null));
-    FirebaseSessionsEnforcementCheck.checkSession(perfSession, "SessionManager()");
   }
 
   @VisibleForTesting
@@ -78,9 +75,6 @@ public class SessionManager {
    * @see PerfSession#isSessionRunningTooLong()
    */
   public void stopGaugeCollectionIfSessionRunningTooLong() {
-    FirebaseSessionsEnforcementCheck.checkSession(
-        perfSession, "SessionManager.stopGaugeCollectionIfSessionRunningTooLong");
-
     if (perfSession.isSessionRunningTooLong()) {
       gaugeManager.stopCollectingGauges();
     }
@@ -158,16 +152,12 @@ public class SessionManager {
   }
 
   private void logGaugeMetadataIfCollectionEnabled() {
-    FirebaseSessionsEnforcementCheck.checkSession(
-        perfSession, "logGaugeMetadataIfCollectionEnabled");
     if (perfSession.isVerbose()) {
       gaugeManager.logGaugeMetadata(perfSession.sessionId());
     }
   }
 
   private void startOrStopCollectingGauges() {
-    FirebaseSessionsEnforcementCheck.checkSession(perfSession, "startOrStopCollectingGauges");
-
     if (perfSession.isVerbose()) {
       gaugeManager.startCollectingGauges(perfSession);
     } else {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
@@ -18,7 +18,6 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import androidx.annotation.Keep;
 import androidx.annotation.VisibleForTesting;
-import com.google.firebase.perf.logging.FirebaseSessionsEnforcementCheck;
 import com.google.firebase.perf.session.gauges.GaugeManager;
 import com.google.firebase.perf.v1.GaugeMetadata;
 import com.google.firebase.perf.v1.GaugeMetric;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
@@ -14,11 +14,10 @@
 
 package com.google.firebase.perf.transport;
 
+import static com.google.firebase.perf.logging.FirebaseSessionsEnforcementCheck.checkSession;
 import static com.google.firebase.perf.util.AppProcessesProvider.getProcessName;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static com.google.firebase.perf.logging.FirebaseSessionsEnforcementCheck.filterLegacySessions;
-import static com.google.firebase.perf.logging.FirebaseSessionsEnforcementCheck.checkSession;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
@@ -302,7 +301,7 @@ public class TransportManager implements AppStateCallback {
    */
   public void log(final TraceMetric traceMetric, final ApplicationProcessState appState) {
     executorService.execute(
-        () -> syncLog(PerfMetric.newBuilder().setTraceMetric(filterLegacySessions(traceMetric)), appState));
+        () -> syncLog(PerfMetric.newBuilder().setTraceMetric(traceMetric), appState));
   }
 
   /**
@@ -332,7 +331,7 @@ public class TransportManager implements AppStateCallback {
     executorService.execute(
         () ->
             syncLog(
-                PerfMetric.newBuilder().setNetworkRequestMetric(filterLegacySessions(networkRequestMetric)), appState));
+                PerfMetric.newBuilder().setNetworkRequestMetric(networkRequestMetric), appState));
   }
 
   /**
@@ -358,7 +357,7 @@ public class TransportManager implements AppStateCallback {
    * {@link #isAllowedToDispatch(PerfMetric)}).
    */
   public void log(final GaugeMetric gaugeMetric, final ApplicationProcessState appState) {
-    checkSession(gaugeMetric.getSessionId(), "Logging GaugeMetric with Legacy Session ID.");
+    checkSession(gaugeMetric.getSessionId(), "log(GaugeMetric)");
     executorService.execute(
         () -> syncLog(PerfMetric.newBuilder().setGaugeMetric(gaugeMetric), appState));
   }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
@@ -301,7 +301,7 @@ public class TransportManager implements AppStateCallback {
    * {@link #isAllowedToDispatch(PerfMetric)}).
    */
   public void log(final TraceMetric traceMetric, final ApplicationProcessState appState) {
-    checkSessionsList(traceMetric.getPerfSessionsList(), "log(TraceMetric)");
+    checkSessionsList(traceMetric.getPerfSessionsList(), traceMetric.getName());
     executorService.execute(
         () -> syncLog(PerfMetric.newBuilder().setTraceMetric(traceMetric), appState));
   }
@@ -330,7 +330,7 @@ public class TransportManager implements AppStateCallback {
    */
   public void log(
       final NetworkRequestMetric networkRequestMetric, final ApplicationProcessState appState) {
-    checkSessionsList(networkRequestMetric.getPerfSessionsList(), "log(NetworkRequestMetric)");
+    checkSessionsList(networkRequestMetric.getPerfSessionsList(), networkRequestMetric.getUrl());
     executorService.execute(
         () ->
             syncLog(

--- a/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
@@ -15,6 +15,7 @@
 package com.google.firebase.perf.transport;
 
 import static com.google.firebase.perf.logging.FirebaseSessionsEnforcementCheck.checkSession;
+import static com.google.firebase.perf.logging.FirebaseSessionsEnforcementCheck.checkSessionsList;
 import static com.google.firebase.perf.util.AppProcessesProvider.getProcessName;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -300,7 +301,7 @@ public class TransportManager implements AppStateCallback {
    * {@link #isAllowedToDispatch(PerfMetric)}).
    */
   public void log(final TraceMetric traceMetric, final ApplicationProcessState appState) {
-    checkSession(traceMetric.getPerfSessionsList(), "log(TraceMetric)");
+    checkSessionsList(traceMetric.getPerfSessionsList(), "log(TraceMetric)");
     executorService.execute(
         () -> syncLog(PerfMetric.newBuilder().setTraceMetric(traceMetric), appState));
   }
@@ -329,7 +330,7 @@ public class TransportManager implements AppStateCallback {
    */
   public void log(
       final NetworkRequestMetric networkRequestMetric, final ApplicationProcessState appState) {
-    checkSession(networkRequestMetric.getPerfSessionsList(), "log(NetworkRequestMetric)");
+    checkSessionsList(networkRequestMetric.getPerfSessionsList(), "log(NetworkRequestMetric)");
     executorService.execute(
         () ->
             syncLog(

--- a/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
@@ -300,6 +300,7 @@ public class TransportManager implements AppStateCallback {
    * {@link #isAllowedToDispatch(PerfMetric)}).
    */
   public void log(final TraceMetric traceMetric, final ApplicationProcessState appState) {
+    checkSession(traceMetric.getPerfSessionsList(), "log(TraceMetric)");
     executorService.execute(
         () -> syncLog(PerfMetric.newBuilder().setTraceMetric(traceMetric), appState));
   }
@@ -328,6 +329,7 @@ public class TransportManager implements AppStateCallback {
    */
   public void log(
       final NetworkRequestMetric networkRequestMetric, final ApplicationProcessState appState) {
+    checkSession(networkRequestMetric.getPerfSessionsList(), "log(NetworkRequestMetric)");
     executorService.execute(
         () ->
             syncLog(

--- a/firebase-perf/src/test/java/com/google/firebase/perf/session/FirebaseSessionsTestHelper.kt
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/session/FirebaseSessionsTestHelper.kt
@@ -25,3 +25,5 @@ fun createTestSession(suffix: Int): PerfSession {
 }
 
 fun testSessionId(suffix: Int): String = "abc$suffix"
+
+fun testLegacySessionId(suffix: Int): String = "zabc$suffix"

--- a/firebase-perf/src/test/java/com/google/firebase/perf/session/PerfSessionTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/session/PerfSessionTest.java
@@ -256,7 +256,7 @@ public class PerfSessionTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void testBuildAndSortKeepsLegacySessionAtTopWithNoVerboseSessions() {
+  public void testBuildAndSortSwapsLegacySessionAtTopWithNoVerboseSessions() {
     // Force all the sessions from now onwards to be non-verbose
     forceNonVerboseSession();
 
@@ -273,8 +273,8 @@ public class PerfSessionTest extends FirebasePerformanceTestBase {
         PerfSession.buildAndSort(ImmutableList.copyOf(sessions));
 
     // Verify that after building the proto objects for PerfSessions, the first session in the array
-    // of proto objects is a legacy session.
-    assertThat(isLegacy(perfSessions[0].getSessionId())).isTrue();
+    // of proto objects is *not* a legacy session.
+    assertThat(isLegacy(perfSessions[0].getSessionId())).isFalse();
   }
 
   @Test


### PR DESCRIPTION
- Updated `PerfSession.buildAndSort`
- Updated logging of legacy session *only* traces to include the trace name.