### PR TITLE
[AI] Fix kdoc

### DIFF
--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveSession.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveSession.kt
@@ -340,9 +340,9 @@ internal constructor(
    * For better performance, frames can also be sent at a lower rate than the video; even as low as
    * 1 frame per second.
    *
-   * @param video Encoded image data extracted from a frame of the video, used to update the
-   * model on the client's conversation, with the corresponding IANA standard MIME type of the video
-   * frame data (e.g., `image/png`, `image/jpeg`, etc.).
+   * @param video Encoded image data extracted from a frame of the video, used to update the model
+   * on the client's conversation, with the corresponding IANA standard MIME type of the video frame
+   * data (e.g., `image/png`, `image/jpeg`, etc.).
    */
   public suspend fun sendVideoRealtime(video: InlineData) {
     FirebaseAIException.catchAsync {


### PR DESCRIPTION
The kdoc for `LiveSession.sendVideoRealtime` referenced the type, `InlineData`, rather than the name of the param, `video`.