### PR TITLE
Validate datastore directory

### DIFF
--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsComponent.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsComponent.kt
@@ -42,6 +42,7 @@ import com.google.firebase.sessions.settings.SessionsSettings
 import com.google.firebase.sessions.settings.SettingsCache
 import com.google.firebase.sessions.settings.SettingsCacheImpl
 import com.google.firebase.sessions.settings.SettingsProvider
+import com.google.firebase.sessions.util.validateParentOrThrow
 import dagger.Binds
 import dagger.BindsInstance
 import dagger.Component
@@ -146,7 +147,7 @@ internal interface FirebaseSessionsComponent {
               SessionConfigsSerializer.defaultValue
             },
           scope = CoroutineScope(blockingDispatcher),
-          produceFile = { appContext.dataStoreFile("aqs/sessionConfigsDataStore.data") },
+          produceFile = { appContext.dataStoreFile("aqs/sessionConfigsDataStore.data").validateParentOrThrow() },
         )
 
       @Provides
@@ -164,7 +165,7 @@ internal interface FirebaseSessionsComponent {
               sessionDataSerializer.defaultValue
             },
           scope = CoroutineScope(blockingDispatcher),
-          produceFile = { appContext.dataStoreFile("aqs/sessionDataStore.data") },
+          produceFile = { appContext.dataStoreFile("aqs/sessionDataStore.data").validateParentOrThrow() },
         )
 
       private fun <T> createDataStore(

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/util/FileUtils.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/util/FileUtils.kt
@@ -1,0 +1,10 @@
+package com.google.firebase.sessions.util
+
+import java.io.File
+
+internal fun File.validateParentOrThrow(): File = parentFile?.let {
+    if (!it.isDirectory) {
+        throw IllegalStateException("Expected ${it.path} to be a directory, but found a file")
+    }
+    this
+} ?: this

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/FileProducerTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/FileProducerTest.kt
@@ -1,0 +1,25 @@
+package com.google.firebase.sessions
+
+import androidx.datastore.dataStoreFile
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.firebase.sessions.testing.FakeFirebaseApp
+import com.google.firebase.sessions.util.validateParentOrThrow
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class FileProducerTest {
+
+    private val appContext = FakeFirebaseApp().firebaseApp.applicationContext
+
+    @Test
+    fun `sessionConfigsDataStore file path validation`() {
+        val aqsTextFile = File(appContext.filesDir, "datastore/aqs")
+        aqsTextFile.parentFile?.mkdirs()
+        aqsTextFile.writeText("This is aqs text file")
+
+        assertThrows(IllegalStateException::class.java) { appContext.dataStoreFile("aqs/sessionConfigsDataStore.data").validateParentOrThrow() }
+    }
+}


### PR DESCRIPTION
The provided log points to a java.io.IOException with the message "Unable to create parent directories," which is the root cause of the crash.



This particular error occurred in the host process app and was triggered by a failure to create the necessary directory structure for a Jetpack DataStore file. The file path in question is in the internal directory $filesDir/datastore/aqs/sessionConfigsDataStore.data.version.



1. FirebaseSessionsComponent is trying to provide a DataStore<SessionConfigs> dependency, this DataStore dependency is located under the file $filesDir/datastore/aqs/sessionConfigsDataStore.data.
<img width="962" height="469" alt="image" src="https://github.com/user-attachments/assets/faf4b2a7-75d2-4a21-889a-7407ff6720bb" />

2. However DataStore fails to validate the path $filesDir/datastore/aqs/sessionConfigsDataStore.data since $filesDir/datastore/aqs exists as a file without extension (not directory)
<img width="966" height="294" alt="image" src="https://github.com/user-attachments/assets/52cbda71-165f-4187-8db6-d4ca49cc3fe9" />

This check fails and throws an exception



3. The issue is 100% reproducible if we create a file $filesDir/datastore/aqs before this check
<img width="967" height="651" alt="image" src="https://github.com/user-attachments/assets/60ef4a2a-0c31-40fd-9df5-75ffad538e3d" />



The proposed fix is not suitable because there is a file called aqs which supposed to be the parent directory of our datastore:

Possible fix: Make AQS manually handle creating the parent directories for DataStore before initializing the two DataStores in https://github.com/firebase/firebase-android-sdk/blob/main/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsComponent.kt#L125 



Proposal:

1. Change directory folder name from $filesDir/datastore/aqs/ to something more oriented to firebase like $filesDir/datastore/firebase-aqs. This will reset values to default

2. Remove aqs from the DataSore file structure: $filesDir/datastore/sessionConfigsDataStore.data.version. This will reset values to default

3. Validate that the aqs file does not exist before initializing the two DataStores, throw and exception for host app.

