### PR TITLE
Return copy of data in getData() method of RemoteMessage.java

### DIFF
--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/RemoteMessage.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/RemoteMessage.java
@@ -35,6 +35,7 @@ import com.google.firebase.messaging.Constants.MessageNotificationKeys;
 import com.google.firebase.messaging.Constants.MessagePayloadKeys;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -131,7 +132,7 @@ public final class RemoteMessage extends AbstractSafeParcelable {
     if (data == null) {
       data = MessagePayloadKeys.extractDeveloperDefinedPayload(bundle);
     }
-    return data;
+    return new HashMap<>(data);
   }
 
   /** @hide */


### PR DESCRIPTION
This change returns a copy of internal data in RemoteMessage, making our code less vulnerable. Tracking bug: b/438714642