### PR TITLE
Force AQS to init before PerfEarly

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfEarly.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfEarly.java
@@ -18,10 +18,12 @@ import android.content.Context;
 import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.StartupTime;
+import com.google.firebase.inject.Provider;
 import com.google.firebase.perf.application.AppStateMonitor;
 import com.google.firebase.perf.config.ConfigResolver;
 import com.google.firebase.perf.metrics.AppStartTrace;
 import com.google.firebase.perf.session.FirebasePerformanceSessionSubscriber;
+import com.google.firebase.sessions.FirebaseSessions;
 import com.google.firebase.sessions.api.FirebaseSessionsDependencies;
 import java.util.concurrent.Executor;
 
@@ -35,12 +37,18 @@ import java.util.concurrent.Executor;
 public class FirebasePerfEarly {
 
   public FirebasePerfEarly(
-      FirebaseApp app, @Nullable StartupTime startupTime, Executor uiExecutor) {
+      FirebaseApp app,
+      @Nullable StartupTime startupTime,
+      Executor uiExecutor,
+      Provider<FirebaseSessions> firebaseSessions) {
     Context context = app.getApplicationContext();
 
     // Initialize ConfigResolver early for accessing device caching layer.
     ConfigResolver configResolver = ConfigResolver.getInstance();
     configResolver.setApplicationContext(context);
+
+    // Ensure FirebaseSessions was initialized
+    firebaseSessions.get();
 
     // Register FirebasePerformance as a subscriber ASAP - which will start collecting gauges if the
     // FirebaseSession is verbose.

--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfRegistrar.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfRegistrar.java
@@ -30,6 +30,7 @@ import com.google.firebase.perf.injection.components.FirebasePerformanceComponen
 import com.google.firebase.perf.injection.modules.FirebasePerformanceModule;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import com.google.firebase.remoteconfig.RemoteConfigComponent;
+import com.google.firebase.sessions.FirebaseSessions;
 import com.google.firebase.sessions.api.FirebaseSessionsDependencies;
 import com.google.firebase.sessions.api.SessionSubscriber;
 import java.util.Arrays;
@@ -46,6 +47,7 @@ import java.util.concurrent.Executor;
  */
 @Keep
 public class FirebasePerfRegistrar implements ComponentRegistrar {
+
   private static final String LIBRARY_NAME = "fire-perf";
   private static final String EARLY_LIBRARY_NAME = "fire-perf-early";
 
@@ -73,15 +75,17 @@ public class FirebasePerfRegistrar implements ComponentRegistrar {
             .add(Dependency.required(FirebaseApp.class))
             .add(Dependency.optionalProvider(StartupTime.class))
             .add(Dependency.required(uiExecutor))
+            .add(Dependency.optionalProvider(FirebaseSessions.class))
             .eagerInDefaultApp()
             .factory(
                 container ->
                     new FirebasePerfEarly(
                         container.get(FirebaseApp.class),
                         container.getProvider(StartupTime.class).get(),
-                        container.get(uiExecutor)))
+                        container.get(uiExecutor),
+                        container.getProvider(FirebaseSessions.class)))
             .build(),
-        /**
+        /*
          * Fireperf SDK is lazily by {@link FirebasePerformanceInitializer} during {@link
          * com.google.firebase.perf.application.AppStateMonitor#onActivityResumed(Activity)}. we use
          * "lazy" dependency for some components that are not required during initialization so as

--- a/firebase-perf/src/test/java/com/google/firebase/perf/FirebasePerfRegistrarTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/FirebasePerfRegistrarTest.java
@@ -25,6 +25,7 @@ import com.google.firebase.components.Dependency;
 import com.google.firebase.components.Qualified;
 import com.google.firebase.installations.FirebaseInstallationsApi;
 import com.google.firebase.remoteconfig.RemoteConfigComponent;
+import com.google.firebase.sessions.FirebaseSessions;
 import java.util.List;
 import java.util.concurrent.Executor;
 import org.junit.Test;
@@ -59,7 +60,8 @@ public class FirebasePerfRegistrarTest {
         .containsExactly(
             Dependency.required(Qualified.qualified(UiThread.class, Executor.class)),
             Dependency.required(FirebaseApp.class),
-            Dependency.optionalProvider(StartupTime.class));
+            Dependency.optionalProvider(StartupTime.class),
+            Dependency.optionalProvider(FirebaseSessions.class));
 
     assertThat(firebasePerfEarlyComponent.isLazy()).isFalse();
   }


### PR DESCRIPTION
Force AQS to initialize before PerfEarly. This is to avoid app start traces having a legacy session id

Before:

```
16:01:10.372 FirebasePerformance  D  Initializing FirebasePerfEarly 22.1.0
16:01:10.482 FirebaseSessions     D  Initializing Firebase Sessions 3.0.1
16:01:10.627 FirebasePerformance  D  Initializing FirebasePerformance 22.1.0
```

After:

```
16:02:17.956 FirebaseSessions     D  Initializing Firebase Sessions 3.0.1
16:02:17.958 FirebasePerformance  D  Initializing FirebasePerfEarly 22.1.0
16:02:18.118 FirebasePerformance  D  Initializing FirebasePerformance 22.1.0
```