### PR TITLE
[Infra] Bump benchmark kotlin plugin version

### DIFF
--- a/health-metrics/benchmark/template/build.gradle
+++ b/health-metrics/benchmark/template/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id 'com.android.application' version '8.2.1' apply false
     id 'com.android.library' version '8.2.1' apply false
     id 'com.android.test' version '7.2.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.8.22' apply false
+    id 'org.jetbrains.kotlin.android' version '2.0.21' apply false
 
     id 'com.google.gms.google-services' version '4.4.2' apply false
     id 'com.google.firebase.crashlytics' version '3.0.2' apply false


### PR DESCRIPTION
It will make it match our actual required min version of 2.0.21