### PR TITLE
[DataConnect] Fix changelog to list Enum work as unreleased

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Unreleased
 
 - [fixed] Addressed minor reference documentation issues (#7399)
+- [changed] Added classes `EnumValue` and `EnumValueSerializer`. These classes are identical to
+  those produced by the Data Connect code generator; however, a future version of the code generator
+  will start using these classes from the SDK rather than generating them.
+  ([#7153](https://github.com/firebase/firebase-android-sdk/pull/7153))
 
 # 17.0.1
 
@@ -8,11 +12,6 @@
 - [changed] Ignore unknown fields in response data instead of throwing a
   `DataConnectOperationException` with message "decoding data from the server's response failed: An
   unknown field for index -3" ([#7314](https://github.com/firebase/firebase-android-sdk/pull/7314))
-
-* [changed] Added classes `EnumValue` and `EnumValueSerializer`. These classes are identical to
-  those produced by the Data Connect code generator; however, a future version of the code generator
-  will start using these classes from the SDK rather than generating them.
-  ([#7153](https://github.com/firebase/firebase-android-sdk/pull/7153))
 
 # 17.0.0
 

--- a/firebase-dataconnect/gradle.properties
+++ b/firebase-dataconnect/gradle.properties
@@ -1,2 +1,2 @@
-version=17.0.2
+version=17.1.0
 latestReleasedVersion=17.0.1


### PR DESCRIPTION
The change #7153 was not part of the 17.0.1 release, so it should be part of the unreleased section. Also, since it introduces API changes, it requires a minor version bump.