### PR TITLE
[EXPERIMENT] feat: Add video streaming support to Firebase AI Logic

### DIFF
--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveSession.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveSession.kt
@@ -215,8 +215,8 @@ internal constructor(
 
       scope = CoroutineScope(blockingDispatcher + childJob())
       val cameraManager =
-        context.getSystemService(android.content.Context.CAMERA_SERVICE) as
-          android.hardware.camera2.CameraManager
+        context.getSystemService(android.content.Context.CAMERA_SERVICE)
+          as android.hardware.camera2.CameraManager
       videoHelper = VideoHelper.build(cameraManager)
       videoHelper
         ?.start(cameraId)

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/VideoHelper.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/VideoHelper.kt
@@ -90,7 +90,9 @@ internal class VideoHelper(
 
     val characteristics = cameraManager.getCameraCharacteristics(cameraId)
     val streamConfigurationMap =
-      characteristics.get(android.hardware.camera2.CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)
+      characteristics.get(
+        android.hardware.camera2.CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP
+      )
     val outputSizes = streamConfigurationMap?.getOutputSizes(ImageFormat.JPEG)
     val size = outputSizes?.maxByOrNull { it.width * it.height } ?: return emptyFlow()
 


### PR DESCRIPTION
This change introduces video streaming capabilities to the Firebase AI Logic library, mirroring the existing audio streaming API.

Key features:
- A new `VideoHelper` class to manage camera input and frame capture.
- `startVideoConversation` and `stopVideoConversation` methods in `LiveSession` to control the video stream.
- Image frames are captured, scaled to a maximum dimension of 2048 pixels, and encoded as JPEGs before being sent to the backend.
- Image processing is offloaded to a background coroutine to avoid blocking the main thread and ensure smooth video streaming.
- Camera resolution selection is optimized to choose the largest available resolution for the best quality.
- Image scaling is performed efficiently using `inSampleSize` to minimize memory and CPU usage.