### PR TITLE
Restore SessionLifecycleService as no-op

### DIFF
--- a/firebase-sessions/CHANGELOG.md
+++ b/firebase-sessions/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [fixed] Fixed a bug when the app foregrounds before Sessions has initialized (#7519)
+- [changed] Restore SessionLifecycleService as no-op
 
 # 3.0.3
 

--- a/firebase-sessions/src/main/AndroidManifest.xml
+++ b/firebase-sessions/src/main/AndroidManifest.xml
@@ -18,6 +18,10 @@
 
   <application>
     <service
+        android:name="com.google.firebase.sessions.SessionLifecycleService"
+        android:enabled="false"
+        android:exported="false" />
+    <service
       android:exported="false"
       android:name="com.google.firebase.components.ComponentDiscoveryService">
       <meta-data

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleService.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleService.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.sessions
+
+import android.app.Service
+import android.content.Intent
+
+/**
+ * A no-op implementation of SessionLifecycleService.
+ *
+ * This service was previously used for session management but has been effectively made a no-op as
+ * part of the architectural changes introduced in
+ * [PR #7318](https://github.com/firebase/firebase-android-sdk/pull/7318). It is retained to prevent
+ * `ClassNotFoundException` for older clients that might still have this service declared in their
+ * AndroidManifest.xml or for systems attempting to restart a previously running instance of this
+ * service.
+ */
+internal class SessionLifecycleService : Service() {
+
+  override fun onBind(unused: Intent?) = null
+}


### PR DESCRIPTION
In context of class not found exception: https://github.com/firebase/firebase-android-sdk/issues/7296

This PR restore a previously deleted service as no operational


The user reported a crash after upgrading to BoM 34.1.0 only for some Samsung and Oppo devices in Android 14/15. https://firebase.google.com/support/release-notes/android 



There was a major refactor on the way of monitoring application lifecycle events and determining when/if a new session should be generated. Which was the main purpose for `SessionLifecycleService`. [Firebase Session](https://github.com/firebase/firebase-android-sdk/blob/main/firebase-sessions/README.md) is used by Crashlytics and Performance internally to measure sessions

[The refactor](https://github.com/firebase/firebase-android-sdk/pull/7039/files#diff-ea2eb8012abccd4cb5dccba37ec109f0eaa2a82fe6be852b5be7c32ed8de2b45) proposes the elimination of the service `SessionLifecycleService` in favor of `SharedSessionRepository`. 

This refactor was released on version `releases/m167` ([see commit here](https://github.com/firebase/firebase-android-sdk/commit/c9a4a3d749440833a75d4de686d60f825ffd79c8)). 

See diff of m167 with m166 [here](https://github.com/firebase/firebase-android-sdk/compare/releases/m166...releases/m167).



Looking for `SessionLifecycleService` usages into the SDK I found just a leftover reference in an Android Test Manifest. So I can conclude this is not production code.

Reviewing the original `SessionLifecycleService` class I found out this service contains a `Binder` implementation 

It sounds like the Android system on those specific devices (Samsung/Oppo on Android 14/15) might be trying to recreate the `SessionLifecycleService` based on a cached manifest from the previous version of the host app, even though the service class itself is no longer present in the new version. This leads to the `ClassNotFoundException`.



**Conclusions:**

A) Stale Service Connections (I see this as the root cause, I’d like to review g3 code to confirm there is not source code having references to the removed service):

If any component within the host app (or the SDK itself) was bound to `SessionLifecycleService` and the `ServiceConnection` wasn't properly released or unbound before the app update (or if the system is trying to restore a previous binding state), the system will attempt to call `onBind` on the service.

When it tries to instantiate `SessionLifecycleService` to do this and finds the class missing, it results in the `ClassNotFoundException`.

The git diff showed `android:exported="false"` for the service, which is good as it means only the SDK could bind to it.

Why this still leads to `ClassNotFoundException` on update:

Even if the new code doesn't try to bind to the removed service anymore, the Android system might still attempt to re-establish connections that it considers active or pending from the previous app session, especially if the app process didn't terminate cleanly or if the system is trying to restore the app's state after an update. If a `ServiceConnection` was active when the app was last running the old version, the system might try to call `onServiceConnected` for that connection, which requires instantiating the service.



tl; dr:
B) Android /System Caching/State Retention:

The Android Package Manager or Activity Manager on certain devices/OS versions might retain information about previously registered services.

If the service was started in a "sticky" way, the system will try to restart it after it's killed or after an app update if it believes the service should still be running. When it tries to do so with the updated app that lacks the service class, it crashes.

C) Stale System State: Sometimes, especially with certain OEM customizations or newer Android versions, the system's package manager or activity manager might not perfectly clear all references to components from an old app version immediately upon an update. For users experiencing this: The most reliable fix is often a clean reinstall.

D) OEM Customizations: Samsung and Oppo devices have their own modifications to Android, which can sometimes lead to different behaviors in how app updates and service lifecycles are handled.




**Proposed workaround:**

Future Service Removals (Refined Mitigation Strategy for Bound Services):

**Version N+1** (Graceful Shutdown & Deprecation): Return the service class in the codebase, modify its onBind(Intent intent) method to return null immediately. This signals to any clients attempting to bind that the service is not available or is shutting down. Crucially, mark the service as `android:enabled="false"` in the AndroidManifest.xml. **This explicitly tells the system the service should not be started or bound**.



**Version N+2** (Full Removal): Now that clients have had a version where the service gracefully refuses bindings and is disabled, it's safer to remove the service class and its manifest entry.




