### PR TITLE
Use Device Encrypted storage context for locked state

### DIFF
--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsComponent.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsComponent.kt
@@ -150,9 +150,7 @@ internal interface FirebaseSessionsComponent {
             },
           scope = CoroutineScope(blockingDispatcher),
           produceFile = {
-            appContext.dataStoreFile("firebaseSessions/sessionConfigsDataStore.data").also {
-              prepDataStoreFile(it)
-            }
+            produceFile(appContext, "firebaseSessions/sessionConfigsDataStore.data")
           },
         )
 
@@ -172,11 +170,21 @@ internal interface FirebaseSessionsComponent {
             },
           scope = CoroutineScope(blockingDispatcher),
           produceFile = {
-            appContext.dataStoreFile("firebaseSessions/sessionDataStore.data").also {
-              prepDataStoreFile(it)
-            }
+            produceFile(appContext, "firebaseSessions/sessionDataStore.data")
           },
         )
+
+
+      private fun produceFile(appContext: Context, fileName: String): File {
+        val deContext = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+          appContext.createDeviceProtectedStorageContext()
+        } else {
+          appContext
+        }
+        return deContext.dataStoreFile(fileName).also {
+          prepDataStoreFile(it)
+        }
+      }
 
       private fun <T> createDataStore(
         serializer: Serializer<T>,


### PR DESCRIPTION
The app is attempting to create the `firebaseSessions` directory inside the app's private files directory, and the operating system is denying this request.

Android has security measures to protect app data when the device is locked. If the device has just been rebooted and the user has not unlocked it for the first time, the app's private storage is encrypted and completely inaccessible. This is known as `Credential Encrypted (CE) storage`.

The Problem: The code is likely running before the user has unlocked their device. This can happen if a background job, a broadcast receiver, or a foreground service starts immediately on boot. When `FirebaseSessionsComponent` is initialized under these conditions, it tries to create the `DataStore` file in an encrypted, inaccessible location. The file system denies the request, resulting in `AccessDeniedException`.

The Solution: Use Device Encrypted (DE) storage for data that must be accessed before the first user unlock. The `androidx.datastore` library has direct support for this. Instead of appContext.dataStoreFile(...), We need to use a context that is aware of `Device Encrypted` storage.

By using `createDeviceProtectedStorageContext()`, I am explicitly telling the system to place this file in a location that is available even when the device is locked. This is the standard and recommended way to handle file access required before the user unlocks their phone.