### PR TITLE
dataconnect: testing: internal refactor of chain of "ifs" to a "when" expression

### DIFF
--- a/firebase-dataconnect/testutil/src/test/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/protoUnitTest.kt
+++ b/firebase-dataconnect/testutil/src/test/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/protoUnitTest.kt
@@ -317,7 +317,7 @@ class protoUnitTest {
     }
 
     fun Value.hasNestedKind(kindCase: Value.KindCase): Boolean =
-      when (this@hasNestedKind.kindCase) {
+      when (this.kindCase) {
         kindCase -> true
         Value.KindCase.LIST_VALUE -> listValue.hasNestedKind(kindCase)
         Value.KindCase.STRUCT_VALUE -> structValue.hasNestedKind(kindCase)


### PR DESCRIPTION
This PR slightly improves code readability and maintainability within the Data Connect unit testing suite by replacing a multi-conditional `if-else if` structure with a Kotlin `when` expression. No functional changes were made by this PR.

### Highlights

* **Refactoring**: The pull request refactors a chain of `if-else if` statements into a more concise and readable `when` expression within the `Value.hasNestedKind` extension function.
* **No Logic Change**: This change is purely a refactoring and does not alter the existing logic or behavior of the unit test code.

<details>
<summary><b>Changelog</b></summary>

* **protoUnitTest.kt**
    * Converted an `if-else if` chain to a `when` expression in the `Value.hasNestedKind` function for improved readability.
</details>
