### PR TITLE
[AI] Adjust backend nomenclature

### DIFF
--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/GenerativeBackend.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/GenerativeBackend.kt
@@ -27,7 +27,7 @@ internal constructor(internal val location: String, internal val backend: Genera
       GenerativeBackend("", GenerativeBackendEnum.GOOGLE_AI)
 
     /**
-     * References the VertexAI Enterprise backend.
+     * References the VertexAI Gemini API backend.
      *
      * @param location passes a valid cloud server location, defaults to "us-central1"
      */


### PR DESCRIPTION
Reword how we refer to our gemini api backend.

Internal b/441887682