### PR TITLE
dataconnect: testing: re-write Struct and ListValue arbs

### DIFF
--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/proto.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/proto.kt
@@ -43,7 +43,6 @@ import io.kotest.property.arbitrary.string
 import io.kotest.property.asSample
 import io.kotest.property.exhaustive.constant
 import io.kotest.property.exhaustive.of
-import kotlin.random.Random
 import kotlin.random.nextInt
 
 object ProtoArb {
@@ -278,7 +277,13 @@ private abstract class CompositeValueArb<V, I>(
     generate(
         rs,
         depthEdgeCaseProbability = rs.random.nextFloat(),
-        GenerateCompositeValueProbabilities(rs)
+        GenerateCompositeValueProbabilities(
+          rs.random.nextFloat(),
+          rs.random.nextFloat(),
+          rs.random.nextFloat(),
+          rs.random.nextFloat(),
+          rs.random.nextFloat(),
+        ),
       )
       .asSample()
 
@@ -443,19 +448,7 @@ private data class GenerateCompositeValueProbabilities(
   val structKeyEdgeCase: Float,
   val scalarValueEdgeCase: Float,
   val nested: Float,
-) {
-  constructor(
-    random: Random
-  ) : this(
-    random.nextFloat(),
-    random.nextFloat(),
-    random.nextFloat(),
-    random.nextFloat(),
-    random.nextFloat(),
-  )
-
-  constructor(rs: RandomSource) : this(rs.random)
-}
+)
 
 private class StructOrListValueGenerator(
   private val scalarValue: Arb<Value>,


### PR DESCRIPTION
This PR refactors of the `dataconnect` arbitrary data generation for `Struct` and `ListValue` types for testing. The changes streamline the complex logic involved in creating diverse and deeply nested test data, enhancing the overall maintainability and clarity of the property-based testing framework. By consolidating common patterns and introducing a dedicated generator class, the codebase becomes more organized and easier to extend.

### Highlights

* **Refactored Arbitrary Data Generation**: The core logic for generating arbitrary `Struct` and `ListValue` instances has been significantly refactored to reduce code duplication. This involved introducing a new `CompositeValueArb` abstract class and a `StructOrListValueGenerator` helper.
* **Consolidated Nested Value Generation**: The mechanism for generating nested `Struct` and `ListValue` instances has been centralized within the `StructOrListValueGenerator`, replacing previous duplicated logic and helper functions.

<details>
<summary><b>Changelog</b></summary>

* **property/arbitrary/proto.kt**
    * Removed unused imports (`withAddedField`, `withAddedListIndex`, `Sample`, `withEdgecases`) and added new ones (`DataConnectPathSegment`, `withAddedPathSegment`).
    * Modified `value` function to accept an optional `structKey` parameter, which is propagated to `struct` and `listValue` calls.
    * Updated `listValue` and `struct` function signatures to include new parameters (`structKey`, `structSize`, `listSize`) and adjusted their constructor calls to use new parameter names (`sizeRange`, `depthRange`, etc.).
    * Replaced the individual `StructArb` and `ListValueArb` classes with a new abstract `CompositeValueArb` base class.
    * Introduced `GenerateCompositeValueProbabilities` data class to group probability parameters for cleaner function signatures.
    * Implemented `StructOrListValueGenerator` to centralize the core logic for generating `Struct` and `ListValue` instances, including handling nesting and edge cases.
    * Refactored `StructArb` and `ListValueArb` to extend `CompositeValueArb` and delegate their generation logic to the new `StructOrListValueGenerator`.
    * Removed `NextNestedValueResult` data class and `NextNestedValueCase` enum, along with the `RandomSource.nextNestedValue` extension function, as their functionality is now integrated into the new generator architecture.
</details>