### PR TITLE
[Infra] Fix broken make change log 

### DIFF
--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/Changelog.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/Changelog.kt
@@ -264,7 +264,7 @@ data class ReleaseContent(val subtext: String, val changes: List<Change>) {
      * ]
      * ```
      */
-    val CHANGE_REGEX = Regex("^\\* ([\\s\\S]+?)(?=^\\*|(?![\\s\\S]))", RegexOption.MULTILINE)
+    val CHANGE_REGEX = "^[*-] ([\\s\\S]+?)(?=^[*-]|(?![\\s\\S]))".toRegex(RegexOption.MULTILINE)
 
     /**
      * Regex for finding the subtext in a release.

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/MakeReleaseNotesTask.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/MakeReleaseNotesTask.kt
@@ -191,7 +191,7 @@ abstract class MakeReleaseNotesTask : DefaultTask() {
      */
     private val LINK_REGEX =
       Regex(
-        "(?:GitHub )?(?:\\[|\\()#(\\d+)(?:\\]|\\))(?:\\(.+?\\))?(?:\\{: \\.external\\})?",
+        "(?:GitHub )?(?:\\[|\\()#(\\d+)(?:\\]|\\))(?:\\(.+?\\))?(?:\\{:\\s*\\.external\\})?",
         RegexOption.MULTILINE,
       )
   }

--- a/plugins/src/test/kotlin/com/google/firebase/gradle/plugins/MakeReleaseNotesTests.kt
+++ b/plugins/src/test/kotlin/com/google/firebase/gradle/plugins/MakeReleaseNotesTests.kt
@@ -17,9 +17,8 @@
 package com.google.firebase.gradle.plugins
 
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.beEmpty
-import io.kotest.matchers.file.exist
-import io.kotest.matchers.should
+import io.kotest.matchers.file.shouldExist
+import io.kotest.matchers.shouldBe
 import java.io.File
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.BeforeClass
@@ -39,9 +38,8 @@ class MakeReleaseNotesTests : FunSpec() {
         "firebase-storage/build/tmp/makeReleaseNotes/release_notes.md"
       )
 
-    releaseNoteFile should exist()
-
-    releaseNoteFile.readLines() diff expectedReleaseNoteFile.readLines() should beEmpty()
+    releaseNoteFile.shouldExist()
+    releaseNoteFile.readText() shouldBe expectedReleaseNoteFile.readText()
   }
 
   private fun buildReleaseNotes() =

--- a/plugins/src/test/kotlin/com/google/firebase/gradle/plugins/MoveUnreleasedChangesTests.kt
+++ b/plugins/src/test/kotlin/com/google/firebase/gradle/plugins/MoveUnreleasedChangesTests.kt
@@ -102,7 +102,7 @@ class MoveUnreleasedChangesTests : FunSpec() {
     val originalEntry = original.releases.first()
 
     releasedEntry.content.changes shouldContainExactly originalEntry.content.changes
-    releasedEntry.content.subtext shouldMatch originalEntry.content.subtext
+    releasedEntry.content.subtext shouldBe originalEntry.content.subtext
   }
 
   companion object {

--- a/plugins/src/test/kotlin/com/google/firebase/gradle/plugins/MoveUnreleasedChangesTests.kt
+++ b/plugins/src/test/kotlin/com/google/firebase/gradle/plugins/MoveUnreleasedChangesTests.kt
@@ -22,7 +22,6 @@ import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveAtLeastSize
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldMatch
 import java.io.File
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.BeforeClass

--- a/plugins/src/test/resources/BasicProject/firebase-storage/CHANGELOG.md
+++ b/plugins/src/test/resources/BasicProject/firebase-storage/CHANGELOG.md
@@ -5,8 +5,7 @@ Note: We did some super cool stuff here!
 - [feature] Added support for disjunctions in queries (`OR` queries).
 
 - [feature] Firebase now supports Kotlin coroutines. With this release, we added
-  [`kotlinx-coroutines-play-services`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-play-services/){:
-  .external} to `firebase-firestore-ktx` as a transitive dependency, which exposes the
+  [`kotlinx-coroutines-play-services`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-play-services/){:.external} to `firebase-firestore-ktx` as a transitive dependency, which exposes the
   `Task<T>.await()` suspend function to convert a
   [`Task`](https://developers.google.com/android/guides/tasks) into a Kotlin coroutine.
 
@@ -15,7 +14,7 @@ Note: We did some super cool stuff here!
 - [removed] Removed some old stuff (#562)
 
 - [feature] Added this thing we wanted
-  [#444](//github.com/firebase/firebase-android-sdk/issues/number){: .external}
+  [#444](//github.com/firebase/firebase-android-sdk/issues/number){:.external}
 
 - [feature] Added
   [`Query.snapshots()`](/docs/reference/kotlin/com/google/firebase/firestore/ktx/package-summary#snapshots_1)
@@ -45,7 +44,7 @@ Note: We did some super cool stuff here!
 # 24.5.0
 
 - [fixed] Fixed stack overflow caused by deeply nested server timestamps. (GitHub
-  [#4702](//github.com/firebase/firebase-android-sdk/issues/4702){: .external})
+  [#4702](//github.com/firebase/firebase-android-sdk/issues/4702){:.external})
 
 ## Kotlin
 

--- a/plugins/src/test/resources/MakeReleaseNotes/release-notes.md
+++ b/plugins/src/test/resources/MakeReleaseNotes/release-notes.md
@@ -2,32 +2,29 @@
 
 Note: We did some super cool stuff here!
 
-- {{feature}} Added support for disjunctions in queries (`OR` queries).
+* {{feature}} Added support for disjunctions in queries (`OR` queries).
 
-- {{feature}} Firebase now supports Kotlin coroutines. With this release, we added
-  [`kotlinx-coroutines-play-services`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-play-services/){:
-  .external} to `firebase-firestore-ktx` as a transitive dependency, which exposes the
+* {{feature}} Firebase now supports Kotlin coroutines. With this release, we added
+  [`kotlinx-coroutines-play-services`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-play-services/){:.external} to `firebase-firestore-ktx` as a transitive dependency, which exposes the
   `Task<T>.await()` suspend function to convert a
   [`Task`](https://developers.google.com/android/guides/tasks) into a Kotlin coroutine.
 
-- {{fixed}} An issue on GitHub [#123](//github.com/firebase/firebase-android-sdk/issues/123){:
-  .external}
+* {{fixed}} An issue on GitHub [#123](//github.com/firebase/firebase-android-sdk/issues/123){: .external}
 
-- {{removed}} Removed some old stuff GitHub
-  [#562](//github.com/firebase/firebase-android-sdk/issues/562){: .external}
+* {{removed}} Removed some old stuff GitHub [#562](//github.com/firebase/firebase-android-sdk/issues/562){: .external}
 
-- {{feature}} Added this thing we wanted GitHub
-  [#444](//github.com/firebase/firebase-android-sdk/issues/444){: .external}
+* {{feature}} Added this thing we wanted
+  GitHub [#444](//github.com/firebase/firebase-android-sdk/issues/444){: .external}
 
-- {{feature}} Added
+* {{feature}} Added
   [`Query.snapshots()`](/docs/reference/kotlin/com/google/firebase/firestore/ktx/package-summary#snapshots_1)
   and
   [`DocumentReference.snapshots()`](/docs/reference/kotlin/com/google/firebase/firestore/ktx/package-summary#snapshots)
   Kotlin Flows to listen for realtime updates.
 
-- {{fixed}} Fixed an issue in `waitForPendingWrites()` that could lead to a `NullPointerException`.
+* {{fixed}} Fixed an issue in `waitForPendingWrites()` that could lead to a `NullPointerException`.
 
-- {{feature}} Added
+* {{feature}} Added
   [`Query.whereNotIn()`](</docs/reference/android/com/google/firebase/firestore/Query#whereNotIn(java.lang.String,%20java.util.List<?%20extends%20java.lang.Object)>>)
   and
   [`Query.whereNotEqualTo()`](</docs/reference/android/com/google/firebase/firestore/Query#whereNotEqualTo(java.lang.String,%20java.lang.Object)>)
@@ -40,6 +37,6 @@ Note: We did some super cool stuff here!
 
   Neither query operator finds documents where the specified field isn't present.
 
-- {{unchanged}} Idk ig we did some stuff
+* {{unchanged}} Idk ig we did some stuff
 
-- {{removed}} some stuff that we didn't really like got removed
+* {{removed}} some stuff that we didn't really like got removed


### PR DESCRIPTION
The introduction of the markdown formatter accidentally changed the golden files for the change log generator. Additionally, the new formatter introduces top-level lists using `-` instead of `*` as we were using, which caused the generator to fail. 

A couple of changes to the matchers were also included as a clean up step.

Internal b/442932777