### PR TITLE
[AI] Remove `PublicPreviewAPI` annotation for image generation

### DIFF
--- a/firebase-ai/CHANGELOG.md
+++ b/firebase-ai/CHANGELOG.md
@@ -5,6 +5,8 @@
   provided public web URLs to inform and enhance its responses. (#7382)
 - [changed] Added better error messages to `ServiceConnectionHandshakeFailedException` (#7412)
 - [changed] Marked the public constructor for `UsageMetadata` as deprecated (#7420)
+- [changed] Using Firebase AI Logic with the Gemini Developer API is now Generally Available (GA).
+- [changed] Using Firebase AI Logic with the Imagen generation APIs is now Generally Available (GA).
 
 # 17.3.0
 

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/FirebaseAI.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/FirebaseAI.kt
@@ -170,7 +170,6 @@ internal constructor(
    * @return The initialized [ImagenModel] instance.
    */
   @JvmOverloads
-  @PublicPreviewAPI
   public fun imagenModel(
     modelName: String,
     generationConfig: ImagenGenerationConfig? = null,

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/ImagenModel.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/ImagenModel.kt
@@ -45,7 +45,6 @@ import com.google.firebase.auth.internal.InternalAuthProvider
  * See the documentation for a list of
  * [supported models](https://firebase.google.com/docs/ai-logic/models).
  */
-@PublicPreviewAPI
 public class ImagenModel
 internal constructor(
   private val modelName: String,
@@ -106,6 +105,7 @@ internal constructor(
    * @param prompt the text input given to the model as a prompt
    * @param config the editing configuration settings
    */
+  @PublicPreviewAPI
   public suspend fun editImage(
     referenceImages: List<ImagenReferenceImage>,
     prompt: String,
@@ -130,6 +130,7 @@ internal constructor(
    * @param mask the mask which defines where in the image can be painted by Imagen.
    * @param config the editing configuration settings, it should include an [ImagenEditMode]
    */
+  @PublicPreviewAPI
   public suspend fun inpaintImage(
     image: ImagenInlineImage,
     prompt: String,
@@ -154,6 +155,7 @@ internal constructor(
    * @param config the editing configuration settings
    * @see [ImagenMaskReference.generateMaskAndPadForOutpainting]
    */
+  @PublicPreviewAPI
   public suspend fun outpaintImage(
     image: ImagenInlineImage,
     newDimensions: Dimensions,
@@ -172,6 +174,7 @@ internal constructor(
     prompt: String,
     generationConfig: ImagenGenerationConfig? = null,
   ): GenerateImageRequest {
+    @OptIn(PublicPreviewAPI::class)
     return GenerateImageRequest(
       listOf(GenerateImageRequest.ImagenPrompt(prompt, null)),
       GenerateImageRequest.ImagenParameters(
@@ -191,6 +194,7 @@ internal constructor(
     )
   }
 
+  @PublicPreviewAPI
   private fun constructEditRequest(
     referenceImages: List<ImagenReferenceImage>,
     prompt: String,

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/common/Request.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/common/Request.kt
@@ -77,7 +77,7 @@ internal data class CountTokensRequest(
 }
 
 @Serializable
-@PublicPreviewAPI
+@OptIn(PublicPreviewAPI::class)
 internal data class GenerateImageRequest(
   val instances: List<ImagenPrompt>,
   val parameters: ImagenParameters,
@@ -88,7 +88,6 @@ internal data class GenerateImageRequest(
     val referenceImages: List<ImagenReferenceImage.Internal>?
   )
 
-  @OptIn(PublicPreviewAPI::class)
   @Serializable
   internal data class ImagenParameters(
     val sampleCount: Int,
@@ -102,7 +101,7 @@ internal data class GenerateImageRequest(
     val addWatermark: Boolean?,
     val imageOutputOptions: ImagenImageFormat.Internal?,
     val editMode: String?,
-    val editConfig: ImagenEditingConfig.Internal?,
+    @OptIn(PublicPreviewAPI::class) val editConfig: ImagenEditingConfig.Internal?,
   )
 
   @Serializable

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenAspectRatio.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenAspectRatio.kt
@@ -17,7 +17,6 @@
 package com.google.firebase.ai.type
 
 /** Represents the aspect ratio that the generated image should conform to. */
-@PublicPreviewAPI
 public class ImagenAspectRatio private constructor(internal val internalVal: String) {
   public companion object {
     /** A square image, useful for icons, profile pictures, etc. */

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenGCSImage.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenGCSImage.kt
@@ -22,6 +22,5 @@ package com.google.firebase.ai.type
  * @param gcsUri Contains the `gs://` URI for the image.
  * @param mimeType Contains the MIME type of the image (for example, `"image/png"`).
  */
-@PublicPreviewAPI
 internal class ImagenGCSImage
 internal constructor(public val gcsUri: String, public val mimeType: String) {}

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenGenerationConfig.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenGenerationConfig.kt
@@ -28,7 +28,6 @@ package com.google.firebase.ai.type
  */
 import kotlin.jvm.JvmField
 
-@PublicPreviewAPI
 public class ImagenGenerationConfig(
   public val negativePrompt: String? = null,
   public val numberOfImages: Int? = 1,
@@ -109,7 +108,6 @@ public class ImagenGenerationConfig(
  * }
  * ```
  */
-@PublicPreviewAPI
 public fun imagenGenerationConfig(
   init: ImagenGenerationConfig.Builder.() -> Unit
 ): ImagenGenerationConfig {

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenGenerationResponse.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenGenerationResponse.kt
@@ -27,7 +27,6 @@ import kotlinx.serialization.Serializable
  * @param filteredReason if fewer images were generated than were requested, this field will contain
  * the reason they were filtered out.
  */
-@PublicPreviewAPI
 public class ImagenGenerationResponse<T>
 internal constructor(public val images: List<T>, public val filteredReason: String?) {
 

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenImageFormat.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenImageFormat.kt
@@ -26,7 +26,6 @@ import kotlinx.serialization.Serializable
  * means the image is permitted to be lower quality to reduce size. This parameter is not relevant
  * for every MIME type.
  */
-@PublicPreviewAPI
 public class ImagenImageFormat
 private constructor(public val mimeType: String, public val compressionQuality: Int?) {
 

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenInlineImage.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenInlineImage.kt
@@ -29,7 +29,6 @@ import kotlinx.serialization.Serializable
  * @property mimeType The IANA standard MIME type of the image data; either `"image/png"` or
  * `"image/jpeg"`; to request a different format, see [ImagenGenerationConfig.imageFormat].
  */
-@PublicPreviewAPI
 public class ImagenInlineImage
 internal constructor(
   public val data: ByteArray,

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenPersonFilterLevel.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenPersonFilterLevel.kt
@@ -17,7 +17,6 @@
 package com.google.firebase.ai.type
 
 /** A filter used to prevent images from containing depictions of children or people. */
-@PublicPreviewAPI
 public class ImagenPersonFilterLevel private constructor(internal val internalVal: String) {
   public companion object {
     /**

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenSafetyFilterLevel.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenSafetyFilterLevel.kt
@@ -17,7 +17,6 @@
 package com.google.firebase.ai.type
 
 /** Used for safety filtering. */
-@PublicPreviewAPI
 public class ImagenSafetyFilterLevel private constructor(internal val internalVal: String) {
   public companion object {
     /** Strongest filtering level, most strict blocking. */

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenSafetySettings.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenSafetySettings.kt
@@ -22,7 +22,6 @@ package com.google.firebase.ai.type
  * @param safetyFilterLevel Used to filter unsafe content.
  * @param personFilterLevel Used to filter images containing people.
  */
-@PublicPreviewAPI
 public class ImagenSafetySettings(
   internal val safetyFilterLevel: ImagenSafetyFilterLevel,
   internal val personFilterLevel: ImagenPersonFilterLevel,


### PR DESCRIPTION
The API surface is graduating to GA. It does not include imagen editing features. Those still require the opt-in annotation to be used.