### PR TITLE
[Infra] Ignore `release_report.md` from formatter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,7 @@ fun Project.applySpotless() {
     }
     format("styling") {
       target("src/**/*.md", "*.md", "docs/**/*.md")
-      targetExclude("**/third_party/**", "src/test/resources/**")
+      targetExclude("**/third_party/**", "src/test/resources/**", "release_report.md")
       prettier().config(mapOf("printWidth" to 100, "proseWrap" to "always"))
     }
   }


### PR DESCRIPTION
The file is auto generated and not intended to be consumed directly, thus formatting isn't a priority. Also, since it's generated during the release process, the only way of running the formatter would be checking out the branch, which is not necessary for any other step of the process.