### PR TITLE
[AI] Correctly handle empty candidates in the accessors

### DIFF
--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/GenerateContentResponse.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/GenerateContentResponse.kt
@@ -36,12 +36,14 @@ public class GenerateContentResponse(
    * exists.
    */
   public val text: String? by lazy {
-    candidates.first().content.parts.filterIsInstance<TextPart>().joinToString(" ") { it.text }
+    candidates.firstOrNull()?.content?.parts?.filterIsInstance<TextPart>()?.joinToString(" ") {
+      it.text
+    }
   }
 
   /** Convenience field to list all the [FunctionCallPart]s in the response, if they exist. */
   public val functionCalls: List<FunctionCallPart> by lazy {
-    candidates.first().content.parts.filterIsInstance<FunctionCallPart>()
+    candidates.firstOrNull()?.content?.parts?.filterIsInstance<FunctionCallPart>().orEmpty()
   }
 
   /**
@@ -50,10 +52,15 @@ public class GenerateContentResponse(
    * This also includes any [ImagePart], but they will be represented as [InlineDataPart] instead.
    */
   public val inlineDataParts: List<InlineDataPart> by lazy {
-    candidates.first().content.parts.let { parts ->
-      parts.filterIsInstance<ImagePart>().map { it.toInlineDataPart() } +
-        parts.filterIsInstance<InlineDataPart>()
-    }
+    candidates
+      .firstOrNull()
+      ?.content
+      ?.parts
+      ?.let { parts ->
+        parts.filterIsInstance<ImagePart>().map { it.toInlineDataPart() } +
+          parts.filterIsInstance<InlineDataPart>()
+      }
+      .orEmpty()
   }
 
   @Serializable

--- a/firebase-ai/src/test/java/com/google/firebase/ai/DevAPIUnarySnapshotTests.kt
+++ b/firebase-ai/src/test/java/com/google/firebase/ai/DevAPIUnarySnapshotTests.kt
@@ -22,12 +22,12 @@ import com.google.firebase.ai.type.ResponseStoppedException
 import com.google.firebase.ai.type.ServerException
 import com.google.firebase.ai.util.goldenDevAPIUnaryFile
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import io.ktor.http.HttpStatusCode
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.withTimeout
@@ -42,9 +42,24 @@ internal class DevAPIUnarySnapshotTests {
       withTimeout(testTimeout) {
         val response = model.generateContent("prompt")
 
-        response.candidates.isEmpty() shouldBe false
+        response.candidates.shouldNotBeEmpty()
         response.candidates.first().finishReason shouldBe FinishReason.STOP
-        response.candidates.first().content.parts.isEmpty() shouldBe false
+        response.candidates.first().content.parts.shouldNotBeEmpty()
+      }
+    }
+
+  @Test
+  fun `only prompt feedback reply`() =
+    goldenDevAPIUnaryFile("unary-failure-only-prompt-feedback.json") {
+      withTimeout(testTimeout) {
+        val response = model.generateContent("prompt")
+
+        response.candidates.shouldBeEmpty()
+
+        // Check response from accessors
+        response.text.shouldBeNull()
+        response.functionCalls.shouldBeEmpty()
+        response.inlineDataParts.shouldBeEmpty()
       }
     }
 
@@ -54,9 +69,9 @@ internal class DevAPIUnarySnapshotTests {
       withTimeout(testTimeout) {
         val response = model.generateContent("prompt")
 
-        response.candidates.isEmpty() shouldBe false
+        response.candidates.shouldNotBeEmpty()
         response.candidates.first().finishReason shouldBe FinishReason.STOP
-        response.candidates.first().content.parts.isEmpty() shouldBe false
+        response.candidates.first().content.parts.shouldNotBeEmpty()
       }
     }
 
@@ -66,11 +81,11 @@ internal class DevAPIUnarySnapshotTests {
       withTimeout(testTimeout) {
         val response = model.generateContent("prompt")
 
-        response.candidates.isEmpty() shouldBe false
+        response.candidates.shouldNotBeEmpty()
         response.candidates.first().citationMetadata?.citations?.size shouldBe 4
         response.candidates.first().citationMetadata?.citations?.forEach {
-          it.startIndex shouldNotBe null
-          it.endIndex shouldNotBe null
+          it.startIndex.shouldNotBeNull()
+          it.endIndex.shouldNotBeNull()
         }
       }
     }


### PR DESCRIPTION
Before, if a response had no candidates, accessors would throw an exception when used instead of handle the case elegantly. Now they either return an empty list, for collections, or null, for string.

The test file is added in https://github.com/FirebaseExtended/vertexai-sdk-test-data/pull/48