### PR TITLE
dataconnect: gradle plugin: fix DataConnectExecutableDownloadTask for arch-specific executable versions

### DIFF
--- a/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/DataConnectGradlePlugin.kt
+++ b/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/DataConnectGradlePlugin.kt
@@ -111,6 +111,7 @@ abstract class DataConnectGradlePlugin : Plugin<Project> {
             )
           )
           operatingSystem.set(dataConnectProviders.operatingSystem)
+          cpuArchitecture.set(dataConnectProviders.cpuArchitecture)
           outputFile.set(
             dataConnectExecutable.map {
               when (it) {

--- a/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/DataConnectProviders.kt
+++ b/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/DataConnectProviders.kt
@@ -62,6 +62,8 @@ class DataConnectProviders(
 
   val operatingSystem: Provider<OperatingSystem> = project.provider { OperatingSystem.current() }
 
+  val cpuArchitecture: Provider<CpuArchitecture> = project.provider { CpuArchitecture.current() }
+
   val postgresConnectionUrl: Provider<String> = run {
     val gradlePropertyName = "dataconnect.emulator.postgresConnectionUrl"
     val valueFromLocalSettings: Provider<String> = localSettings.postgresConnectionUrl


### PR DESCRIPTION
A previous PR, #7600, fixed the `updateJson` task of the data connect Gradle plugin to find cli versions whose file name contains its target cpu architecture. This PR is a follow-up to #7600 to also implement the same logic for the Gradle task that _downloads_ the cli.