### PR TITLE
Make creating DataStore files more resilient

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [fixed] Made creating DataStore files more resilient [#7440]
+
 # 20.0.2
 
 - [changed] Bumped internal dependencies.

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsComponent.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsComponent.kt
@@ -150,9 +150,9 @@ internal interface FirebaseSessionsComponent {
             },
           scope = CoroutineScope(blockingDispatcher),
           produceFile = {
-            prepDataStoreFile(
-              appContext.dataStoreFile("firebaseSessions/sessionConfigsDataStore.data")
-            )
+            appContext.dataStoreFile("firebaseSessions/sessionConfigsDataStore.data").also {
+              prepDataStoreFile(it)
+            }
           },
         )
 
@@ -172,7 +172,9 @@ internal interface FirebaseSessionsComponent {
             },
           scope = CoroutineScope(blockingDispatcher),
           produceFile = {
-            prepDataStoreFile(appContext.dataStoreFile("firebaseSessions/sessionDataStore.data"))
+            appContext.dataStoreFile("firebaseSessions/sessionDataStore.data").also {
+              prepDataStoreFile(it)
+            }
           },
         )
 
@@ -211,8 +213,8 @@ internal interface FirebaseSessionsComponent {
        * Prepares the DataStore file by ensuring its parent directory exists. Throws [IOException]
        * if the directory could not be created, or if a conflicting file could not be removed.
        */
-      private fun prepDataStoreFile(dataStoreFile: File): File {
-        val parentDir = dataStoreFile.parentFile ?: return dataStoreFile
+      private fun prepDataStoreFile(dataStoreFile: File) {
+        val parentDir = dataStoreFile.parentFile ?: return
 
         // Check if something exists at the path, but isn't a directory
         if (parentDir.exists() && !parentDir.isDirectory) {
@@ -225,7 +227,7 @@ internal interface FirebaseSessionsComponent {
         }
 
         if (parentDir.isDirectory) {
-          return dataStoreFile
+          return
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -242,8 +244,6 @@ internal interface FirebaseSessionsComponent {
             }
           }
         }
-
-        return dataStoreFile
       }
     }
   }


### PR DESCRIPTION
Prepare the DataStore files directly in the Sessions SDK, instead of relying on DataStore to do it.

DataStore uses the old `File.mkdirs` api, which lacks any meaningful error messages. This will use the better `Files.createDirectories` api if available, which has proper error messages. 

Also renamed the parent directory from `aqs` to `firebaseSessions` to avoid any collision with any other libraries that might use DataStore and a 3 letter file name. If there is an unexpected file where the `firebaseSessions` directory should be, this will safely remove it.

Tested manually by creating the conflicting file and running the Sessions Test App on both old and new api levels.