### PR TITLE
[Infra] Run spotless in post release clean up

### DIFF
--- a/.github/workflows/post_release_cleanup.yml
+++ b/.github/workflows/post_release_cleanup.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Run post release cleanup task
         run: |
           ./gradlew postReleaseCleanup
+          ./gradlew spotlessApply
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8


### PR DESCRIPTION
The post cleanup task modifies the \`CHANGELOG.md\` files of the released SDKs. To ensure the formatting remains valid, we should run the spotless task.