### PR TITLE
dataconnect: testing: RandomSeedTestRule.kt tiny log message cleanup

### DIFF
--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/RandomSeedTestRule.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/RandomSeedTestRule.kt
@@ -36,8 +36,8 @@ class RandomSeedTestRule(val rs: Lazy<RandomSource>) : TestRule {
         result.onFailure {
           if (rs.isInitialized()) {
             println(
-              "55negqf33k Test ${description.displayName} failed using " +
-                "RandomSource with seed=${rs.value.seed}"
+              "WARNING[55negqf33k]: RandomSeedTestRule: Test failed using " +
+                "RandomSource with seed=${rs.value.seed}: ${description.displayName}"
             )
           }
         }


### PR DESCRIPTION
This PR makes a minor cleanup of a log message within the Data Connect `RandomSeedTestRule.kt` file. The change improves the clarity and consistency of test failure output, making it easier to diagnose issues when tests fail due to random seed usage.
