### PR TITLE
Potential refactor

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfEarly.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfEarly.java
@@ -34,7 +34,7 @@ import java.util.concurrent.Executor;
 public class FirebasePerfEarly {
 
   public FirebasePerfEarly(
-      FirebaseApp app, @Nullable StartupTime startupTime, Executor uiExecutor) {
+      FirebaseApp app, @Nullable StartupTime startupTime, Executor uiExecutor, SessionManager sessionManager) {
     Context context = app.getApplicationContext();
 
     // Initialize ConfigResolver early for accessing device caching layer.
@@ -42,21 +42,22 @@ public class FirebasePerfEarly {
     configResolver.setApplicationContext(context);
 
     AppStateMonitor appStateMonitor = AppStateMonitor.getInstance();
+    appStateMonitor.setSessionManager(sessionManager);
     appStateMonitor.registerActivityLifecycleCallbacks(context);
     appStateMonitor.registerForAppColdStart(new FirebasePerformanceInitializer());
 
     if (startupTime != null) {
       AppStartTrace appStartTrace = AppStartTrace.getInstance();
+      appStartTrace.setSessionManager(sessionManager);
       appStartTrace.registerActivityLifecycleCallbacks(context);
       uiExecutor.execute(new AppStartTrace.StartFromBackgroundRunnable(appStartTrace));
     }
-
     // TODO: Bring back Firebase Sessions dependency to watch for updates to sessions.
 
     // In the case of cold start, we create a session and start collecting gauges as early as
     // possible.
     // There is code in SessionManager that prevents us from resetting the session twice in case
     // of app cold start.
-    SessionManager.getInstance().initializeGaugeCollection();
+    sessionManager.initializeGaugeCollection();
   }
 }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfRegistrar.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfRegistrar.java
@@ -26,11 +26,8 @@ import com.google.firebase.components.Dependency;
 import com.google.firebase.components.Qualified;
 import com.google.firebase.installations.FirebaseInstallationsApi;
 import com.google.firebase.perf.injection.components.DaggerFirebasePerformanceComponent;
-import com.google.firebase.perf.injection.components.DaggerSessionManagerComponent;
 import com.google.firebase.perf.injection.components.FirebasePerformanceComponent;
-import com.google.firebase.perf.injection.components.SessionManagerComponent;
 import com.google.firebase.perf.injection.modules.FirebasePerformanceModule;
-import com.google.firebase.perf.injection.modules.SessionManagerModule;
 import com.google.firebase.perf.session.SessionManager;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import com.google.firebase.remoteconfig.RemoteConfigComponent;
@@ -81,7 +78,9 @@ public class FirebasePerfRegistrar implements ComponentRegistrar {
                         container.get(uiExecutor),
                         container.get(SessionManager.class)))
             .build(),
-        Component.builder(SessionManager.class).factory(container -> new SessionManager()).build(),
+        Component.builder(SessionManager.class).factory(container ->
+                SessionManager.getInstance() //TODO: JR: Remove getInstance in subsequent phases
+        ).build(),
         /**
          * Fireperf SDK is lazily by {@link FirebasePerformanceInitializer} during {@link
          * com.google.firebase.perf.application.AppStateMonitor#onActivityResumed(Activity)}. we use

--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformance.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformance.java
@@ -140,6 +140,7 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
   private final Provider<RemoteConfigComponent> firebaseRemoteConfigProvider;
   private final FirebaseInstallationsApi firebaseInstallationsApi;
   private final Provider<TransportFactory> transportFactoryProvider;
+  private final SessionManager sessionManager;
 
   /**
    * Constructs the FirebasePerformance class and allows injecting dependencies.
@@ -168,6 +169,7 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
     this.firebaseRemoteConfigProvider = firebaseRemoteConfigProvider;
     this.firebaseInstallationsApi = firebaseInstallationsApi;
     this.transportFactoryProvider = transportFactoryProvider;
+    this.sessionManager = sessionManager;
 
     if (firebaseApp == null) {
       this.mPerformanceCollectionForceEnabledState = false;
@@ -177,7 +179,7 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
     }
 
     TransportManager.getInstance()
-        .initialize(firebaseApp, firebaseInstallationsApi, transportFactoryProvider);
+        .initialize(firebaseApp, firebaseInstallationsApi, transportFactoryProvider, sessionManager);
 
     Context appContext = firebaseApp.getApplicationContext();
     // TODO(b/110178816): Explore moving off of main thread.
@@ -187,7 +189,7 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
     this.configResolver.getRemoteConfigManager().setFirebaseRemoteConfigProvider(firebaseRemoteConfigProvider);
     this.configResolver.setMetadataBundle(mMetadataBundle);
     this.configResolver.setApplicationContext(appContext);
-    sessionManager.setApplicationContext(appContext);
+    this.sessionManager.setApplicationContext(appContext);
 
     mPerformanceCollectionForceEnabledState = configResolver.getIsPerformanceCollectionEnabled();
     if (logger.isLogcatEnabled() && isPerformanceCollectionEnabled()) {
@@ -423,7 +425,7 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
    */
   @NonNull
   public HttpMetric newHttpMetric(@NonNull String url, @NonNull @HttpMethod String httpMethod) {
-    return new HttpMetric(url, httpMethod, TransportManager.getInstance(), new Timer());
+    return new HttpMetric(url, httpMethod, TransportManager.getInstance(), new Timer(), sessionManager);
   }
 
   /**
@@ -436,7 +438,7 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
    */
   @NonNull
   public HttpMetric newHttpMetric(@NonNull URL url, @NonNull @HttpMethod String httpMethod) {
-    return new HttpMetric(url, httpMethod, TransportManager.getInstance(), new Timer());
+    return new HttpMetric(url, httpMethod, TransportManager.getInstance(), new Timer(), sessionManager);
   }
 
   /**

--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformance.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformance.java
@@ -151,7 +151,6 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
    * @param firebaseRemoteConfigProvider The {@link Provider} for FirebaseRemoteConfig instance.
    * @param firebaseInstallationsApi The FirebaseInstallationsApi instance.
    * @param transportFactoryProvider The {@link Provider} for the the {@link TransportFactory}.
-   * @param remoteConfigManager The RemoteConfigManager instance.
    * @param configResolver The ConfigResolver instance.
    * @param sessionManager The SessionManager instance.
    */
@@ -162,7 +161,6 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
       Provider<RemoteConfigComponent> firebaseRemoteConfigProvider,
       FirebaseInstallationsApi firebaseInstallationsApi,
       Provider<TransportFactory> transportFactoryProvider,
-      RemoteConfigManager remoteConfigManager,
       ConfigResolver configResolver,
       SessionManager sessionManager) {
 
@@ -185,8 +183,8 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
     // TODO(b/110178816): Explore moving off of main thread.
     mMetadataBundle = extractMetadata(appContext);
 
-    remoteConfigManager.setFirebaseRemoteConfigProvider(firebaseRemoteConfigProvider);
     this.configResolver = configResolver;
+    this.configResolver.getRemoteConfigManager().setFirebaseRemoteConfigProvider(firebaseRemoteConfigProvider);
     this.configResolver.setMetadataBundle(mMetadataBundle);
     this.configResolver.setApplicationContext(appContext);
     sessionManager.setApplicationContext(appContext);

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -80,6 +80,8 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
   private boolean isRegisteredForLifecycleCallbacks = false;
   private boolean isColdStart = true;
 
+  private SessionManager sessionManager;
+
   public static AppStateMonitor getInstance() {
     if (instance == null) {
       synchronized (AppStateMonitor.class) {
@@ -159,7 +161,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
       activityToRecorderMap.put(activity, recorder);
       if (activity instanceof FragmentActivity) {
         FragmentStateMonitor fragmentStateMonitor =
-            new FragmentStateMonitor(clock, transportManager, this, recorder);
+            new FragmentStateMonitor(clock, transportManager, this, recorder, sessionManager);
         activityToFragmentStateMonitorMap.put(activity, fragmentStateMonitor);
         FragmentActivity fragmentActivity = (FragmentActivity) activity;
         fragmentActivity
@@ -198,7 +200,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
       // Starts recording frame metrics for this activity.
       activityToRecorderMap.get(activity).start();
       // Start the Trace
-      Trace screenTrace = new Trace(getScreenTraceName(activity), transportManager, clock, this);
+      Trace screenTrace = new Trace(getScreenTraceName(activity), transportManager, clock, this, sessionManager);
       screenTrace.start();
       activityToScreenTraceMap.put(activity, screenTrace);
     }
@@ -379,7 +381,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
             .setName(name)
             .setClientStartTimeUs(startTime.getMicros())
             .setDurationUs(startTime.getDurationMicros(endTime))
-            .addPerfSessions(SessionManager.getInstance().perfSession().build());
+            .addPerfSessions(sessionManager.perfSession().build());
     // Atomically get mTsnsCount and set it to zero.
     int tsnsCount = this.tsnsCount.getAndSet(0);
     synchronized (metricToCountMap) {
@@ -462,5 +464,13 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
   @VisibleForTesting
   public void setIsColdStart(boolean isColdStart) {
     this.isColdStart = isColdStart;
+  }
+
+  public SessionManager getSessionManager() {
+    return sessionManager;
+  }
+
+  public void setSessionManager(SessionManager sessionManager) {
+    this.sessionManager = sessionManager;
   }
 }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -200,7 +200,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
       // Starts recording frame metrics for this activity.
       activityToRecorderMap.get(activity).start();
       // Start the Trace
-      Trace screenTrace = new Trace(getScreenTraceName(activity), transportManager, clock, this, sessionManager);
+      Trace screenTrace = new Trace(getScreenTraceName(activity), transportManager, clock, this);
       screenTrace.start();
       activityToScreenTraceMap.put(activity, screenTrace);
     }
@@ -416,6 +416,10 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
     return FrameMetricsRecorder.isFrameMetricsRecordingSupported();
   }
 
+  public SessionManager getSessionManager() {
+    return sessionManager;
+  }
+
   /** An interface to be implemented by subscribers which needs to receive app state update. */
   public static interface AppStateCallback {
     public void onUpdateAppState(ApplicationProcessState newState);
@@ -464,10 +468,6 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
   @VisibleForTesting
   public void setIsColdStart(boolean isColdStart) {
     this.isColdStart = isColdStart;
-  }
-
-  public SessionManager getSessionManager() {
-    return sessionManager;
   }
 
   public void setSessionManager(SessionManager sessionManager) {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/FragmentStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/FragmentStateMonitor.java
@@ -67,7 +67,7 @@ public class FragmentStateMonitor extends FragmentManager.FragmentLifecycleCallb
     // Start Fragment screen trace
     logger.debug("FragmentMonitor %s.onFragmentResumed", f.getClass().getSimpleName());
     Trace fragmentTrace =
-        new Trace(getFragmentScreenTraceName(f), transportManager, clock, appStateMonitor, sessionManager);
+        new Trace(getFragmentScreenTraceName(f), transportManager, clock, appStateMonitor);
     fragmentTrace.start();
 
     fragmentTrace.putAttribute(

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/FragmentStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/FragmentStateMonitor.java
@@ -21,6 +21,7 @@ import androidx.fragment.app.FragmentManager;
 import com.google.firebase.perf.logging.AndroidLogger;
 import com.google.firebase.perf.metrics.FrameMetricsCalculator.PerfFrameMetrics;
 import com.google.firebase.perf.metrics.Trace;
+import com.google.firebase.perf.session.SessionManager;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Constants;
@@ -33,6 +34,7 @@ public class FragmentStateMonitor extends FragmentManager.FragmentLifecycleCallb
   private final WeakHashMap<Fragment, Trace> fragmentToTraceMap = new WeakHashMap<>();
   private final Clock clock;
   private final TransportManager transportManager;
+  private final SessionManager sessionManager;
   private final AppStateMonitor appStateMonitor;
   private final FrameMetricsRecorder activityFramesRecorder;
 
@@ -40,11 +42,13 @@ public class FragmentStateMonitor extends FragmentManager.FragmentLifecycleCallb
       Clock clock,
       TransportManager transportManager,
       AppStateMonitor appStateMonitor,
-      FrameMetricsRecorder recorder) {
+      FrameMetricsRecorder recorder,
+      SessionManager sessionManager) {
     this.clock = clock;
     this.transportManager = transportManager;
     this.appStateMonitor = appStateMonitor;
     this.activityFramesRecorder = recorder;
+    this.sessionManager = sessionManager;
   }
 
   /**
@@ -63,7 +67,7 @@ public class FragmentStateMonitor extends FragmentManager.FragmentLifecycleCallb
     // Start Fragment screen trace
     logger.debug("FragmentMonitor %s.onFragmentResumed", f.getClass().getSimpleName());
     Trace fragmentTrace =
-        new Trace(getFragmentScreenTraceName(f), transportManager, clock, appStateMonitor);
+        new Trace(getFragmentScreenTraceName(f), transportManager, clock, appStateMonitor, sessionManager);
     fragmentTrace.start();
 
     fragmentTrace.putAttribute(

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
@@ -58,7 +58,7 @@ public class ConfigResolver {
   private static volatile ConfigResolver instance;
 
   // Configuration Storage objects.
-  private final RemoteConfigManager remoteConfigManager;
+  private RemoteConfigManager remoteConfigManager;
   private ImmutableBundle metadataBundle;
   private DeviceCacheManager deviceCacheManager;
 
@@ -75,7 +75,7 @@ public class ConfigResolver {
       @Nullable ImmutableBundle metadataBundle,
       @Nullable DeviceCacheManager deviceCacheManager) {
     this.remoteConfigManager =
-        remoteConfigManager == null ? RemoteConfigManager.getInstance() : remoteConfigManager;
+        remoteConfigManager != null ? remoteConfigManager : new RemoteConfigManager();
     this.metadataBundle = metadataBundle == null ? new ImmutableBundle() : metadataBundle;
     this.deviceCacheManager =
         deviceCacheManager == null ? DeviceCacheManager.getInstance() : deviceCacheManager;
@@ -96,6 +96,11 @@ public class ConfigResolver {
   @VisibleForTesting
   public void setDeviceCacheManager(DeviceCacheManager deviceCacheManager) {
     this.deviceCacheManager = deviceCacheManager;
+  }
+
+  @VisibleForTesting
+  public void setRemoteConfigManager(RemoteConfigManager remoteConfigManager) {
+    this.remoteConfigManager = remoteConfigManager;
   }
 
   public void setContentProviderContext(Context context) {
@@ -915,5 +920,9 @@ public class ConfigResolver {
 
   private boolean isSessionsMaxDurationMinutesValid(long maxDurationMin) {
     return maxDurationMin > 0;
+  }
+
+  public RemoteConfigManager getRemoteConfigManager() {
+    return remoteConfigManager;
   }
 }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/RemoteConfigManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/RemoteConfigManager.java
@@ -47,7 +47,6 @@ import java.util.concurrent.TimeUnit;
 public class RemoteConfigManager {
 
   private static final AndroidLogger logger = AndroidLogger.getInstance();
-  private static final RemoteConfigManager instance = new RemoteConfigManager();
   private static final String FIREPERF_FRC_NAMESPACE_NAME = "fireperf";
   private static final long TIME_AFTER_WHICH_A_FETCH_IS_CONSIDERED_STALE_MS =
       TimeUnit.HOURS.toMillis(12);
@@ -67,7 +66,7 @@ public class RemoteConfigManager {
 
   // TODO(b/258263016): Migrate to go/firebase-android-executors
   @SuppressLint("ThreadPoolCreation")
-  private RemoteConfigManager() {
+  public RemoteConfigManager() {
     this(
         DeviceCacheManager.getInstance(),
         new ThreadPoolExecutor(
@@ -94,11 +93,6 @@ public class RemoteConfigManager {
             ? new ConcurrentHashMap<>()
             : new ConcurrentHashMap<>(firebaseRemoteConfig.getAll());
     this.remoteConfigFetchDelayInMs = remoteConfigFetchDelayInMs;
-  }
-
-  /** Gets the singleton instance. */
-  public static RemoteConfigManager getInstance() {
-    return instance;
   }
 
   /**

--- a/firebase-perf/src/main/java/com/google/firebase/perf/injection/components/SessionManagerComponent.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/injection/components/SessionManagerComponent.java
@@ -1,0 +1,17 @@
+package com.google.firebase.perf.injection.components;
+
+import androidx.annotation.NonNull;
+
+import com.google.firebase.perf.injection.modules.SessionManagerModule;
+import com.google.firebase.perf.session.SessionManager;
+
+import javax.inject.Singleton;
+
+import dagger.Component;
+
+@Component(modules = {SessionManagerModule.class})
+@Singleton
+public interface SessionManagerComponent {
+  @NonNull
+  SessionManager getSessionManager();
+}

--- a/firebase-perf/src/main/java/com/google/firebase/perf/injection/modules/FirebasePerformanceModule.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/injection/modules/FirebasePerformanceModule.java
@@ -67,11 +67,6 @@ public class FirebasePerformanceModule {
   }
 
   @Provides
-  RemoteConfigManager providesRemoteConfigManager() {
-    return RemoteConfigManager.getInstance();
-  }
-
-  @Provides
   ConfigResolver providesConfigResolver() {
     return ConfigResolver.getInstance();
   }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/injection/modules/FirebasePerformanceModule.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/injection/modules/FirebasePerformanceModule.java
@@ -34,16 +34,19 @@ public class FirebasePerformanceModule {
   private final FirebaseInstallationsApi firebaseInstallations;
   private final Provider<RemoteConfigComponent> remoteConfigComponentProvider;
   private final Provider<TransportFactory> transportFactoryProvider;
+  private final SessionManager sessionManager;
 
   public FirebasePerformanceModule(
       @NonNull FirebaseApp firebaseApp,
       @NonNull FirebaseInstallationsApi firebaseInstallations,
       @NonNull Provider<RemoteConfigComponent> remoteConfigComponentProvider,
-      @NonNull Provider<TransportFactory> transportFactoryProvider) {
+      @NonNull Provider<TransportFactory> transportFactoryProvider,
+      @NonNull SessionManager sessionManager) {
     this.firebaseApp = firebaseApp;
     this.firebaseInstallations = firebaseInstallations;
     this.remoteConfigComponentProvider = remoteConfigComponentProvider;
     this.transportFactoryProvider = transportFactoryProvider;
+    this.sessionManager = sessionManager;
   }
 
   @Provides
@@ -73,6 +76,6 @@ public class FirebasePerformanceModule {
 
   @Provides
   SessionManager providesSessionManager() {
-    return SessionManager.getInstance();
+    return sessionManager;
   }
 }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/injection/modules/SessionManagerModule.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/injection/modules/SessionManagerModule.java
@@ -1,0 +1,22 @@
+package com.google.firebase.perf.injection.modules;
+
+import androidx.annotation.NonNull;
+
+import com.google.firebase.perf.session.SessionManager;
+
+import dagger.Module;
+import dagger.Provides;
+
+@Module
+public class SessionManagerModule {
+  private final SessionManager sessionManager;
+
+  public SessionManagerModule(@NonNull SessionManager sessionManager) {
+    this.sessionManager = sessionManager;
+  }
+
+  @Provides
+  SessionManager providesSessionManager() {
+    return sessionManager;
+  }
+}

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -92,6 +92,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, LifecycleObser
   private final ConfigResolver configResolver;
   private final TraceMetric.Builder experimentTtid;
   private Context appContext;
+  private SessionManager sessionManager;
 
   /**
    * The first time onCreate() of any activity is called, the activity is saved as launchActivity.
@@ -413,7 +414,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, LifecycleObser
     appStartActivity = new WeakReference<Activity>(activity);
 
     onResumeTime = clock.getTime();
-    this.startSession = SessionManager.getInstance().perfSession();
+    this.startSession = sessionManager.perfSession();
     AndroidLogger.getInstance()
         .debug(
             "onResume(): "
@@ -570,6 +571,10 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, LifecycleObser
     }
 
     return false;
+  }
+
+  public void setSessionManager(SessionManager sessionManager) {
+    this.sessionManager = sessionManager;
   }
 
   /**

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/HttpMetric.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/HttpMetric.java
@@ -22,6 +22,7 @@ import com.google.firebase.perf.FirebasePerformance.HttpMethod;
 import com.google.firebase.perf.FirebasePerformanceAttributable;
 import com.google.firebase.perf.config.ConfigResolver;
 import com.google.firebase.perf.logging.AndroidLogger;
+import com.google.firebase.perf.session.SessionManager;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.util.Constants;
 import com.google.firebase.perf.util.Timer;
@@ -52,12 +53,12 @@ public class HttpMetric implements FirebasePerformanceAttributable {
    * @hide
    */
   public HttpMetric(
-      String url, @HttpMethod String httpMethod, TransportManager transportManager, Timer timer) {
+      String url, @HttpMethod String httpMethod, TransportManager transportManager, Timer timer, SessionManager sessionManager) {
     customAttributesMap = new ConcurrentHashMap<>();
     this.timer = timer;
 
     networkMetricBuilder =
-        NetworkRequestMetricBuilder.builder(transportManager).setUrl(url).setHttpMethod(httpMethod);
+        NetworkRequestMetricBuilder.builder(transportManager, sessionManager).setUrl(url).setHttpMethod(httpMethod);
     networkMetricBuilder.setManualNetworkRequestMetric();
 
     if (!ConfigResolver.getInstance().isPerformanceMonitoringEnabled()) {
@@ -72,8 +73,8 @@ public class HttpMetric implements FirebasePerformanceAttributable {
    * @hide
    */
   public HttpMetric(
-      URL url, @HttpMethod String httpMethod, TransportManager transportManager, Timer timer) {
-    this(url.toString(), httpMethod, transportManager, timer);
+      URL url, @HttpMethod String httpMethod, TransportManager transportManager, Timer timer, SessionManager sessionManager) {
+    this(url.toString(), httpMethod, transportManager, timer, sessionManager);
   }
 
   /**

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/Trace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/Trace.java
@@ -181,11 +181,12 @@ public class Trace extends AppStateUpdateHandler
     this.transportManager = transportManager;
     sessions = Collections.synchronizedList(new ArrayList<>());
     this.gaugeManager = gaugeManager;
-    this.sessionManager = transportManager.getSessionManager();
+    this.sessionManager = appStateMonitor.getSessionManager();
   }
 
   private Trace(@NonNull Parcel in, boolean isDataOnly) {
     super(isDataOnly ? null : AppStateMonitor.getInstance());
+    this.sessionManager = AppStateMonitor.getInstance().getSessionManager();
     parent = in.readParcelable(Trace.class.getClassLoader());
     name = in.readString();
     subtraces = new ArrayList<>();
@@ -207,7 +208,6 @@ public class Trace extends AppStateUpdateHandler
       clock = new Clock();
       gaugeManager = GaugeManager.getInstance();
     }
-    sessionManager = TransportManager.getInstance().getSessionManager();
   }
 
   /** Starts this trace. */
@@ -437,8 +437,7 @@ public class Trace extends AppStateUpdateHandler
       @NonNull String traceName,
       @NonNull TransportManager transportManager,
       @NonNull Clock clock,
-      @NonNull AppStateMonitor appStateMonitor,
-      @NonNull SessionManager sessionManager) {
+      @NonNull AppStateMonitor appStateMonitor) {
     Trace trace = traceNameToTraceMap.get(traceName);
     if (trace == null) {
       trace =

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/Trace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/Trace.java
@@ -24,6 +24,8 @@ import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+
+import com.google.firebase.perf.FirebasePerformance;
 import com.google.firebase.perf.FirebasePerformanceAttributable;
 import com.google.firebase.perf.application.AppStateMonitor;
 import com.google.firebase.perf.application.AppStateUpdateHandler;
@@ -57,6 +59,7 @@ public class Trace extends AppStateUpdateHandler
 
   private final Trace parent;
   private final GaugeManager gaugeManager;
+  private final SessionManager sessionManager;
   private final String name;
 
   private final Map<String, Counter> counterNameToCounterMap;
@@ -138,6 +141,7 @@ public class Trace extends AppStateUpdateHandler
     transportManager = parent.transportManager;
     sessions = Collections.synchronizedList(new ArrayList<>());
     gaugeManager = this.parent.gaugeManager;
+    sessionManager = this.parent.sessionManager;
   }
 
   /**
@@ -150,7 +154,8 @@ public class Trace extends AppStateUpdateHandler
       @NonNull String name,
       @NonNull TransportManager transportManager,
       @NonNull Clock clock,
-      @NonNull AppStateMonitor appStateMonitor) {
+      @NonNull AppStateMonitor appStateMonitor
+  ) {
     this(name, transportManager, clock, appStateMonitor, GaugeManager.getInstance());
   }
 
@@ -176,6 +181,7 @@ public class Trace extends AppStateUpdateHandler
     this.transportManager = transportManager;
     sessions = Collections.synchronizedList(new ArrayList<>());
     this.gaugeManager = gaugeManager;
+    this.sessionManager = transportManager.getSessionManager();
   }
 
   private Trace(@NonNull Parcel in, boolean isDataOnly) {
@@ -201,6 +207,7 @@ public class Trace extends AppStateUpdateHandler
       clock = new Clock();
       gaugeManager = GaugeManager.getInstance();
     }
+    sessionManager = TransportManager.getInstance().getSessionManager();
   }
 
   /** Starts this trace. */
@@ -227,9 +234,8 @@ public class Trace extends AppStateUpdateHandler
 
     registerForAppState();
 
-    SessionManager sessionManager = SessionManager.getInstance();
     PerfSession perfSession = sessionManager.perfSession();
-    SessionManager.getInstance().registerForSessionUpdates(sessionAwareObject);
+    sessionManager.registerForSessionUpdates(sessionAwareObject);
 
     updateSession(perfSession);
 
@@ -250,7 +256,7 @@ public class Trace extends AppStateUpdateHandler
       return;
     }
 
-    SessionManager.getInstance().unregisterForSessionUpdates(sessionAwareObject);
+    sessionManager.unregisterForSessionUpdates(sessionAwareObject);
 
     unregisterForAppState();
     endTime = clock.getTime();
@@ -259,9 +265,8 @@ public class Trace extends AppStateUpdateHandler
       if (!name.isEmpty()) {
         transportManager.log(new TraceMetricBuilder(this).build(), getAppState());
 
-        if (SessionManager.getInstance().perfSession().isGaugeAndEventCollectionEnabled()) {
-          gaugeManager.collectGaugeMetricOnce(
-              SessionManager.getInstance().perfSession().getTimer());
+        if (sessionManager.perfSession().isGaugeAndEventCollectionEnabled()) {
+          gaugeManager.collectGaugeMetricOnce(sessionManager.perfSession().getTimer());
         }
       } else {
         logger.error("Trace name is empty, no log is sent to server");
@@ -432,7 +437,8 @@ public class Trace extends AppStateUpdateHandler
       @NonNull String traceName,
       @NonNull TransportManager transportManager,
       @NonNull Clock clock,
-      @NonNull AppStateMonitor appStateMonitor) {
+      @NonNull AppStateMonitor appStateMonitor,
+      @NonNull SessionManager sessionManager) {
     Trace trace = traceNameToTraceMap.get(traceName);
     if (trace == null) {
       trace =

--- a/firebase-perf/src/main/java/com/google/firebase/perf/network/FirebasePerfHttpClient.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/network/FirebasePerfHttpClient.java
@@ -176,7 +176,7 @@ public class FirebasePerfHttpClient {
       final TransportManager transportManager)
       throws IOException {
     HttpResponse response = null;
-    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager);
+    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, transportManager.getSessionManager());
     try {
       builder.setUrl(request.getURI().toString()).setHttpMethod(request.getMethod());
       Long requestContentLength =
@@ -224,7 +224,7 @@ public class FirebasePerfHttpClient {
       final TransportManager transportManager)
       throws IOException {
     HttpResponse response = null;
-    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager);
+    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, transportManager.getSessionManager());
     try {
       builder.setUrl(request.getURI().toString()).setHttpMethod(request.getMethod());
       Long requestContentLength =
@@ -272,7 +272,7 @@ public class FirebasePerfHttpClient {
       final Timer timer,
       final TransportManager transportManager)
       throws IOException {
-    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager);
+    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, transportManager.getSessionManager());
     try {
       builder.setUrl(request.getURI().toString()).setHttpMethod(request.getMethod());
       Long requestContentLength =
@@ -309,7 +309,7 @@ public class FirebasePerfHttpClient {
       final Timer timer,
       final TransportManager transportManager)
       throws IOException {
-    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager);
+    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, transportManager.getSessionManager());
     try {
       builder.setUrl(request.getURI().toString()).setHttpMethod(request.getMethod());
       Long requestContentLength =
@@ -347,7 +347,7 @@ public class FirebasePerfHttpClient {
       final TransportManager transportManager)
       throws IOException {
     HttpResponse response = null;
-    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager);
+    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, transportManager.getSessionManager());
     try {
       builder
           .setUrl(target.toURI() + request.getRequestLine().getUri())
@@ -399,7 +399,7 @@ public class FirebasePerfHttpClient {
       final TransportManager transportManager)
       throws IOException {
     HttpResponse response = null;
-    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager);
+    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, transportManager.getSessionManager());
     try {
       builder
           .setUrl(target.toURI() + request.getRequestLine().getUri())
@@ -450,7 +450,7 @@ public class FirebasePerfHttpClient {
       final Timer timer,
       final TransportManager transportManager)
       throws IOException {
-    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager);
+    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, transportManager.getSessionManager());
     try {
       builder
           .setUrl(target.toURI() + request.getRequestLine().getUri())
@@ -492,7 +492,7 @@ public class FirebasePerfHttpClient {
       final Timer timer,
       final TransportManager transportManager)
       throws IOException {
-    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager);
+    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, transportManager.getSessionManager());
     try {
       builder
           .setUrl(target.toURI() + request.getRequestLine().getUri())

--- a/firebase-perf/src/main/java/com/google/firebase/perf/network/FirebasePerfHttpClient.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/network/FirebasePerfHttpClient.java
@@ -15,7 +15,10 @@
 package com.google.firebase.perf.network;
 
 import androidx.annotation.Keep;
+
+import com.google.firebase.perf.FirebasePerformance;
 import com.google.firebase.perf.metrics.NetworkRequestMetricBuilder;
+import com.google.firebase.perf.session.SessionManager;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.util.Timer;
 import java.io.IOException;
@@ -45,7 +48,7 @@ public class FirebasePerfHttpClient {
   @Keep
   public static HttpResponse execute(final HttpClient client, final HttpUriRequest request)
       throws IOException {
-    return execute(client, request, new Timer(), TransportManager.getInstance());
+    return execute(client, request, new Timer(), TransportManager.getInstance(), SessionManager.getInstance());
   }
 
   /**
@@ -58,7 +61,7 @@ public class FirebasePerfHttpClient {
   public static HttpResponse execute(
       final HttpClient client, final HttpUriRequest request, final HttpContext context)
       throws IOException {
-    return execute(client, request, context, new Timer(), TransportManager.getInstance());
+    return execute(client, request, context, new Timer(), TransportManager.getInstance(), SessionManager.getInstance());
   }
 
   /**
@@ -73,7 +76,7 @@ public class FirebasePerfHttpClient {
       final HttpUriRequest request,
       final ResponseHandler<T> responseHandler)
       throws IOException {
-    return execute(client, request, responseHandler, new Timer(), TransportManager.getInstance());
+    return execute(client, request, responseHandler, new Timer(), TransportManager.getInstance(), SessionManager.getInstance());
   }
 
   /**
@@ -90,7 +93,7 @@ public class FirebasePerfHttpClient {
       final HttpContext context)
       throws IOException {
     return execute(
-        client, request, responseHandler, context, new Timer(), TransportManager.getInstance());
+        client, request, responseHandler, context, new Timer(), TransportManager.getInstance(), SessionManager.getInstance());
   }
 
   /**
@@ -103,7 +106,7 @@ public class FirebasePerfHttpClient {
   public static HttpResponse execute(
       final HttpClient client, final HttpHost target, final HttpRequest request)
       throws IOException {
-    return execute(client, target, request, new Timer(), TransportManager.getInstance());
+    return execute(client, target, request, new Timer(), TransportManager.getInstance(), SessionManager.getInstance());
   }
 
   /**
@@ -119,7 +122,7 @@ public class FirebasePerfHttpClient {
       final HttpRequest request,
       final HttpContext context)
       throws IOException {
-    return execute(client, target, request, context, new Timer(), TransportManager.getInstance());
+    return execute(client, target, request, context, new Timer(), TransportManager.getInstance(), SessionManager.getInstance());
   }
 
   /**
@@ -136,7 +139,7 @@ public class FirebasePerfHttpClient {
       final ResponseHandler<? extends T> responseHandler)
       throws IOException {
     return execute(
-        client, target, request, responseHandler, new Timer(), TransportManager.getInstance());
+        client, target, request, responseHandler, new Timer(), TransportManager.getInstance(), SessionManager.getInstance());
   }
 
   /**
@@ -160,7 +163,8 @@ public class FirebasePerfHttpClient {
         responseHandler,
         context,
         new Timer(),
-        TransportManager.getInstance());
+        TransportManager.getInstance(),
+        SessionManager.getInstance());
   }
 
   /**
@@ -173,10 +177,11 @@ public class FirebasePerfHttpClient {
       final HttpClient client,
       final HttpUriRequest request,
       final Timer timer,
-      final TransportManager transportManager)
+      final TransportManager transportManager,
+      final SessionManager sessionManager)
       throws IOException {
     HttpResponse response = null;
-    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, transportManager.getSessionManager());
+    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, sessionManager);
     try {
       builder.setUrl(request.getURI().toString()).setHttpMethod(request.getMethod());
       Long requestContentLength =
@@ -221,10 +226,11 @@ public class FirebasePerfHttpClient {
       final HttpUriRequest request,
       final HttpContext context,
       final Timer timer,
-      final TransportManager transportManager)
+      final TransportManager transportManager,
+      final SessionManager sessionManager)
       throws IOException {
     HttpResponse response = null;
-    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, transportManager.getSessionManager());
+    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, sessionManager);
     try {
       builder.setUrl(request.getURI().toString()).setHttpMethod(request.getMethod());
       Long requestContentLength =
@@ -270,9 +276,10 @@ public class FirebasePerfHttpClient {
       final HttpUriRequest request,
       final ResponseHandler<T> responseHandler,
       final Timer timer,
-      final TransportManager transportManager)
+      final TransportManager transportManager,
+      final SessionManager sessionManager)
       throws IOException {
-    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, transportManager.getSessionManager());
+    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, sessionManager);
     try {
       builder.setUrl(request.getURI().toString()).setHttpMethod(request.getMethod());
       Long requestContentLength =
@@ -307,9 +314,10 @@ public class FirebasePerfHttpClient {
       final ResponseHandler<T> responseHandler,
       final HttpContext context,
       final Timer timer,
-      final TransportManager transportManager)
+      final TransportManager transportManager,
+      final SessionManager sessionManager)
       throws IOException {
-    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, transportManager.getSessionManager());
+    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, sessionManager);
     try {
       builder.setUrl(request.getURI().toString()).setHttpMethod(request.getMethod());
       Long requestContentLength =
@@ -344,10 +352,11 @@ public class FirebasePerfHttpClient {
       final HttpHost target,
       final HttpRequest request,
       final Timer timer,
-      final TransportManager transportManager)
+      final TransportManager transportManager,
+      final SessionManager sessionManager)
       throws IOException {
     HttpResponse response = null;
-    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, transportManager.getSessionManager());
+    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, sessionManager);
     try {
       builder
           .setUrl(target.toURI() + request.getRequestLine().getUri())
@@ -396,10 +405,11 @@ public class FirebasePerfHttpClient {
       final HttpRequest request,
       final HttpContext context,
       final Timer timer,
-      final TransportManager transportManager)
+      final TransportManager transportManager,
+      final SessionManager sessionManager)
       throws IOException {
     HttpResponse response = null;
-    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, transportManager.getSessionManager());
+    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, sessionManager);
     try {
       builder
           .setUrl(target.toURI() + request.getRequestLine().getUri())
@@ -448,9 +458,10 @@ public class FirebasePerfHttpClient {
       final HttpRequest request,
       final ResponseHandler<? extends T> responseHandler,
       final Timer timer,
-      final TransportManager transportManager)
+      final TransportManager transportManager,
+      final SessionManager sessionManager)
       throws IOException {
-    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, transportManager.getSessionManager());
+    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, sessionManager);
     try {
       builder
           .setUrl(target.toURI() + request.getRequestLine().getUri())
@@ -490,9 +501,10 @@ public class FirebasePerfHttpClient {
       final ResponseHandler<? extends T> responseHandler,
       final HttpContext context,
       final Timer timer,
-      final TransportManager transportManager)
+      final TransportManager transportManager,
+      final SessionManager sessionManager)
       throws IOException {
-    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, transportManager.getSessionManager());
+    NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager, sessionManager);
     try {
       builder
           .setUrl(target.toURI() + request.getRequestLine().getUri())

--- a/firebase-perf/src/main/java/com/google/firebase/perf/network/FirebasePerfOkHttpClient.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/network/FirebasePerfOkHttpClient.java
@@ -16,6 +16,7 @@ package com.google.firebase.perf.network;
 
 import androidx.annotation.Keep;
 import com.google.firebase.perf.metrics.NetworkRequestMetricBuilder;
+import com.google.firebase.perf.session.SessionManager;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.util.Timer;
 import java.io.IOException;
@@ -37,7 +38,7 @@ public class FirebasePerfOkHttpClient {
   public static Response execute(final Call call) throws IOException {
     final Response response;
     NetworkRequestMetricBuilder builder =
-        NetworkRequestMetricBuilder.builder(TransportManager.getInstance());
+        NetworkRequestMetricBuilder.builder(TransportManager.getInstance(), /*, sessionManager = */ null);
     Timer timer = new Timer();
     long startTimeMicros = timer.getMicros();
     try {
@@ -65,12 +66,12 @@ public class FirebasePerfOkHttpClient {
   }
 
   @Keep
-  public static void enqueue(final Call call, final Callback callback) {
+  public static void enqueue(final Call call, final Callback callback, final SessionManager sessionManager) {
     Timer timer = new Timer();
     long startTime = timer.getMicros();
     call.enqueue(
         new InstrumentOkHttpEnqueueCallback(
-            callback, TransportManager.getInstance(), timer, startTime));
+            callback, TransportManager.getInstance(), timer, startTime, sessionManager));
   }
 
   static void sendNetworkMetric(

--- a/firebase-perf/src/main/java/com/google/firebase/perf/network/InstrumentOkHttpEnqueueCallback.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/network/InstrumentOkHttpEnqueueCallback.java
@@ -15,6 +15,7 @@
 package com.google.firebase.perf.network;
 
 import com.google.firebase.perf.metrics.NetworkRequestMetricBuilder;
+import com.google.firebase.perf.session.SessionManager;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.util.Timer;
 import java.io.IOException;
@@ -37,9 +38,10 @@ public class InstrumentOkHttpEnqueueCallback implements Callback {
       final Callback callback,
       final TransportManager transportManager,
       Timer timer,
-      long startTime) {
+      long startTime,
+      final SessionManager sessionManager) {
     this.callback = callback;
-    networkMetricBuilder = NetworkRequestMetricBuilder.builder(transportManager);
+    networkMetricBuilder = NetworkRequestMetricBuilder.builder(transportManager, sessionManager);
     startTimeMicros = startTime;
     this.timer = timer;
   }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
@@ -37,9 +37,6 @@ import java.util.concurrent.Future;
 @Keep // Needed because of b/117526359.
 public class SessionManager extends AppStateUpdateHandler {
 
-  @SuppressLint("StaticFieldLeak")
-  private static final SessionManager instance = new SessionManager();
-
   private final GaugeManager gaugeManager;
   private final AppStateMonitor appStateMonitor;
   private final Set<WeakReference<SessionAwareObject>> clients = new HashSet<>();
@@ -47,17 +44,12 @@ public class SessionManager extends AppStateUpdateHandler {
   private PerfSession perfSession;
   private Future syncInitFuture;
 
-  /** Returns the singleton instance of SessionManager. */
-  public static SessionManager getInstance() {
-    return instance;
-  }
-
   /** Returns the currently active PerfSession. */
   public final PerfSession perfSession() {
     return perfSession;
   }
 
-  private SessionManager() {
+  public SessionManager() {
     // Generate a new sessionID for every cold start.
     this(
         GaugeManager.getInstance(),

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
@@ -36,7 +36,8 @@ import java.util.concurrent.Future;
 /** Session manager to generate sessionIDs and broadcast to the application. */
 @Keep // Needed because of b/117526359.
 public class SessionManager extends AppStateUpdateHandler {
-
+  @SuppressLint("StaticFieldLeak")
+  private static final SessionManager instance = new SessionManager();
   private final GaugeManager gaugeManager;
   private final AppStateMonitor appStateMonitor;
   private final Set<WeakReference<SessionAwareObject>> clients = new HashSet<>();
@@ -49,7 +50,12 @@ public class SessionManager extends AppStateUpdateHandler {
     return perfSession;
   }
 
-  public SessionManager() {
+  /** Returns the singleton instance of SessionManager. */
+  public static SessionManager getInstance() {
+    return instance;
+  }
+
+  private SessionManager() {
     // Generate a new sessionID for every cold start.
     this(
         GaugeManager.getInstance(),

--- a/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
@@ -114,6 +114,7 @@ public class TransportManager implements AppStateCallback {
   @Nullable private FirebasePerformance firebasePerformance;
   private FirebaseInstallationsApi firebaseInstallationsApi;
   private Provider<TransportFactory> flgTransportFactoryProvider;
+  private SessionManager sessionManager;
   private FlgTransport flgTransport;
   private ExecutorService executorService;
   private Context appContext;
@@ -197,12 +198,14 @@ public class TransportManager implements AppStateCallback {
   public void initialize(
       @NonNull FirebaseApp firebaseApp,
       @NonNull FirebaseInstallationsApi firebaseInstallationsApi,
-      @NonNull Provider<TransportFactory> flgTransportFactoryProvider) {
+      @NonNull Provider<TransportFactory> flgTransportFactoryProvider,
+      @NonNull SessionManager sessionManager) {
 
     this.firebaseApp = firebaseApp;
     projectId = firebaseApp.getOptions().getProjectId();
     this.firebaseInstallationsApi = firebaseInstallationsApi;
     this.flgTransportFactoryProvider = flgTransportFactoryProvider;
+    this.sessionManager = sessionManager;
 
     // Run initialization in background thread
     this.executorService.execute(this::syncInit);
@@ -382,7 +385,7 @@ public class TransportManager implements AppStateCallback {
       dispatchLog(perfMetric);
 
       // Check if the session is expired. If so, stop gauge collection.
-      SessionManager.getInstance().stopGaugeCollectionIfSessionRunningTooLong();
+      sessionManager.stopGaugeCollectionIfSessionRunningTooLong();
     }
   }
 
@@ -662,6 +665,9 @@ public class TransportManager implements AppStateCallback {
     }
   }
 
+  public SessionManager getSessionManager() {
+    return sessionManager;
+  }
   // endregion
 
   // region Visible for Testing

--- a/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
@@ -664,10 +664,6 @@ public class TransportManager implements AppStateCallback {
       return ConsoleUrlGenerator.generateCustomTraceUrl(projectId, packageName, traceName);
     }
   }
-
-  public SessionManager getSessionManager() {
-    return sessionManager;
-  }
   // endregion
 
   // region Visible for Testing

--- a/firebase-perf/src/test/java/com/google/firebase/perf/FirebasePerfRegistrarTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/FirebasePerfRegistrarTest.java
@@ -24,6 +24,7 @@ import com.google.firebase.components.Component;
 import com.google.firebase.components.Dependency;
 import com.google.firebase.components.Qualified;
 import com.google.firebase.installations.FirebaseInstallationsApi;
+import com.google.firebase.perf.session.SessionManager;
 import com.google.firebase.remoteconfig.RemoteConfigComponent;
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -39,13 +40,14 @@ public class FirebasePerfRegistrarTest {
     FirebasePerfRegistrar firebasePerfRegistrar = new FirebasePerfRegistrar();
     List<Component<?>> components = firebasePerfRegistrar.getComponents();
 
-    assertThat(components).hasSize(3);
+    assertThat(components).hasSize(4);
 
     Component<?> firebasePerfComponent = components.get(0);
 
     assertThat(firebasePerfComponent.getDependencies())
         .containsExactly(
             Dependency.required(FirebaseApp.class),
+            Dependency.required(SessionManager.class),
             Dependency.requiredProvider(RemoteConfigComponent.class),
             Dependency.required(FirebaseInstallationsApi.class),
             Dependency.requiredProvider(TransportFactory.class),
@@ -59,6 +61,7 @@ public class FirebasePerfRegistrarTest {
         .containsExactly(
             Dependency.required(Qualified.qualified(UiThread.class, Executor.class)),
             Dependency.required(FirebaseApp.class),
+            Dependency.required(SessionManager.class),
             Dependency.optionalProvider(StartupTime.class));
 
     assertThat(firebasePerfEarlyComponent.isLazy()).isFalse();

--- a/firebase-perf/src/test/java/com/google/firebase/perf/FirebasePerformanceTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/FirebasePerformanceTest.java
@@ -63,7 +63,7 @@ public class FirebasePerformanceTest {
       "firebase_performance_collection_deactivated";
   private static final String FIREPERF_ENABLED_KEY = "firebase_performance_collection_enabled";
 
-  @Nullable private RemoteConfigManager spyRemoteConfigManager = null;
+  @Nullable private RemoteConfigManager spyRemoteConfigManager = spy(new RemoteConfigManager());
   @Nullable private ConfigResolver spyConfigResolver = null;
 
   @Nullable private SessionManager spySessionManager = null;
@@ -100,9 +100,10 @@ public class FirebasePerformanceTest {
     sharedPreferences.edit().clear().commit();
     DeviceCacheManager.clearInstance();
 
-    spyRemoteConfigManager = spy(RemoteConfigManager.getInstance());
     ConfigResolver.clearInstance();
-    spyConfigResolver = spy(ConfigResolver.getInstance());
+    ConfigResolver configResolver = ConfigResolver.getInstance();
+    configResolver.setRemoteConfigManager(spyRemoteConfigManager);
+    spyConfigResolver = spy(configResolver);
 
     spySessionManager = spy(SessionManager.getInstance());
     fakeDirectExecutorService = new FakeDirectExecutorService();
@@ -470,6 +471,7 @@ public class FirebasePerformanceTest {
             () -> FirebaseApp.getInstance().get(TransportFactory.class));
 
     verify(spyRemoteConfigManager).setFirebaseRemoteConfigProvider(firebaseRemoteConfigProvider);
+    assertThat(spyRemoteConfigManager.isFirebaseRemoteConfigAvailable()).isTrue();
   }
 
   @Test
@@ -577,7 +579,6 @@ public class FirebasePerformanceTest {
         firebaseRemoteConfigProvider,
         mock(FirebaseInstallationsApi.class),
         transportFactoryProvider,
-        spyRemoteConfigManager,
         spyConfigResolver,
         spySessionManager);
   }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/FirebasePerformanceTestBase.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/FirebasePerformanceTestBase.java
@@ -53,6 +53,9 @@ public class FirebasePerformanceTestBase {
   protected static final String FAKE_FIREBASE_PROJECT_ID = "fir-perftestapp";
 
   protected Context appContext;
+  protected SessionManager provideSessionManager() {
+    return SessionManager.getInstance();
+  }
 
   @Before
   public void setUpFirebaseApp() {
@@ -85,19 +88,19 @@ public class FirebasePerformanceTestBase {
     ConfigResolver.getInstance().setMetadataBundle(new ImmutableBundle(bundle));
   }
 
-  protected static void forceVerboseSession() {
+  protected void forceVerboseSession() {
     forceVerboseSessionWithSamplingPercentage(100);
   }
 
-  protected static void forceNonVerboseSession() {
+  protected void forceNonVerboseSession() {
     forceVerboseSessionWithSamplingPercentage(0);
   }
 
-  private static void forceVerboseSessionWithSamplingPercentage(long samplingPercentage) {
+  private void forceVerboseSessionWithSamplingPercentage(long samplingPercentage) {
     Bundle bundle = new Bundle();
     bundle.putFloat("sessions_sampling_percentage", samplingPercentage);
     ConfigResolver.getInstance().setMetadataBundle(new ImmutableBundle(bundle));
 
-    SessionManager.getInstance().setPerfSession(PerfSession.createWithId("sessionId"));
+    provideSessionManager().setPerfSession(PerfSession.createWithId("sessionId"));
   }
 }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/RemoteConfigManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/RemoteConfigManagerTest.java
@@ -76,8 +76,8 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
 
   @Test
   public void getInstance_verifiesSingleton() {
-    RemoteConfigManager instanceOne = RemoteConfigManager.getInstance();
-    RemoteConfigManager instanceTwo = RemoteConfigManager.getInstance();
+    RemoteConfigManager instanceOne = ConfigResolver.getInstance().getRemoteConfigManager();
+    RemoteConfigManager instanceTwo = ConfigResolver.getInstance().getRemoteConfigManager();
 
     assertThat(instanceOne).isSameInstanceAs(instanceTwo);
   }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/AppStartTraceTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/AppStartTraceTest.java
@@ -34,9 +34,11 @@ import android.os.SystemClock;
 import android.view.View;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.firebase.perf.FirebasePerformanceTestBase;
+import com.google.firebase.perf.application.AppStateMonitor;
 import com.google.firebase.perf.config.ConfigResolver;
 import com.google.firebase.perf.session.PerfSession;
 import com.google.firebase.perf.session.SessionManager;
+import com.google.firebase.perf.session.gauges.GaugeManager;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Constants;
@@ -68,6 +70,12 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
 
   @Mock private Clock clock;
   @Mock private TransportManager transportManager;
+
+  @Mock private GaugeManager mockGaugeManager;
+  @Mock private AppStateMonitor mockAppStateMonitor;
+  private PerfSession session = new PerfSession("sessionId", new Clock());
+  private SessionManager sessionManager =
+      new SessionManager(mockGaugeManager, session, mockAppStateMonitor);
   @Mock private ConfigResolver configResolver;
   @Mock private Activity activity1;
   @Mock private Activity activity2;
@@ -106,6 +114,7 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
     FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
     AppStartTrace trace =
         new AppStartTrace(transportManager, clock, configResolver, fakeExecutorService);
+    trace.setSessionManager(sessionManager);
     trace.registerActivityLifecycleCallbacks(appContext);
     // first activity goes through onCreate()->onStart()->onResume() state change.
     currentTime = 1;
@@ -180,6 +189,7 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
     FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
     AppStartTrace trace =
         new AppStartTrace(transportManager, clock, configResolver, fakeExecutorService);
+    trace.setSessionManager(sessionManager);
     trace.registerActivityLifecycleCallbacks(appContext);
     // first activity onCreate()
     currentTime = 1;
@@ -217,6 +227,7 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
     FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
     AppStartTrace trace =
         new AppStartTrace(transportManager, clock, configResolver, fakeExecutorService);
+    trace.setSessionManager(sessionManager);
     trace.registerActivityLifecycleCallbacks(appContext);
     // Delays activity creation after 1 minute from app start time.
     currentTime =
@@ -244,6 +255,7 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
     Timer fakeTimer = spy(new Timer(currentTime));
     AppStartTrace trace =
         new AppStartTrace(transportManager, clock, configResolver, fakeExecutorService);
+    trace.setSessionManager(sessionManager);
     trace.registerActivityLifecycleCallbacks(appContext);
     trace.setMainThreadRunnableTime(fakeTimer);
 
@@ -272,6 +284,7 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
     Timer fakeTimer = spy(new Timer(currentTime));
     AppStartTrace trace =
         new AppStartTrace(transportManager, clock, configResolver, fakeExecutorService);
+    trace.setSessionManager(sessionManager);
     trace.registerActivityLifecycleCallbacks(appContext);
     trace.setMainThreadRunnableTime(fakeTimer);
 
@@ -305,6 +318,7 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
     FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
     AppStartTrace trace =
         new AppStartTrace(transportManager, clock, configResolver, fakeExecutorService);
+    trace.setSessionManager(sessionManager);
     trace.registerActivityLifecycleCallbacks(appContext);
     // Simulate resume and manually stepping time forward
     ShadowSystemClock.advanceBy(Duration.ofMillis(1000));

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/HttpMetricTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/HttpMetricTest.java
@@ -21,6 +21,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.google.firebase.perf.FirebasePerformance.HttpMethod;
 import com.google.firebase.perf.FirebasePerformanceTestBase;
+import com.google.firebase.perf.session.SessionManager;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.util.Constants;
 import com.google.firebase.perf.util.Timer;
@@ -54,7 +55,7 @@ public class HttpMetricTest extends FirebasePerformanceTestBase {
   @Test
   public void startStop() {
     HttpMetric metric =
-        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer);
+        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer, SessionManager.getInstance());
     metric.start();
     metric.stop();
     verify(transportManager)
@@ -67,7 +68,7 @@ public class HttpMetricTest extends FirebasePerformanceTestBase {
   @Test
   public void setHttpResponseCode() {
     HttpMetric metric =
-        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer);
+        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer, SessionManager.getInstance());
     metric.start();
     metric.setHttpResponseCode(200);
     metric.stop();
@@ -83,7 +84,7 @@ public class HttpMetricTest extends FirebasePerformanceTestBase {
   @Test
   public void setRequestSize() {
     HttpMetric metric =
-        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer);
+        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer, SessionManager.getInstance());
     metric.start();
     metric.setRequestPayloadSize(256);
     metric.stop();
@@ -99,7 +100,7 @@ public class HttpMetricTest extends FirebasePerformanceTestBase {
   @Test
   public void setResponseSize() {
     HttpMetric metric =
-        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer);
+        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer, SessionManager.getInstance());
     metric.start();
     metric.setResponsePayloadSize(256);
     metric.stop();
@@ -115,7 +116,7 @@ public class HttpMetricTest extends FirebasePerformanceTestBase {
   @Test
   public void setResponseContentType() {
     HttpMetric metric =
-        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer);
+        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer, SessionManager.getInstance());
     metric.start();
     metric.setResponseContentType("text/html");
     metric.stop();
@@ -131,7 +132,7 @@ public class HttpMetricTest extends FirebasePerformanceTestBase {
   @Test
   public void markRequestComplete() {
     HttpMetric metric =
-        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer);
+        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer, SessionManager.getInstance());
     metric.start();
     metric.markRequestComplete();
     metric.stop();
@@ -151,7 +152,7 @@ public class HttpMetricTest extends FirebasePerformanceTestBase {
   @Test
   public void markResponseStart() {
     HttpMetric metric =
-        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer);
+        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer, SessionManager.getInstance());
     metric.start();
     metric.markResponseStart();
     metric.stop();
@@ -171,7 +172,7 @@ public class HttpMetricTest extends FirebasePerformanceTestBase {
   @Test
   public void putAttribute() {
     HttpMetric metric =
-        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer);
+        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer, SessionManager.getInstance());
     metric.start();
     metric.putAttribute("attr1", "free");
     metric.stop();
@@ -192,7 +193,7 @@ public class HttpMetricTest extends FirebasePerformanceTestBase {
   @Test
   public void putInvalidAttribute() {
     HttpMetric metric =
-        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer);
+        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer, SessionManager.getInstance());
     metric.start();
     metric.putAttribute("_invalidattr1", "free");
     metric.stop();
@@ -212,7 +213,7 @@ public class HttpMetricTest extends FirebasePerformanceTestBase {
   @Test
   public void putAttributeAfterHttpMetricIsStopped() {
     HttpMetric metric =
-        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer);
+        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer, SessionManager.getInstance());
     metric.start();
     metric.stop();
     metric.putAttribute("attr1", "free");
@@ -232,7 +233,7 @@ public class HttpMetricTest extends FirebasePerformanceTestBase {
   @Test
   public void removeAttribute() {
     HttpMetric metric =
-        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer);
+        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer, SessionManager.getInstance());
     metric.start();
     metric.putAttribute("attr1", "free");
     Map<String, String> attributes = metric.getAttributes();
@@ -257,7 +258,7 @@ public class HttpMetricTest extends FirebasePerformanceTestBase {
   @Test
   public void removeAttributeAfterStopped() {
     HttpMetric metric =
-        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer);
+        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer, SessionManager.getInstance());
     metric.start();
     metric.putAttribute("attr1", "free");
     metric.stop();
@@ -279,7 +280,7 @@ public class HttpMetricTest extends FirebasePerformanceTestBase {
   @Test
   public void addAttributeWithSameName() {
     HttpMetric metric =
-        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer);
+        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer, SessionManager.getInstance());
     metric.start();
     metric.putAttribute("attr1", "free");
     metric.putAttribute("attr1", "paid");
@@ -301,7 +302,7 @@ public class HttpMetricTest extends FirebasePerformanceTestBase {
   @Test
   public void testMaxAttributes() {
     HttpMetric metric =
-        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer);
+        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer, SessionManager.getInstance());
     metric.start();
     for (int i = 0; i <= Constants.MAX_TRACE_CUSTOM_ATTRIBUTES; i++) {
       metric.putAttribute("dim" + i, "value" + i);
@@ -332,7 +333,7 @@ public class HttpMetricTest extends FirebasePerformanceTestBase {
   @Test
   public void testMoreThanMaxAttributes() {
     HttpMetric metric =
-        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer);
+        new HttpMetric("https://www.google.com/", HttpMethod.GET, transportManager, timer, SessionManager.getInstance());
     metric.start();
     for (int i = 0; i <= Constants.MAX_TRACE_CUSTOM_ATTRIBUTES; i++) {
       metric.putAttribute("dim" + i, "value" + i);

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/TraceMetricBuilderTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/TraceMetricBuilderTest.java
@@ -15,10 +15,14 @@
 package com.google.firebase.perf.metrics;
 
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.google.firebase.perf.FirebasePerformanceTestBase;
 import com.google.firebase.perf.application.AppStateMonitor;
+import com.google.firebase.perf.session.PerfSession;
+import com.google.firebase.perf.session.SessionManager;
+import com.google.firebase.perf.session.gauges.GaugeManager;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Constants;
@@ -30,6 +34,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
@@ -52,6 +57,12 @@ public class TraceMetricBuilderTest extends FirebasePerformanceTestBase {
 
   @Mock private AppStateMonitor appStateMonitor;
 
+  @Spy private GaugeManager mockGaugeManager = GaugeManager.getInstance();
+
+  private PerfSession session = new PerfSession("sessionId", new Clock());
+  private SessionManager sessionManager =
+          new SessionManager(mockGaugeManager, session, appStateMonitor);
+
   @Before
   public void setUp() {
     currentTime = 0;
@@ -65,6 +76,8 @@ public class TraceMetricBuilderTest extends FirebasePerformanceTestBase {
             })
         .when(clock)
         .getTime();
+
+    when(appStateMonitor.getSessionManager()).thenReturn(sessionManager);
   }
 
   @Test

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/TraceTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/TraceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import android.content.Context;
@@ -49,6 +50,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
 
@@ -64,11 +66,21 @@ public class TraceTest extends FirebasePerformanceTestBase {
 
   @Mock private TransportManager mockTransportManager;
   @Mock private Clock mockClock;
-  @Mock private AppStateMonitor mockAppStateMonitor;
+  @Spy
+  private GaugeManager mockGaugeManager = GaugeManager.getInstance();
+  @Spy private AppStateMonitor mockAppStateMonitor = AppStateMonitor.getInstance();
+  private PerfSession session = new PerfSession("sessionId", new Clock());
+  private SessionManager sessionManager =
+          new SessionManager(mockGaugeManager, session, mockAppStateMonitor);
 
   private ArgumentCaptor<TraceMetric> arguments;
 
   private long currentTime;
+
+  @Override
+  protected SessionManager provideSessionManager() {
+    return sessionManager;
+  }
 
   @Before
   public void setUp() {
@@ -84,6 +96,7 @@ public class TraceTest extends FirebasePerformanceTestBase {
     ConfigResolver configResolver = ConfigResolver.getInstance();
     configResolver.setDeviceCacheManager(new DeviceCacheManager(new FakeDirectExecutorService()));
     configResolver.setApplicationContext(appContext);
+    when(mockAppStateMonitor.getSessionManager()).thenReturn(sessionManager);
   }
 
   @Test

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/validator/FirebasePerfNetworkValidatorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/validator/FirebasePerfNetworkValidatorTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.firebase.perf.FirebasePerformanceTestBase;
 import com.google.firebase.perf.metrics.NetworkRequestMetricBuilder;
+import com.google.firebase.perf.session.SessionManager;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.v1.NetworkRequestMetric;
 import com.google.firebase.perf.v1.NetworkRequestMetric.HttpMethod;
@@ -98,7 +99,7 @@ public class FirebasePerfNetworkValidatorTest extends FirebasePerformanceTestBas
   @Test
   public void testNullResponseCode() {
     NetworkRequestMetricBuilder metricBuilder =
-        NetworkRequestMetricBuilder.builder(TransportManager.getInstance());
+        NetworkRequestMetricBuilder.builder(TransportManager.getInstance(), SessionManager.getInstance());
 
     // Set all the required fields except response code
     metricBuilder.setUrl("https://www.google.com");
@@ -161,7 +162,7 @@ public class FirebasePerfNetworkValidatorTest extends FirebasePerformanceTestBas
   @Test
   public void testClientStartTimeUs() {
     NetworkRequestMetricBuilder metricBuilder =
-        NetworkRequestMetricBuilder.builder(TransportManager.getInstance());
+        NetworkRequestMetricBuilder.builder(TransportManager.getInstance(), SessionManager.getInstance());
 
     // Set all required fields except clientStartTimeUs
     metricBuilder.setUrl("https://www.google.com");
@@ -294,7 +295,7 @@ public class FirebasePerfNetworkValidatorTest extends FirebasePerformanceTestBas
   @Test
   public void testAbsenceOfUrlFailsValidation() {
     NetworkRequestMetricBuilder metricBuilder =
-        NetworkRequestMetricBuilder.builder(TransportManager.getInstance());
+        NetworkRequestMetricBuilder.builder(TransportManager.getInstance(), SessionManager.getInstance());
 
     // Set all required fields except url
     metricBuilder.setHttpMethod("GET");
@@ -311,7 +312,7 @@ public class FirebasePerfNetworkValidatorTest extends FirebasePerformanceTestBas
   @Test
   public void testAbsenceOfHttpMethodFailsValidation() {
     NetworkRequestMetricBuilder metricBuilder =
-        NetworkRequestMetricBuilder.builder(TransportManager.getInstance());
+        NetworkRequestMetricBuilder.builder(TransportManager.getInstance(), SessionManager.getInstance());
 
     // Set all required fields except httpMethod
     metricBuilder.setUrl("https://www.google.com");
@@ -328,7 +329,7 @@ public class FirebasePerfNetworkValidatorTest extends FirebasePerformanceTestBas
   @Test
   public void testAbsenceOfHttpResponseCodeFailsValidation() {
     NetworkRequestMetricBuilder metricBuilder =
-        NetworkRequestMetricBuilder.builder(TransportManager.getInstance());
+        NetworkRequestMetricBuilder.builder(TransportManager.getInstance(), SessionManager.getInstance());
 
     // Set all required fields except httpResponseCode
     metricBuilder.setUrl("https://www.google.com");
@@ -346,7 +347,7 @@ public class FirebasePerfNetworkValidatorTest extends FirebasePerformanceTestBas
   @Test
   public void testAbsenceOfClientStartTimeUsFailsValidation() {
     NetworkRequestMetricBuilder metricBuilder =
-        NetworkRequestMetricBuilder.builder(TransportManager.getInstance());
+        NetworkRequestMetricBuilder.builder(TransportManager.getInstance(), SessionManager.getInstance());
 
     // Set all required fields except httpResponseCode
     metricBuilder.setUrl("https://www.google.com");
@@ -364,7 +365,7 @@ public class FirebasePerfNetworkValidatorTest extends FirebasePerformanceTestBas
   @Test
   public void testAbsenceOfTimeToResponseCompletedUsFailsValidation() {
     NetworkRequestMetricBuilder metricBuilder =
-        NetworkRequestMetricBuilder.builder(TransportManager.getInstance());
+        NetworkRequestMetricBuilder.builder(TransportManager.getInstance(), SessionManager.getInstance());
 
     // Set all required fields except timeToResponseCompletedUs
     metricBuilder.setUrl("https://www.google.com");
@@ -382,7 +383,7 @@ public class FirebasePerfNetworkValidatorTest extends FirebasePerformanceTestBas
   private NetworkRequestMetricBuilder createNetworkRequestMetricBuilderWithRequiredValuesPresent() {
 
     NetworkRequestMetricBuilder networkRequestMetricBuilder =
-        NetworkRequestMetricBuilder.builder(TransportManager.getInstance());
+        NetworkRequestMetricBuilder.builder(TransportManager.getInstance(), SessionManager.getInstance());
 
     networkRequestMetricBuilder.setUrl("https://www.google.com");
     networkRequestMetricBuilder.setHttpMethod("GET");

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/validator/FirebasePerfTraceValidatorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/validator/FirebasePerfTraceValidatorTest.java
@@ -17,12 +17,17 @@ package com.google.firebase.perf.metrics.validator;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.google.firebase.perf.FirebasePerformanceTestBase;
 import com.google.firebase.perf.application.AppStateMonitor;
 import com.google.firebase.perf.metrics.Trace;
+import com.google.firebase.perf.session.PerfSession;
+import com.google.firebase.perf.session.SessionManager;
+import com.google.firebase.perf.session.gauges.GaugeManager;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Constants;
@@ -35,6 +40,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
@@ -46,6 +52,8 @@ public class FirebasePerfTraceValidatorTest extends FirebasePerformanceTestBase 
   private long currentTime = 0;
 
   @Mock private Clock clock;
+
+  @Spy private AppStateMonitor appStateMonitor = AppStateMonitor.getInstance();
 
   @Before
   public void setUp() {
@@ -279,7 +287,11 @@ public class FirebasePerfTraceValidatorTest extends FirebasePerformanceTestBase 
     long expectedTraceDuration = 50;
 
     TransportManager transportManager = mock(TransportManager.class);
-    AppStateMonitor appStateMonitor = mock(AppStateMonitor.class);
+    when(appStateMonitor.getSessionManager()).thenReturn(new SessionManager(
+            mock(GaugeManager.class),
+            new PerfSession("sessionId", new Clock()),
+            appStateMonitor
+    ));
     ArgumentCaptor<TraceMetric> argMetric = ArgumentCaptor.forClass(TraceMetric.class);
 
     Trace trace = new Trace(traceName, transportManager, clock, appStateMonitor);

--- a/firebase-perf/src/test/java/com/google/firebase/perf/network/FirebasePerfHttpClientTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/network/FirebasePerfHttpClientTest.java
@@ -26,7 +26,12 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.google.firebase.perf.FirebasePerformanceTestBase;
+import com.google.firebase.perf.application.AppStateMonitor;
+import com.google.firebase.perf.session.PerfSession;
+import com.google.firebase.perf.session.SessionManager;
+import com.google.firebase.perf.session.gauges.GaugeManager;
 import com.google.firebase.perf.transport.TransportManager;
+import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.perf.v1.ApplicationProcessState;
 import com.google.firebase.perf.v1.NetworkRequestMetric;
@@ -53,6 +58,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.robolectric.RobolectricTestRunner;
 
 /** Unit tests for {@link com.google.firebase.perf.network.FirebasePerfHttpClient}. */
@@ -66,11 +72,18 @@ public class FirebasePerfHttpClientTest extends FirebasePerformanceTestBase {
   @Mock private Timer timer;
   @Captor private ArgumentCaptor<NetworkRequestMetric> networkArgumentCaptor;
 
+  @Spy private GaugeManager mockGaugeManager = GaugeManager.getInstance();
+  @Spy private AppStateMonitor mockAppStateMonitor = AppStateMonitor.getInstance();
+  private PerfSession session = new PerfSession("sessionId", new Clock());
+  private SessionManager sessionManager =
+          new SessionManager(mockGaugeManager, session, mockAppStateMonitor);
+
   @Before
   public void setUp() {
     initMocks(this);
     when(timer.getMicros()).thenReturn((long) 1000);
     when(timer.getDurationMicros()).thenReturn((long) 2000);
+    when(mockAppStateMonitor.getSessionManager()).thenReturn(sessionManager);
   }
 
   @Test
@@ -81,7 +94,7 @@ public class FirebasePerfHttpClientTest extends FirebasePerformanceTestBase {
     when(client.execute(request)).thenReturn(response);
 
     HttpResponse httpResponse =
-        FirebasePerfHttpClient.execute(client, request, timer, transportManager);
+        FirebasePerfHttpClient.execute(client, request, timer, transportManager, sessionManager);
 
     assertSame(httpResponse, response);
     verify(timer).reset();
@@ -100,7 +113,7 @@ public class FirebasePerfHttpClientTest extends FirebasePerformanceTestBase {
     when(client.execute(request, context)).thenReturn(response);
 
     HttpResponse httpResponse =
-        FirebasePerfHttpClient.execute(client, request, context, timer, transportManager);
+        FirebasePerfHttpClient.execute(client, request, context, timer, transportManager, sessionManager);
 
     assertSame(httpResponse, response);
     verify(transportManager)
@@ -119,7 +132,7 @@ public class FirebasePerfHttpClientTest extends FirebasePerformanceTestBase {
     when(client.execute(host, request)).thenReturn(response);
 
     HttpResponse httpResponse =
-        FirebasePerfHttpClient.execute(client, host, request, timer, transportManager);
+        FirebasePerfHttpClient.execute(client, host, request, timer, transportManager, sessionManager);
 
     assertSame(httpResponse, response);
     verify(transportManager)
@@ -139,7 +152,7 @@ public class FirebasePerfHttpClientTest extends FirebasePerformanceTestBase {
     when(client.execute(host, request, c)).thenReturn(response);
 
     HttpResponse httpResponse =
-        FirebasePerfHttpClient.execute(client, host, request, c, timer, transportManager);
+        FirebasePerfHttpClient.execute(client, host, request, c, timer, transportManager, sessionManager);
 
     assertSame(httpResponse, response);
     verify(transportManager)
@@ -155,7 +168,7 @@ public class FirebasePerfHttpClientTest extends FirebasePerformanceTestBase {
     HttpUriRequest request = mockHttpUriRequest();
     ResponseHandler<HttpResponse> handler = mock(ResponseHandlerInterface.class);
 
-    FirebasePerfHttpClient.execute(client, request, handler, timer, transportManager);
+    FirebasePerfHttpClient.execute(client, request, handler, timer, transportManager, sessionManager);
 
     ArgumentCaptor<HttpUriRequest> argRequest = ArgumentCaptor.forClass(HttpUriRequest.class);
     ArgumentCaptor<InstrumentApacheHttpResponseHandler> argHandler =
@@ -173,7 +186,7 @@ public class FirebasePerfHttpClientTest extends FirebasePerformanceTestBase {
     HttpContext context = mock(HttpContext.class);
     ResponseHandler<HttpResponse> handler = mock(ResponseHandlerInterface.class);
 
-    FirebasePerfHttpClient.execute(client, request, handler, context, timer, transportManager);
+    FirebasePerfHttpClient.execute(client, request, handler, context, timer, transportManager, sessionManager);
 
     ArgumentCaptor<HttpUriRequest> argRequest = ArgumentCaptor.forClass(HttpUriRequest.class);
     ArgumentCaptor<InstrumentApacheHttpResponseHandler> argHandler =
@@ -193,7 +206,7 @@ public class FirebasePerfHttpClientTest extends FirebasePerformanceTestBase {
     HttpHost host = mockHttpHost();
     ResponseHandler<HttpResponse> handler = mock(ResponseHandlerInterface.class);
 
-    FirebasePerfHttpClient.execute(client, host, request, handler, timer, transportManager);
+    FirebasePerfHttpClient.execute(client, host, request, handler, timer, transportManager, sessionManager);
 
     ArgumentCaptor<HttpHost> argHost = ArgumentCaptor.forClass(HttpHost.class);
     ArgumentCaptor<HttpRequest> argRequest = ArgumentCaptor.forClass(HttpRequest.class);
@@ -215,7 +228,7 @@ public class FirebasePerfHttpClientTest extends FirebasePerformanceTestBase {
     ResponseHandler<HttpResponse> handler = mock(ResponseHandlerInterface.class);
 
     FirebasePerfHttpClient.execute(
-        client, host, request, handler, context, timer, transportManager);
+        client, host, request, handler, context, timer, transportManager, sessionManager);
 
     ArgumentCaptor<HttpHost> argHost = ArgumentCaptor.forClass(HttpHost.class);
     ArgumentCaptor<HttpRequest> argRequest = ArgumentCaptor.forClass(HttpRequest.class);
@@ -244,7 +257,7 @@ public class FirebasePerfHttpClientTest extends FirebasePerformanceTestBase {
         IOException.class,
         () -> {
           HttpResponse httpResponse =
-              FirebasePerfHttpClient.execute(client, request, timer, transportManager);
+              FirebasePerfHttpClient.execute(client, request, timer, transportManager, sessionManager);
           assertSame(httpResponse, response);
         });
     verify(transportManager)
@@ -267,7 +280,7 @@ public class FirebasePerfHttpClientTest extends FirebasePerformanceTestBase {
         IOException.class,
         () -> {
           HttpResponse httpResponse =
-              FirebasePerfHttpClient.execute(client, request, context, timer, transportManager);
+              FirebasePerfHttpClient.execute(client, request, context, timer, transportManager, sessionManager);
           assertSame(httpResponse, response);
         });
     verify(transportManager)
@@ -290,7 +303,7 @@ public class FirebasePerfHttpClientTest extends FirebasePerformanceTestBase {
         IOException.class,
         () -> {
           HttpResponse httpResponse =
-              FirebasePerfHttpClient.execute(client, host, request, timer, transportManager);
+              FirebasePerfHttpClient.execute(client, host, request, timer, transportManager, sessionManager);
           assertSame(httpResponse, response);
         });
     verify(transportManager)
@@ -314,7 +327,7 @@ public class FirebasePerfHttpClientTest extends FirebasePerformanceTestBase {
         IOException.class,
         () -> {
           HttpResponse httpResponse =
-              FirebasePerfHttpClient.execute(client, host, request, c, timer, transportManager);
+              FirebasePerfHttpClient.execute(client, host, request, c, timer, transportManager, sessionManager);
 
           assertSame(httpResponse, response);
         });
@@ -337,7 +350,7 @@ public class FirebasePerfHttpClientTest extends FirebasePerformanceTestBase {
     assertThrows(
         IOException.class,
         () -> {
-          FirebasePerfHttpClient.execute(client, request, handler, timer, transportManager);
+          FirebasePerfHttpClient.execute(client, request, handler, timer, transportManager, sessionManager);
         });
     verify(transportManager)
         .log(networkArgumentCaptor.capture(), ArgumentMatchers.any(ApplicationProcessState.class));
@@ -362,7 +375,7 @@ public class FirebasePerfHttpClientTest extends FirebasePerformanceTestBase {
         IOException.class,
         () -> {
           FirebasePerfHttpClient.execute(
-              client, request, handler, context, timer, transportManager);
+              client, request, handler, context, timer, transportManager, sessionManager);
         });
     verify(transportManager)
         .log(networkArgumentCaptor.capture(), ArgumentMatchers.any(ApplicationProcessState.class));
@@ -386,7 +399,7 @@ public class FirebasePerfHttpClientTest extends FirebasePerformanceTestBase {
     assertThrows(
         IOException.class,
         () -> {
-          FirebasePerfHttpClient.execute(client, host, request, handler, timer, transportManager);
+          FirebasePerfHttpClient.execute(client, host, request, handler, timer, transportManager, sessionManager);
         });
     verify(transportManager)
         .log(networkArgumentCaptor.capture(), ArgumentMatchers.any(ApplicationProcessState.class));
@@ -413,7 +426,7 @@ public class FirebasePerfHttpClientTest extends FirebasePerformanceTestBase {
         IOException.class,
         () -> {
           FirebasePerfHttpClient.execute(
-              client, host, request, handler, context, timer, transportManager);
+              client, host, request, handler, context, timer, transportManager, sessionManager);
         });
     verify(transportManager)
         .log(networkArgumentCaptor.capture(), ArgumentMatchers.any(ApplicationProcessState.class));

--- a/firebase-perf/src/test/java/com/google/firebase/perf/network/InstrHttpInputStreamTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/network/InstrHttpInputStreamTest.java
@@ -22,8 +22,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.firebase.perf.FirebasePerformanceTestBase;
+import com.google.firebase.perf.application.AppStateMonitor;
 import com.google.firebase.perf.metrics.NetworkRequestMetricBuilder;
+import com.google.firebase.perf.session.PerfSession;
+import com.google.firebase.perf.session.SessionManager;
+import com.google.firebase.perf.session.gauges.GaugeManager;
 import com.google.firebase.perf.transport.TransportManager;
+import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.perf.v1.ApplicationProcessState;
 import com.google.firebase.perf.v1.NetworkRequestMetric;
@@ -39,6 +44,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
 import org.robolectric.RobolectricTestRunner;
 
 /**
@@ -53,6 +59,11 @@ public class InstrHttpInputStreamTest extends FirebasePerformanceTestBase {
   @Mock TransportManager transportManager;
   @Mock Timer timer;
   @Captor ArgumentCaptor<NetworkRequestMetric> networkArgumentCaptor;
+  @Spy private GaugeManager mockGaugeManager = GaugeManager.getInstance();
+  @Spy private AppStateMonitor mockAppStateMonitor = AppStateMonitor.getInstance();
+  private PerfSession session = new PerfSession("sessionId", new Clock());
+  private SessionManager sessionManager =
+          new SessionManager(mockGaugeManager, session, mockAppStateMonitor);
 
   private NetworkRequestMetricBuilder networkMetricBuilder;
 
@@ -61,7 +72,8 @@ public class InstrHttpInputStreamTest extends FirebasePerformanceTestBase {
     closeable = MockitoAnnotations.openMocks(this);
     when(timer.getMicros()).thenReturn((long) 1000);
     when(timer.getDurationMicros()).thenReturn((long) 2000);
-    networkMetricBuilder = NetworkRequestMetricBuilder.builder(transportManager);
+    when(mockAppStateMonitor.getSessionManager()).thenReturn(sessionManager);
+    networkMetricBuilder = NetworkRequestMetricBuilder.builder(transportManager, sessionManager);
   }
 
   @After

--- a/firebase-perf/src/test/java/com/google/firebase/perf/network/InstrHttpOutputStreamTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/network/InstrHttpOutputStreamTest.java
@@ -21,8 +21,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.firebase.perf.FirebasePerformanceTestBase;
+import com.google.firebase.perf.application.AppStateMonitor;
 import com.google.firebase.perf.metrics.NetworkRequestMetricBuilder;
+import com.google.firebase.perf.session.PerfSession;
+import com.google.firebase.perf.session.SessionManager;
+import com.google.firebase.perf.session.gauges.GaugeManager;
 import com.google.firebase.perf.transport.TransportManager;
+import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.perf.v1.ApplicationProcessState;
 import com.google.firebase.perf.v1.NetworkRequestMetric;
@@ -37,6 +42,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
 import org.robolectric.RobolectricTestRunner;
 
 /** Unit tests for {@link com.google.firebase.perf.network.InstrHttpOutputStream}. */
@@ -47,7 +53,11 @@ public class InstrHttpOutputStreamTest extends FirebasePerformanceTestBase {
   @Mock TransportManager transportManager;
   @Mock Timer timer;
   @Captor ArgumentCaptor<NetworkRequestMetric> networkArgumentCaptor;
-
+  @Spy private GaugeManager mockGaugeManager = GaugeManager.getInstance();
+  @Spy private AppStateMonitor mockAppStateMonitor = AppStateMonitor.getInstance();
+  private PerfSession session = new PerfSession("sessionId", new Clock());
+  private SessionManager sessionManager =
+          new SessionManager(mockGaugeManager, session, mockAppStateMonitor);
   private NetworkRequestMetricBuilder networkMetricBuilder;
 
   @Before
@@ -55,7 +65,8 @@ public class InstrHttpOutputStreamTest extends FirebasePerformanceTestBase {
     MockitoAnnotations.initMocks(this);
     when(timer.getMicros()).thenReturn((long) 1000);
     when(timer.getDurationMicros()).thenReturn((long) 2000);
-    networkMetricBuilder = NetworkRequestMetricBuilder.builder(transportManager);
+    when(mockAppStateMonitor.getSessionManager()).thenReturn(sessionManager);
+    networkMetricBuilder = NetworkRequestMetricBuilder.builder(transportManager, sessionManager);
   }
 
   @Test

--- a/firebase-perf/src/test/java/com/google/firebase/perf/network/InstrHttpURLConnectionTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/network/InstrHttpURLConnectionTest.java
@@ -24,8 +24,13 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.google.firebase.perf.FirebasePerformanceTestBase;
+import com.google.firebase.perf.application.AppStateMonitor;
 import com.google.firebase.perf.metrics.NetworkRequestMetricBuilder;
+import com.google.firebase.perf.session.PerfSession;
+import com.google.firebase.perf.session.SessionManager;
+import com.google.firebase.perf.session.gauges.GaugeManager;
 import com.google.firebase.perf.transport.TransportManager;
+import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.perf.v1.ApplicationProcessState;
 import com.google.firebase.perf.v1.NetworkRequestMetric;
@@ -47,6 +52,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.robolectric.RobolectricTestRunner;
 
 /** Unit tests for {@link InstrHttpURLConnection}. */
@@ -56,7 +62,11 @@ public class InstrHttpURLConnectionTest extends FirebasePerformanceTestBase {
   @Mock private TransportManager transportManager;
   @Mock private Timer timer;
   @Captor private ArgumentCaptor<NetworkRequestMetric> networkArgumentCaptor;
-
+  @Spy private GaugeManager mockGaugeManager = GaugeManager.getInstance();
+  @Spy private AppStateMonitor mockAppStateMonitor = AppStateMonitor.getInstance();
+  private PerfSession session = new PerfSession("sessionId", new Clock());
+  private SessionManager sessionManager =
+          new SessionManager(mockGaugeManager, session, mockAppStateMonitor);
   private NetworkRequestMetricBuilder networkMetricBuilder;
 
   @Before
@@ -64,7 +74,8 @@ public class InstrHttpURLConnectionTest extends FirebasePerformanceTestBase {
     initMocks(this);
     when(timer.getMicros()).thenReturn((long) 1000);
     when(timer.getDurationMicros()).thenReturn((long) 2000);
-    networkMetricBuilder = NetworkRequestMetricBuilder.builder(transportManager);
+    when(mockAppStateMonitor.getSessionManager()).thenReturn(sessionManager);
+    networkMetricBuilder = NetworkRequestMetricBuilder.builder(transportManager, sessionManager);
   }
 
   @Test

--- a/firebase-perf/src/test/java/com/google/firebase/perf/network/InstrHttpsURLConnectionTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/network/InstrHttpsURLConnectionTest.java
@@ -21,8 +21,13 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.google.firebase.perf.FirebasePerformanceTestBase;
+import com.google.firebase.perf.application.AppStateMonitor;
 import com.google.firebase.perf.metrics.NetworkRequestMetricBuilder;
+import com.google.firebase.perf.session.PerfSession;
+import com.google.firebase.perf.session.SessionManager;
+import com.google.firebase.perf.session.gauges.GaugeManager;
 import com.google.firebase.perf.transport.TransportManager;
+import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.perf.v1.ApplicationProcessState;
 import com.google.firebase.perf.v1.NetworkRequestMetric;
@@ -52,6 +57,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.robolectric.RobolectricTestRunner;
 
 /** Unit tests for {@link InstrHttpsURLConnection}. */
@@ -61,6 +67,11 @@ public class InstrHttpsURLConnectionTest extends FirebasePerformanceTestBase {
   @Mock private TransportManager transportManager;
   @Mock private Timer timer;
   @Captor private ArgumentCaptor<NetworkRequestMetric> networkArgumentCaptor;
+  @Spy private GaugeManager mockGaugeManager = GaugeManager.getInstance();
+  @Spy private AppStateMonitor mockAppStateMonitor = AppStateMonitor.getInstance();
+  private PerfSession session = new PerfSession("sessionId", new Clock());
+  private SessionManager sessionManager =
+          new SessionManager(mockGaugeManager, session, mockAppStateMonitor);
 
   private NetworkRequestMetricBuilder networkMetricBuilder;
 
@@ -69,7 +80,8 @@ public class InstrHttpsURLConnectionTest extends FirebasePerformanceTestBase {
     initMocks(this);
     when(timer.getMicros()).thenReturn((long) 1000);
     when(timer.getDurationMicros()).thenReturn((long) 2000);
-    networkMetricBuilder = NetworkRequestMetricBuilder.builder(transportManager);
+    when(mockAppStateMonitor.getSessionManager()).thenReturn(sessionManager);
+    networkMetricBuilder = NetworkRequestMetricBuilder.builder(transportManager, sessionManager);
   }
 
   @Test

--- a/firebase-perf/src/test/java/com/google/firebase/perf/network/InstrURLConnectionBaseTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/network/InstrURLConnectionBaseTest.java
@@ -23,8 +23,13 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.google.firebase.perf.FirebasePerformanceTestBase;
+import com.google.firebase.perf.application.AppStateMonitor;
 import com.google.firebase.perf.metrics.NetworkRequestMetricBuilder;
+import com.google.firebase.perf.session.PerfSession;
+import com.google.firebase.perf.session.SessionManager;
+import com.google.firebase.perf.session.gauges.GaugeManager;
 import com.google.firebase.perf.transport.TransportManager;
+import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.perf.v1.ApplicationProcessState;
 import com.google.firebase.perf.v1.NetworkRequestMetric;
@@ -39,6 +44,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.robolectric.RobolectricTestRunner;
 
 /** Unit tests for {@link InstrURLConnectionBase}. */
@@ -48,6 +54,11 @@ public class InstrURLConnectionBaseTest extends FirebasePerformanceTestBase {
   @Mock private TransportManager transportManager;
   @Mock private Timer timer;
   @Captor private ArgumentCaptor<NetworkRequestMetric> networkArgumentCaptor;
+  @Spy private GaugeManager mockGaugeManager = GaugeManager.getInstance();
+  @Spy private AppStateMonitor mockAppStateMonitor = AppStateMonitor.getInstance();
+  private PerfSession session = new PerfSession("sessionId", new Clock());
+  private SessionManager sessionManager =
+          new SessionManager(mockGaugeManager, session, mockAppStateMonitor);
 
   private NetworkRequestMetricBuilder networkMetricBuilder;
 
@@ -56,7 +67,8 @@ public class InstrURLConnectionBaseTest extends FirebasePerformanceTestBase {
     initMocks(this);
     when(timer.getMicros()).thenReturn((long) 1000);
     when(timer.getDurationMicros()).thenReturn((long) 2000);
-    networkMetricBuilder = NetworkRequestMetricBuilder.builder(transportManager);
+    when(mockAppStateMonitor.getSessionManager()).thenReturn(sessionManager);
+    networkMetricBuilder = NetworkRequestMetricBuilder.builder(transportManager, sessionManager);
   }
 
   @Test

--- a/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/MainActivity.kt
+++ b/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/MainActivity.kt
@@ -17,6 +17,7 @@
 package com.google.firebase.testing.sessions
 
 import android.os.Bundle
+import com.google.firebase.perf.config.ConfigResolver
 import com.google.firebase.testing.sessions.databinding.ActivityMainBinding
 
 class MainActivity : BaseActivity() {

--- a/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/MainActivity.kt
+++ b/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/MainActivity.kt
@@ -17,7 +17,6 @@
 package com.google.firebase.testing.sessions
 
 import android.os.Bundle
-import com.google.firebase.perf.config.ConfigResolver
 import com.google.firebase.testing.sessions.databinding.ActivityMainBinding
 
 class MainActivity : BaseActivity() {


### PR DESCRIPTION
This is a proposal for removing SessionManager as a singleton



# Current implementation
    
`SessionManager` primary purposes are:
 
 - **Session Creation and Management:** It creates and manages `PerfSession` objects. Each session is identified by a unique ID (a UUID), which is crucial for grouping related performance data. A new session is generated at every cold start of the app and also when the app comes to the foreground.
 
 - **Session ID Distribution:** The class acts as a broadcaster. It informs other parts of the application (referred to as `SessionAwareObject` clients) whenever the active performance session changes. This ensures that all performance data (like traces and metrics) is correctly associated with the current session ID.
 
 - **Lifecycle Awareness:** It listens to application state changes (like going into the foreground or background) via the `AppStateMonitor`. This allows it to make decisions, such as starting a new session when the app is foregrounded.
          
 - **Gauge Metric Control:** It controls the collection of periodic metrics (gauges), like CPU and memory usage. It tells the `GaugeManager` when to start or stop collecting these metrics based on the current session's configuration and the application's state (foreground/background).

          
          
Currently this class is referenced in some others like
 
 <img width="706" height="572" alt="SessionManagerEx drawio" src="https://github.com/user-attachments/assets/20840bac-50f3-4038-a83b-8337ebca687c" />
          
          
          
### **`Trace`**
 - Usage in `start()` method: When a `Trace` is started, it interacts with the `SessionManager` for two primary reasons:
 
 
     1. **To get the current session:** It calls `SessionManager.getInstance().perfSession()` to retrieve the active `PerfSession`. This session object (containing the session ID) is then associated with the trace.
     3. **To register for updates:** It calls `SessionManager.getInstance().registerForSessionUpdates(sessionAwareObject)` to listen for future session changes. This ensures that if a new session starts while the trace is still running (e.g., the app goes to the background and comes back), the trace can be associated with the new session ID as well.
          
- Usage in `stop()` method: When the `Trace` is stopped, it calls `SessionManager.getInstance().unregisterForSessionUpdates(sessionAwareObject)` to stop listening for session updates, preventing memory leaks.
 
 
 
 ### **`GaugeManager`**
 
 - **Usage's purpose:** The `GaugeManager` is responsible for collecting periodic data like CPU and memory usage (gauges).
 - **Interaction:** The `SessionManager` holds the logic for when to start or stop collecting these gauges. It calls methods on `GaugeManager` to start or stop gauge collection based on whether a session is running and if the app is in the foreground. This ensures that gauge metrics are only collected during an active, verbose session.
          
          
          
 ### **`AppStateMonitor`**
 
 - **Usage's purpose:** This class monitors the application's lifecycle (e.g., when the app enters the foreground or background).
 - **Interaction:** The `AppStateMonitor` notifies its listeners, one of which is the `SessionManager`, of these state changes. The `SessionManager` uses this information to decide when to update the session. For example, when the app comes to the foreground after a certain period of inactivity in the background, `SessionManager` will generate a new session ID.
          
          
### **`FirebasePerformance`**
 
 - **Usage's purpose:** This is the main public entry point for the Firebase Performance Monitoring SDK.
 - **Interaction:** During the initialization of the Performance Monitoring feature, `FirebasePerformance` likely triggers the initialization of the `SessionManager` to start the very first session when the app starts up.
          


# Proposed refactor

## Trace
The core change is that the `Trace` class no longer directly calls a static `SessionManager.getInstance()` method. Instead, it now receives its `SessionManager` instance from `AppStateMonitor` during its own initialization.

In order to eliminate `SessionManager` as a singleton

1. Removal of Direct Singleton Access
2. New Class Member Variable for SessionManager
3. `SessionManager` is Now Injected During Construction

The `Trace` constructors have been updated to receive the `SessionManager` instance from `AppStateMonitor`. `AppStateMonitor` now acts as a provider or factory for the `SessionManager`. However more effort should be made to also remove `AppStateMonitor` as a singleton.

## TransportManager
This class is responsible for queueing and sending performance data to the Firebase backend. The changes here are central to the new dependency injection approach.

`SessionManager` Injected via `initialize()`: The primary initialize method, which is called when Firebase Performance starts up, now explicitly requires a `SessionManager` object as a parameter. This is the key injection point.

## AppStartTrace
`AppStartTrace` is a special, one-time-use class responsible for capturing the application's startup metrics. It has a unique lifecycle compared to regular `Trace` objects.

The `AppStartTrace` would have called `SessionManager.getInstance()` directly, most likely when it was time to dispatch the trace, to get the session ID. The constructor for `AppStartTrace` has been updated to accept the `SessionManager` instance as a parameter. This is the key dependency injection point for this class.


# Impact of These Changes
1. **Decoupling:** `Trace` is no longer tightly coupled to the static singleton implementation of `SessionManager`. It now only knows that it needs an instance of `SessionManager`, which it receives from `AppStateMonitor`.
2. **Improved Testability:** This is a major benefit. When testing the `Trace` class, we can now provide a mock or fake `SessionManager` object in the constructor. This allows us to test the logic of the `Trace` class in isolation without relying on the real `SessionManager` and the entire Firebase SDK initialization.
3. **Centralized Dependency Management:** By having `AppStateMonitor` be the source for the `SessionManager` instance, we have centralized the responsibility of creating and providing this dependency. This makes the code more organized and is a significant step toward completely removing the global singleton pattern.

