### PR TITLE
Fix CopyGoogleServicesPlugin for dataconnect

### DIFF
--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/CopyGoogleServicesPlugin.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/CopyGoogleServicesPlugin.kt
@@ -17,7 +17,6 @@
 package com.google.firebase.gradle.plugins
 
 import com.android.build.gradle.BaseExtension
-import com.android.build.gradle.internal.tasks.factory.dependsOn
 import java.io.File
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -38,18 +37,17 @@ import org.gradle.kotlin.dsl.register
 abstract class CopyGoogleServicesPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     if (File(project.projectDir, "google-services.json").exists()) {
-      project.logger.warn("Google Services file already present in project, skipping copy task")
-      return
-    }
+      project.logger.info("Google Services file already present in project, skipping copy task")
+    } else {
+      val sourcePath = getSourcePath(project)
+      val copyRootGoogleServices = registerCopyRootGoogleServicesTask(project, sourcePath)
 
-    val sourcePath = getSourcePath(project)
-    val copyRootGoogleServices = registerCopyRootGoogleServicesTask(project, sourcePath)
-
-    project.allprojects {
-      // fixes dependencies with gradle tasks that do not properly dependOn `preBuild`
-      tasks.configureEach {
-        if (name !== "copyRootGoogleServices") {
-          dependsOn(copyRootGoogleServices)
+      project.allprojects {
+        // fixes dependencies with gradle tasks that do not properly dependOn `preBuild`
+        tasks.configureEach {
+          if (name !== "copyRootGoogleServices") {
+            dependsOn(copyRootGoogleServices)
+          }
         }
       }
     }


### PR DESCRIPTION
This PR fixes a recent regression in `CopyGoogleServicesPlugin.kt` introduced by https://github.com/firebase/firebase-android-sdk/pull/7454 where the `com.google.gms.google-services` Gradle plugin was not being applied when a project already had its own `google-services.json` file. The fix ensures the plugin is always applied during test runs, which is required for firebase-dataconnect to compile its tests.

- Modified the early return logic to only skip the file copying task, not the entire plugin application
- Changed the log level from warning to info when a Google Services file already exists
- Ensured the Google Services plugin is applied regardless of whether `google-services.json` exists
- Removed an unused import

The build error fixed by this PR looks like this:

```
firebase-dataconnect/src/androidTest/.../FirebaseAppIdTestUtil.kt:23:68 Unresolved reference 'string'.
```