### PR TITLE
Remove API checks that are always true/false.

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -22,7 +22,6 @@ import android.app.Application.ActivityLifecycleCallbacks;
 import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.PowerManager;
 import android.os.Process;
 import android.view.View;
 import android.view.ViewTreeObserver;
@@ -564,40 +563,13 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, LifecycleObser
         }
         if (appProcess.processName.equals(appProcessName)
             || appProcess.processName.startsWith(allowedAppProcessNamePrefix)) {
-          boolean isAppInForeground = true;
-
-          // For the case when the app is in foreground and the device transitions to sleep mode,
-          // the importance of the process is set to IMPORTANCE_TOP_SLEEPING. However, this
-          // importance level was introduced in M. Pre M, the process importance is not changed to
-          // IMPORTANCE_TOP_SLEEPING when the display turns off. So we need to rely also on the
-          // state of the display to decide if any app process is really visible.
-          if (Build.VERSION.SDK_INT < 23 /* M */) {
-            isAppInForeground = isScreenOn(appContext);
-          }
-
-          if (isAppInForeground) {
-            return true;
-          }
+          // Returns true if the process with `IMPORTANCE_FOREGROUND` matches current process.
+          return true;
         }
       }
     }
 
     return false;
-  }
-
-  /**
-   * Returns whether the device screen is on.
-   *
-   * @param appContext The application's context.
-   */
-  public static boolean isScreenOn(Context appContext) {
-    PowerManager powerManager = (PowerManager) appContext.getSystemService(Context.POWER_SERVICE);
-    if (powerManager == null) {
-      return true;
-    }
-    return (Build.VERSION.SDK_INT >= 20 /* KITKAT_WATCH */)
-        ? powerManager.isInteractive()
-        : powerManager.isScreenOn();
   }
 
   /**

--- a/firebase-perf/src/main/java/com/google/firebase/perf/network/InstrURLConnectionBase.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/network/InstrURLConnectionBase.java
@@ -411,9 +411,7 @@ class InstrURLConnectionBase {
   }
 
   public void setFixedLengthStreamingMode(final long contentLength) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-      httpUrlConnection.setFixedLengthStreamingMode(contentLength);
-    }
+    httpUrlConnection.setFixedLengthStreamingMode(contentLength);
   }
 
   public void setIfModifiedSince(final long ifmodifiedsince) {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/FirstDrawDoneListener.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/FirstDrawDoneListener.java
@@ -87,11 +87,6 @@ public class FirstDrawDoneListener implements ViewTreeObserver.OnDrawListener {
    *     placeholder.
    */
   private static boolean isAliveAndAttached(View view) {
-    return view.getViewTreeObserver().isAlive() && isAttachedToWindow(view);
-  }
-
-  /** Backport {@link View#isAttachedToWindow()} which is API 19+ only. */
-  private static boolean isAttachedToWindow(View view) {
-    return view.isAttachedToWindow();
+    return view.getViewTreeObserver().isAlive() && view.isAttachedToWindow();
   }
 }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/FirstDrawDoneListener.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/FirstDrawDoneListener.java
@@ -92,9 +92,6 @@ public class FirstDrawDoneListener implements ViewTreeObserver.OnDrawListener {
 
   /** Backport {@link View#isAttachedToWindow()} which is API 19+ only. */
   private static boolean isAttachedToWindow(View view) {
-    if (Build.VERSION.SDK_INT >= 19) {
-      return view.isAttachedToWindow();
-    }
     return view.getWindowToken() != null;
   }
 }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/FirstDrawDoneListener.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/FirstDrawDoneListener.java
@@ -92,6 +92,6 @@ public class FirstDrawDoneListener implements ViewTreeObserver.OnDrawListener {
 
   /** Backport {@link View#isAttachedToWindow()} which is API 19+ only. */
   private static boolean isAttachedToWindow(View view) {
-    return view.getWindowToken() != null;
+    return view.isAttachedToWindow();
   }
 }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/Timer.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/Timer.java
@@ -17,7 +17,6 @@ package com.google.firebase.perf.util;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
-import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.os.SystemClock;
@@ -72,10 +71,7 @@ public class Timer implements Parcelable {
    * @return wall-clock time in microseconds.
    */
   private static long elapsedRealtimeMicros() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-      return NANOSECONDS.toMicros(SystemClock.elapsedRealtimeNanos());
-    }
-    return MILLISECONDS.toMicros(SystemClock.elapsedRealtime());
+    return NANOSECONDS.toMicros(SystemClock.elapsedRealtimeNanos());
   }
 
   // TODO: make all constructors private, use public static factory methods, per Effective Java


### PR DESCRIPTION
#nochangelog

As part of the app start trace change, I noticed there were some API checks which were always true/false.