### PR TITLE
firestore: fix slow queries when a collection has many NO_DOCUMENT tombstones

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
@@ -48,7 +48,7 @@ class SQLiteSchema {
    * The version of the schema. Increase this by one for each migration added to runMigrations
    * below.
    */
-  static final int VERSION = 17;
+  static final int VERSION = 18;
 
   /**
    * The batch size for data migrations.
@@ -181,6 +181,10 @@ class SQLiteSchema {
 
     if (fromVersion < 17 && toVersion >= 17) {
       createGlobalsTable();
+    }
+
+    if (fromVersion < 18 && toVersion >= 18) {
+      addDocumentType();
     }
 
     /*
@@ -445,6 +449,12 @@ class SQLiteSchema {
     if (!tableContainsColumn("remote_documents", "path_length")) {
       // The "path_length" column store the number of segments in the path.
       db.execSQL("ALTER TABLE remote_documents ADD COLUMN path_length INTEGER");
+    }
+  }
+
+  private void addDocumentType() {
+    if (!tableContainsColumn("remote_documents", "document_type")) {
+      db.execSQL("ALTER TABLE remote_documents ADD COLUMN document_type INTEGER");
     }
   }
 


### PR DESCRIPTION
Change `SQLiteRemoteDocumentCache.java` to improve performance of queries for collections when a collection has many NO_DOCUMENT tombstones.

In my performance test, querying an empty collection with no NO_DOCUMENT tombstones took 2 milliseconds. A collection with 10,000 NO_DOCUMENT tombstones took 67 milliseconds, despite the snapshot size being 0. With the fix in this PR, the same query of a collection with 10,000 NO_DOCUMENT tombstones took 6 milliseconds, only _slightly_ slower than the 2 milliseconds the query takes with a fully empty collection.

Fixes #7295