### PR TITLE
dataconnect: fix `updateJson` task to find cli versions whose file name contains its target cpu architecture

### DIFF
--- a/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/CpuArchitecture.kt
+++ b/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/CpuArchitecture.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.dataconnect.gradle.plugin
+
+import java.util.Locale
+
+enum class CpuArchitecture {
+  AMD64,
+  ARM64;
+
+  companion object {
+    fun current(): CpuArchitecture? {
+      val arch = System.getProperty("os.arch")
+      return if (arch === null) null else forName(arch)
+    }
+
+    fun forName(arch: String): CpuArchitecture? =
+      forNameWithLowercaseArch(arch.lowercase(Locale.ROOT))
+
+    // This logic was adapted from
+    // https://github.com/gradle/gradle/blob/4457734e73fc567a43ccf96185341432b636bc47/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/os/OperatingSystem.java#L357-L369
+    private fun forNameWithLowercaseArch(arch: String): CpuArchitecture? =
+      when (arch) {
+        "x86_64",
+        "amd64" -> CpuArchitecture.AMD64
+        "aarch64" -> CpuArchitecture.ARM64
+        else -> null
+      }
+  }
+}

--- a/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableVersionRegistry.kt
+++ b/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableVersionRegistry.kt
@@ -70,6 +70,7 @@ object DataConnectExecutableVersionsRegistry {
   data class VersionInfo(
     @Serializable(with = LooseVersionSerializer::class) val version: Version,
     @Serializable(with = OperatingSystemSerializer::class) val os: OperatingSystem,
+    @Serializable(with = CpuArchitectureSerializer::class) val arch: CpuArchitecture? = null,
     val size: Long,
     val sha512DigestHex: String,
   )
@@ -95,11 +96,39 @@ object DataConnectExecutableVersionsRegistry {
       encoder.encodeString(value.serializedValue)
   }
 
+  private object CpuArchitectureSerializer : KSerializer<CpuArchitecture> {
+    override val descriptor =
+      PrimitiveSerialDescriptor(
+        "com.google.firebase.dataconnect.gradle.plugin.CpuArchitecture",
+        PrimitiveKind.STRING,
+      )
+
+    override fun deserialize(decoder: Decoder): CpuArchitecture =
+      decoder.decodeString().let { serializedValue ->
+        CpuArchitecture.entries.singleOrNull { it.serializedValue == serializedValue }
+          ?: throw DataConnectGradleException(
+            "yxnvjm2nxe",
+            "Unknown CPU architecture: $serializedValue " +
+              "(must be one of ${CpuArchitecture.entries.joinToString { it.serializedValue }})"
+          )
+      }
+
+    override fun serialize(encoder: Encoder, value: CpuArchitecture) =
+      encoder.encodeString(value.serializedValue)
+  }
+
   val OperatingSystem.serializedValue: String
     get() =
       when (this) {
         OperatingSystem.Windows -> "windows"
         OperatingSystem.MacOS -> "macos"
         OperatingSystem.Linux -> "linux"
+      }
+
+  val CpuArchitecture.serializedValue: String
+    get() =
+      when (this) {
+        CpuArchitecture.AMD64 -> "amd64"
+        CpuArchitecture.ARM64 -> "arm64"
       }
 }


### PR DESCRIPTION
dataconnect: fix `updateJson` task to find Data Connect executables whose file name is updated to also include the cpu architecture

This naming change started with Data Connect executable version 2.16.0, which started to be published in both x86_64 and arm64 variants. For example, the file name for the macos emulator version 2.15.1 was `dataconnect-emulator-macos-v2.15.1` but in 2.16.0 there were two executables named `dataconnect-emulator-macos-amd64-v2.16.0` and `dataconnect-emulator-macos-arm64-v2.16.0` (the only difference being one is named "amd64" and the other "arm64").