### PR TITLE
chore(firebaseai): Update changelog per release 

### DIFF
--- a/firebase-ai/CHANGELOG.md
+++ b/firebase-ai/CHANGELOG.md
@@ -11,9 +11,12 @@
 
 * [changed] Added a `dilation` parameter to `ImagenMaskReference.generateMaskAndPadForOutpainting`
   (#7260)
-* [feature] Added support for limited-use tokens with Firebase App Check. These short-lived tokens
-  provide greater protection for the APIs that give you access to Gemini and Imagen models. Learn
-  how to [enable usage of limited-use tokens](https://firebase.google.com/docs/ai-logic/app-check).
+* [feature] Added support for limited-use tokens with Firebase App Check.
+  These limited-use tokens are required for an upcoming optional feature called
+  _replay protection_. We recommend
+  [enabling the usage of limited-use tokens](https://firebase.google.com/docs/ai-logic/app-check)
+  now so that when replay protection becomes available, you can enable it sooner
+  because more of your users will be on versions of your app that send limited-use tokens.
   (#7285)
 
 # 17.1.0


### PR DESCRIPTION
Rachel updated the changelog wording before shipping to firesite, and she wanted the SDKs to update the wording in their SDK changelogs to match. This updates the relevant changelog entry (for limited-use tokens) to match.