### PR TITLE
e2e-app.gradle: upgrade guava dependency to 31.0.1

### DIFF
--- a/firebase-perf/e2e-app/e2e-app.gradle
+++ b/firebase-perf/e2e-app/e2e-app.gradle
@@ -86,7 +86,7 @@ dependencies {
 
     // Google Deps
     implementation "com.google.android.gms:play-services-tasks:18.0.1"
-    implementation "com.google.guava:guava:30.1.1-android"
+    implementation "com.google.guava:guava:31.0.1-android"
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation "androidx.recyclerview:recyclerview:1.1.0"


### PR DESCRIPTION
This fixes a `NoSuchMethodError: No virtual method buildOrThrow()` error introduced when the Truth library was upgraded from 1.4.4 to 1.4.5 in PR #7497.

Here is the full stack trace:

```
java.lang.NoSuchMethodError: No virtual method buildOrThrow()Lcom/google/common/collect/ImmutableMap; in class Lcom/google/common/collect/ImmutableMap$Builder; or its super classes (declaration of 'com.google.common.collect.ImmutableMap$Builder' appears in /data/app/com.google.firebase.testing.fireperf-UwnD88IA3xxKNmt0idI3uA==/base.apk!classes7.dex)
	at com.google.common.truth.Subject.<clinit>(Subject.java:1282)
	at com.google.common.truth.ComparableSubject.comparables(ComparableSubject.java:182)
	at com.google.common.truth.StandardSubjectBuilder.that(StandardSubjectBuilder.java:110)
	at com.google.common.truth.Truth.assertThat(Truth.java:153)
	at com.google.firebase.testing.fireperf.FirebasePerformanceFragmentScreenTracesTest.scrollAndCycleThroughAllFragments(FirebasePerformanceFragmentScreenTracesTest.java:56)
```

This bug was solved with help from Gemini, which gave this insight:

```
I am getting the crash below in an Android integration tests.

Did Guava remove the ImmutableMap.buildOrThrow() method or something??
```

Links:
* https://github.com/firebase/firebase-android-sdk/actions/runs/20035701928/job/57464321738?pr=7585
* https://firebase.corp.google.com/project/fireescape-c4819/testlab/histories/bh.588330bbc5b76933/matrices/6849433697466807925/executions/bs.356271b0dcb89e85/testcases/1

No, Guava did not remove the method. In fact, the situation is the exact opposite: **buildOrThrow() is a newer method** that was added in Guava **31.0**.

The error NoSuchMethodError is happening because there is a **dependency conflict** in your project.

* **The Cause:** Your test library (Google Truth) was compiled against a **newer** version of Guava (31.0+) and expects buildOrThrow() to exist. However, another library in your project (likely a transitive dependency) is forcing an **older** version of Guava (older than 31.0) onto your classpath at runtime.
* **The Victim:** com.google.common.truth.Subject is trying to call this method, but the older Guava JAR loaded by Android doesn't have it yet.

You need to force your project to use a newer version of Guava that includes this method.

Add (or update) the Guava dependency explicitly in your module's build.gradle file within the dependencies block. Make sure to use the \-android flavor:

Groovy

dependencies {
    // Force a newer version of Guava (31.0 or higher) for your tests
    androidTestImplementation 'com.google.guava:guava:33.3.1-android'
}

**Note:** If you are using implementation or api for Guava elsewhere, ensure those versions are also consistent (31.0+) so you don't get runtime crashes in your production app as well.

You likely upgraded com.google.truth:truth recently.

* **Truth 1.1.4 and newer** started using ImmutableMap.buildOrThrow() internally.
* If your project pulls in an older library (like an older version of the Android tools or Firebase SDKs) that depends on Guava 28.x or 20.0, Gradle's conflict resolution might be downgrading Guava to that older version, breaking Truth.

To confirm which old library is "poisoning" your dependency tree, you can run the following command in your terminal:

Bash

./gradlew app:dependencies \--configuration androidTestCompileClasspath

*(Replace app with your module name)*. Look for com.google.guava:guava in the output. You will likely see something like 33.3.1-android \-\> 28.1-android, indicating a downgrade happened. Adding the explicit dependency above fixes this by telling Gradle "I really mean it, use the new one."