### PR TITLE
Add `common_google_play_services_unknown_issue` to keep.xml

### DIFF
--- a/firebase-common/src/main/res/raw/firebase_common_keep.xml
+++ b/firebase-common/src/main/res/raw/firebase_common_keep.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools"
-    tools:keep="@string/google_app_id,@string/gcm_defaultSenderId,@string/google_api_key,@string/firebase_database_url,@string/ga_trackingId,@string/google_storage_bucket,@string/project_id" />
+    tools:keep="@string/google_app_id,@string/gcm_defaultSenderId,@string/google_api_key,@string/firebase_database_url,@string/ga_trackingId,@string/google_storage_bucket,@string/project_id,@string/common_google_play_services_unknown_issue" />


### PR DESCRIPTION
Otherwise this can get stripped out by the resource shrinker. The issue here arises when running Firebase on a device without Google Play services. Without this, an app having undergone resource shrinking will crash being unable to find this resource. Because some Firebase services are documented to work without Play services, this shouldn't cause a crash.