### PR TITLE
firestore: test: fix expected message in ServerTimestampTest.java to include "Instant"

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ServerTimestampTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ServerTimestampTest.java
@@ -363,7 +363,7 @@ public class ServerTimestampTest {
     } catch (IllegalArgumentException e) {
       assertEquals(
           "Field timestamp is annotated with @ServerTimestamp but is class "
-              + "java.lang.String instead of Date or Timestamp.",
+              + "java.lang.String instead of Date, Timestamp, or Instant.",
           e.getMessage());
     }
   }


### PR DESCRIPTION
firestore: test: fix `ServerTimestampTest.java` that was accidentally broken by #6235

The test failure fixed by this PR is:

```
com.google.firebase.firestore.ServerTimestampTest > testPOJOWithWrongType[emulator-5554 - 12] FAILED
	org.junit.ComparisonFailure: expected:<...ring instead of Date[ or Timestamp].> but was:<...ring instead of Date[, Timestamp, or Instant].>
	at org.junit.Assert.assertEquals(Assert.java:117)
```

It simply updates the expected exception message as follows:

```
- "java.lang.String instead of Date or Timestamp.",
+ "java.lang.String instead of Date, Timestamp, or Instant.",
```