### PR TITLE
[crash] Add missing entries to changelogs

### DIFF
--- a/firebase-crashlytics-ndk/CHANGELOG.md
+++ b/firebase-crashlytics-ndk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [changed] Bumped internal dependencies.
+
 # 20.0.2
 
 - [changed] Bumped internal dependencies.
@@ -107,7 +109,7 @@
 <aside class="caution">This version of <code>firebase-crashlytics-ndk</code> can
   cause a nondeterministic crash on startup. For more information, see
   <a href="https://github.com/firebase/firebase-android-sdk/issues/4683"
-	 class="external">GitHub Issue #4683</a>. We recommend updating to the
+     class="external">GitHub Issue #4683</a>. We recommend updating to the
   latest version (v18.3.5+) which contains a fix.
 </aside>
 
@@ -294,16 +296,16 @@ the new SDK.
 <aside class="note"><p>The changes in these release notes are only relevant to
   [crashlytics] NDK users who are upgrading from the legacy Fabric SDK.</p>
   <ul>
-	<li>If you're using [crashlytics] for NDK crash reporting in your app for
-	  the first time, follow the
-	  <a href="/docs/crashlytics/get-started-new-sdk?platform=android">getting
-	started instructions</a>.
-	</li>
-	<li>If you're upgrading from the legacy Fabric SDK to the
-	  [firebase_crashlytics] SDK for NDK crash reporting, follow the
-	  <a href="/docs/crashlytics/upgrade-sdk?platform=android">upgrade
-	instructions</a> to update your app with the following SDK changes.
-	</li>
+    <li>If you're using [crashlytics] for NDK crash reporting in your app for
+      the first time, follow the
+      <a href="/docs/crashlytics/get-started-new-sdk?platform=android">getting
+    started instructions</a>.
+    </li>
+    <li>If you're upgrading from the legacy Fabric SDK to the
+      [firebase_crashlytics] SDK for NDK crash reporting, follow the
+      <a href="/docs/crashlytics/upgrade-sdk?platform=android">upgrade
+    instructions</a> to update your app with the following SDK changes.
+    </li>
   </ul>
 </aside>
 

--- a/firebase-sessions/CHANGELOG.md
+++ b/firebase-sessions/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [fixed] Made creating DataStore files more resilient (#7440)
+
 # 3.0.2
 
 - [changed] Bumped internal dependencies.


### PR DESCRIPTION
The change introduced in #7440 will force the release of both  
crashlytics-ndk and sessions. This PR adds the corresponding entries  
to the changelog files.