### PR TITLE
feat: Skip tests for doc-only changes

### DIFF
--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/ci/AffectedProjectFinder.java
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/ci/AffectedProjectFinder.java
@@ -39,6 +39,8 @@ public class AffectedProjectFinder {
     this(project, changedPaths(project.getRootDir()), ignorePaths);
   }
 
+  private static final Set<String> DOC_EXTENSIONS = ImmutableSet.of("md", "txt", "html");
+
   public AffectedProjectFinder(
       Project project, Set<String> changedPaths, List<Pattern> ignorePaths) {
     this.project = project;
@@ -53,7 +55,15 @@ public class AffectedProjectFinder {
                   }
                   return true;
                 })
+            .filter(p -> !isDocFile(p))
             .collect(Collectors.toSet());
+  }
+
+  private static boolean isDocFile(String path) {
+    if (path.startsWith("docs/")) {
+      return true;
+    }
+    return DOC_EXTENSIONS.stream().anyMatch(ext -> path.endsWith("." + ext));
   }
 
   Set<Project> find() {

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/ci/AffectedProjectFinder.java
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/ci/AffectedProjectFinder.java
@@ -16,6 +16,7 @@ package com.google.firebase.gradle.plugins.ci;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.CharStreams;
+import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -63,7 +64,7 @@ public class AffectedProjectFinder {
     if (path.startsWith("docs/")) {
       return true;
     }
-    return DOC_EXTENSIONS.stream().anyMatch(ext -> path.endsWith("." + ext));
+    return DOC_EXTENSIONS.contains(Files.getFileExtension(path));
   }
 
   Set<Project> find() {


### PR DESCRIPTION
This change improves the CI process by skipping test runs for pull requests that only contain changes to documentation files.

The logic is implemented in `AffectedProjectFinder.java`. It filters out files with common documentation extensions (`.md`, `.txt`, `.html`) and files in the `docs/` directory from the set of changed files.

If all changed files in a pull request are documentation files, the set of affected projects will be empty, and no tests will be run. This avoids unnecessary test runs and saves CI resources.