### PR TITLE
[FAL] Update limited-use token docs

### DIFF
--- a/firebase-ai/CHANGELOG.md
+++ b/firebase-ai/CHANGELOG.md
@@ -7,11 +7,11 @@
   configured.
 * [changed] Added a `dilation` parameter to `ImagenMaskReference.generateMaskAndPadForOutpainting`
   (#7260)
-* [feature] Added a new configuration option to enable limited-use App Check tokens for attesting
-  Firebase AI Logic requests. This enhances security against replay attacks. To use this feature,
-  configure it explicitly via the new `useLimitedUseAppCheckTokens` parameter when initializing
-  `FirebaseAI`. We recommend migrating to limited-use tokens now, so your app will be ready to take
-  advantage of replay protection when it becomes available for Firebase AI Logic. 
+* [feature] Added support for limited-use tokens with Firebase App Check. These short-lived tokens
+  provide greater protection for the APIs that give you access to Gemini and Imagen models. Learn
+  how to [enable usage of limited-use tokens](https://firebase.google.com/docs/ai-logic/app-check).
+  (#7285)
+
 
 # 17.1.0
 =======

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/FirebaseAI.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/FirebaseAI.kt
@@ -231,10 +231,9 @@ internal constructor(
      *
      * @param backend the backend reference to make generative AI requests to.
      * @param useLimitedUseAppCheckTokens when sending tokens to the backend, this option enables
-     * the usage of App Check's limited-use tokens instead of the standard cached tokens. Learn
-     * more about [limited-use tokens](https://firebase.google.com/docs/ai-logic/app-check),
-     * including their nuances, when to use them, and best practices for integrating them into your
-     * app.
+     * the usage of App Check's limited-use tokens instead of the standard cached tokens. Learn more
+     * about [limited-use tokens](https://firebase.google.com/docs/ai-logic/app-check), including
+     * their nuances, when to use them, and best practices for integrating them into your app.
      *
      * _This flag is set to `false` by default._
      */
@@ -281,8 +280,9 @@ public fun Firebase.ai(
  *
  * @param backend the backend reference to make generative AI requests to.
  * @param useLimitedUseAppCheckTokens use App Check's limited-use tokens when sending requests to
- * the backend. Learn more about [limited-use tokens](https://firebase.google.com/docs/ai-logic/app-check),
- * including their nuances, when to use them, and best practices for integrating them into your app.
+ * the backend. Learn more about
+ * [limited-use tokens](https://firebase.google.com/docs/ai-logic/app-check), including their
+ * nuances, when to use them, and best practices for integrating them into your app.
  */
 // TODO(b/440356335): Update docs above when web page goes live in M170
 public fun Firebase.ai(

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/FirebaseAI.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/FirebaseAI.kt
@@ -231,22 +231,13 @@ internal constructor(
      *
      * @param backend the backend reference to make generative AI requests to.
      * @param useLimitedUseAppCheckTokens when sending tokens to the backend, this option enables
-     * the usage of App Check's limited-use tokens instead of the standard cached tokens.
-     *
-     * A new limited-use tokens will be generated for each request; providing a smaller attack
-     * surface for malicious parties to hijack tokens. When used alongside replay protection,
-     * limited-use tokens are also _consumed_ after each request, ensuring they can't be used again.
+     * the usage of App Check's limited-use tokens instead of the standard cached tokens. Learn
+     * more about [limited-use tokens](https://firebase.google.com/docs/ai-logic/app-check),
+     * including their nuances, when to use them, and best practices for integrating them into your
+     * app.
      *
      * _This flag is set to `false` by default._
-     *
-     * **Important:** Replay protection is not currently supported for the FirebaseAI backend. While
-     * this feature is being developed, you can still migrate to using limited-use tokens. Because
-     * limited-use tokens are backwards compatible, you can still use them without replay
-     * protection. Due to their shorter TTL over standard App Check tokens, they still provide a
-     * security benefit. Migrating to limited-use tokens sooner minimizes disruption when support
-     * for replay protection is added.
      */
-    // TODO(b/440356335): Update docs above when web page goes live in M170
     @JvmStatic
     @JvmOverloads
     public fun getInstance(
@@ -290,7 +281,8 @@ public fun Firebase.ai(
  *
  * @param backend the backend reference to make generative AI requests to.
  * @param useLimitedUseAppCheckTokens use App Check's limited-use tokens when sending requests to
- * the backend. To learn more about what this means, see the full docs on [FirebaseAI.getInstance].
+ * the backend. Learn more about [limited-use tokens](https://firebase.google.com/docs/ai-logic/app-check),
+ * including their nuances, when to use them, and best practices for integrating them into your app.
  */
 // TODO(b/440356335): Update docs above when web page goes live in M170
 public fun Firebase.ai(


### PR DESCRIPTION
Per [b/440356335](https://b.corp.google.com/issues/440356335),

This updates the limited-use token related docs to point to the web page that will go live with the release. Initially, it was planned for the docs to go live when Unity released, but Rachel now intends to have them live immediately -- with a note about Unity until they go live.

The updates are made per Rachel's recommendations and discussions in the javadoc CL/ALF doc.