### PR TITLE
firestore: DocumentViewChangeSet.java: Improve query performance by using an unsorted HashMap instead of a sorted TreeMap

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -8,6 +8,8 @@
   [#7376](//github.com/firebase/firebase-android-sdk/issues/7376)
 - [changed] Improve query performance via internal memoization of calculated document data.
   [#7370](//github.com/firebase/firebase-android-sdk/issues/7370)
+- [changed] Switch TreeSet to HashSet to improve query execution performance.
+  [#NNNN](//github.com/firebase/firebase-android-sdk/issues/NNNN)
 
 # 26.0.0
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/DocumentViewChangeSet.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/DocumentViewChangeSet.java
@@ -19,16 +19,15 @@ import static com.google.firebase.firestore.util.Assert.fail;
 import com.google.firebase.firestore.core.DocumentViewChange.Type;
 import com.google.firebase.firestore.model.DocumentKey;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.TreeMap;
 
 /** A set of changes to documents with respect to a view. This set is mutable. */
 public class DocumentViewChangeSet {
-  // This map is sorted to make the unit tests simpler.
-  private final TreeMap<DocumentKey, DocumentViewChange> changes;
+  private final HashMap<DocumentKey, DocumentViewChange> changes;
 
   public DocumentViewChangeSet() {
-    changes = new TreeMap<>();
+    changes = new HashMap<>();
   }
 
   public void addChange(DocumentViewChange change) {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/DocumentViewChangeSetTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/DocumentViewChangeSetTest.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.firestore.core;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.firebase.firestore.testutil.TestUtil.EMPTY_MAP;
 import static com.google.firebase.firestore.testutil.TestUtil.doc;
 import static org.junit.Assert.assertEquals;
@@ -71,20 +72,14 @@ public class DocumentViewChangeSetTest {
 
     List<DocumentViewChange> changes = set.getChanges();
 
-    assertEquals(7, changes.size());
-    assertEquals(added, changes.get(0).getDocument());
-    assertEquals(Type.ADDED, changes.get(0).getType());
-    assertEquals(removed, changes.get(1).getDocument());
-    assertEquals(Type.REMOVED, changes.get(1).getType());
-    assertEquals(modified, changes.get(2).getDocument());
-    assertEquals(Type.MODIFIED, changes.get(2).getType());
-    assertEquals(addedThenModified, changes.get(3).getDocument());
-    assertEquals(Type.ADDED, changes.get(3).getType());
-    assertEquals(removedThenAdded, changes.get(4).getDocument());
-    assertEquals(Type.MODIFIED, changes.get(4).getType());
-    assertEquals(modifiedThenRemoved, changes.get(5).getDocument());
-    assertEquals(Type.REMOVED, changes.get(5).getType());
-    assertEquals(modifiedThenModified, changes.get(6).getDocument());
-    assertEquals(Type.MODIFIED, changes.get(6).getType());
+    assertThat(changes)
+        .containsExactly(
+            DocumentViewChange.create(Type.ADDED, added),
+            DocumentViewChange.create(Type.REMOVED, removed),
+            DocumentViewChange.create(Type.MODIFIED, modified),
+            DocumentViewChange.create(Type.ADDED, addedThenModified),
+            DocumentViewChange.create(Type.MODIFIED, removedThenAdded),
+            DocumentViewChange.create(Type.REMOVED, modifiedThenRemoved),
+            DocumentViewChange.create(Type.MODIFIED, modifiedThenModified));
   }
 }


### PR DESCRIPTION
Improve Firestore query performance by using an unsorted HashMap instead of a sorted TreeMap when the "sorted" property is not strictly needed. This change was made to `DocumentViewChangeSet.java`, and its corresponding unit test.

The actual performance numbers of the improvement are small, but some isolated tests showed dramatic improvements, and I can't imagine this change _detracting_ from performance in any cases.
