### PR TITLE
[Infra] Bump okhttp dependency from 3.12.13 to 4.12.0 

### DIFF
--- a/firebase-functions/CHANGELOG.md
+++ b/firebase-functions/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [changed] Bump dependency on OkHTTP to version 4.12.0.
+
 # 22.0.1
 
 - [changed] Bumped internal dependencies.

--- a/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseFunctions.kt
+++ b/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseFunctions.kt
@@ -38,10 +38,10 @@ import java.util.concurrent.Executor
 import javax.inject.Named
 import okhttp3.Call
 import okhttp3.Callback
-import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import org.json.JSONException
 import org.json.JSONObject
@@ -87,7 +87,7 @@ internal constructor(
       try {
         URL(regionOrCustomDomain)
         false
-      } catch (malformedURLException: MalformedURLException) {
+      } catch (_: MalformedURLException) {
         true
       }
     if (isRegion) {
@@ -227,8 +227,8 @@ internal constructor(
     val encoded = serializer.encode(data)
     body["data"] = encoded
     val bodyJSON = JSONObject(body)
-    val contentType = MediaType.parse("application/json")
-    val requestBody = RequestBody.create(contentType, bodyJSON.toString())
+    val contentType = "application/json".toMediaTypeOrNull()
+    val requestBody = bodyJSON.toString().toRequestBody(contentType)
     var request = Request.Builder().url(url).post(requestBody)
     if (context!!.authToken != null) {
       request = request.header("Authorization", "Bearer " + context.authToken)
@@ -268,8 +268,8 @@ internal constructor(
 
         @Throws(IOException::class)
         override fun onResponse(ignored: Call, response: Response) {
-          val code = fromHttpStatus(response.code())
-          val bodyAsString = response.body()!!.string()
+          val code = fromHttpStatus(response.code)
+          val bodyAsString = response.body!!.string()
           val exception = fromResponse(code, bodyAsString, serializer)
           if (exception != null) {
             tcs.setException(exception)

--- a/firebase-perf/CHANGELOG.md
+++ b/firebase-perf/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [changed] Bump dependency on OkHTTP to version 4.12.0.
+
 # 22.0.2
 
 - [changed] Bumped internal dependencies.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -166,7 +166,7 @@ maven-resolver-provider = { module = "org.apache.maven:maven-resolver-provider",
 maven-resolver-transport-file = { module = "org.apache.maven.resolver:maven-resolver-transport-file", version.ref = "mavenResolverApi" }
 maven-resolver-transport-http = { module = "org.apache.maven.resolver:maven-resolver-transport-http", version.ref = "mavenResolverApi" }
 maven-resolver-util = { module = "org.apache.maven.resolver:maven-resolver-util", version.ref = "mavenResolverApi" }
-okhttp = { module = "com.squareup.okhttp3:okhttp", version = "3.12.13" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version = "4.12.0" }
 org-json = { module = "org.json:json", version = "20240303" }
 play-services-cloud-messaging = { module = "com.google.android.gms:play-services-cloud-messaging", version.ref = "playServicesCloudMessaging" }
 play-services-stats = { module = "com.google.android.gms:play-services-stats", version.ref = "playServicesStats" }
@@ -222,13 +222,13 @@ wiremock-standalone = { module = "com.github.tomakehurst:wiremock-standalone", v
 kotest = ["kotest-runner", "kotest-assertions", "kotest-property", "kotest-property-arbs"]
 playservices = ["playservices-base", "playservices-basement", "playservices-tasks"]
 maven-resolver = [
-	"maven-resolver-api",
-	"maven-resolver-connector-basic",
-	"maven-resolver-impl",
-	"maven-resolver-provider",
-	"maven-resolver-transport-file",
-	"maven-resolver-transport-http",
-	"maven-resolver-util"
+    "maven-resolver-api",
+    "maven-resolver-connector-basic",
+    "maven-resolver-impl",
+    "maven-resolver-provider",
+    "maven-resolver-transport-file",
+    "maven-resolver-transport-http",
+    "maven-resolver-util"
 ]
 
 [plugins]


### PR DESCRIPTION
This change affects the Functions and Perf SDKs. We moved to the latest version of 4.x since it's the last one requiring kotlin < 2.0.21, which is the version we use. Versions in the 5.x branch require kotlin > 2.1.x