### PR TITLE
dataconnect: testing: use Arb.choice() instead of Arb.merge()

### DIFF
--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/arbs.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/arbs.kt
@@ -29,6 +29,7 @@ import io.kotest.property.arbitrary.arabic
 import io.kotest.property.arbitrary.arbitrary
 import io.kotest.property.arbitrary.ascii
 import io.kotest.property.arbitrary.boolean
+import io.kotest.property.arbitrary.choice
 import io.kotest.property.arbitrary.choose
 import io.kotest.property.arbitrary.cyrillic
 import io.kotest.property.arbitrary.double
@@ -37,7 +38,6 @@ import io.kotest.property.arbitrary.filterNot
 import io.kotest.property.arbitrary.hex
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.map
-import io.kotest.property.arbitrary.merge
 import io.kotest.property.arbitrary.orNull
 import io.kotest.property.arbitrary.string
 import io.kotest.property.asSample
@@ -51,10 +51,12 @@ object DataConnectArb {
   val javaTime: JavaTimeArbs = JavaTimeArbs
 
   val codepoints: Arb<Codepoint> =
-    Codepoint.ascii()
-      .merge(Codepoint.egyptianHieroglyphs())
-      .merge(Codepoint.arabic())
-      .merge(Codepoint.cyrillic())
+    Arb.choice(
+        Codepoint.ascii(),
+        Codepoint.egyptianHieroglyphs(),
+        Codepoint.arabic(),
+        Codepoint.cyrillic(),
+      )
       // Do not produce character code 0 because it's not supported by Postgresql:
       // https://www.postgresql.org/docs/current/datatype-character.html
       .filterNot { it.value == 0 }


### PR DESCRIPTION
This PR refactors Data Connect's the character generation logic within its testing utility. By transitioning from sequential `Arb.merge()` calls to a single `Arb.choice()` invocation, the PR improves the statistical distribution of generated codepoints, ensuring that test data more accurately represents a diverse range of characters.

### Highlights

* **Improved Character Distribution**: The method for generating codepoints in testing utilities has been updated from a series of `Arb.merge()` calls to a single `Arb.choice()` call. This change ensures a more even distribution of generated characters, addressing the previous strong weighting towards the final `Arb` in the chain.

<details>
<summary><b>Changelog</b></summary>

* **arbs.kt**
    * Replaced chained `Arb.merge()` calls with a single `Arb.choice()` call for the `codepoints` arbitrary generator.
    * Updated import statements to include `io.kotest.property.arbitrary.choice` and remove `io.kotest.property.arbitrary.merge`.
</details>
