### PR TITLE
dataconnect: CHANGELOG.md: add PR link for "Ignore unknown fields in response data" entry

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [changed] Ignore unknown fields in response data instead of throwing a
   `DataConnectOperationException` with message "decoding data from the server's response failed: An
   unknown field for index -3"
+  ([#7314](https://github.com/firebase/firebase-android-sdk/pull/7314))
 
 # 17.0.0
 


### PR DESCRIPTION
This PR updates the change log for Data Connect to add the link to https://github.com/firebase/firebase-android-sdk/pull/7314 (Ignore unknown fields in response data instead of throwing) for its entry. This was overlooked in the original PR and having the link gives more context to readers of the change log who are interested in details.