### PR TITLE
Make sure unit_tests don't fail if no modules are affected

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs:
       - determine_changed
+    if: ${{ needs.determine_changed.outputs.modules != '[]' }}
     strategy:
       fail-fast: false
       matrix:
@@ -89,12 +90,11 @@ jobs:
   # to be used as a required check for merging.
   check_all:
     runs-on: ubuntu-22.04
-    if: always()
     name: Unit Tests (matrix)
     needs: unit_tests
+    if: ${{ failure() }}
     steps:
-      - name: Check test matrix
-        if: needs.unit_tests.result != 'success'
+      - name: Check test matrix results
         run: exit 1
 
 


### PR DESCRIPTION
The unit tests CI workflow has been failing when no modules were affected. See https://github.com/firebase/firebase-android-sdk/actions/runs/17332506204/job/49221502380?pr=7303 as an example

The solution has been to fully skip jobs in the workflow when there are no affected jobs. 