### PR TITLE
Return defensive copy of data in RemoteMessage

### DIFF
--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/RemoteMessage.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/RemoteMessage.java
@@ -35,8 +35,8 @@ import com.google.firebase.messaging.Constants.MessageNotificationKeys;
 import com.google.firebase.messaging.Constants.MessagePayloadKeys;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A remote Firebase Message.


### PR DESCRIPTION
b/438714642: This change ensures we do not return the internal map but rather a defensive copy of data. Makes our code less vulnerable.