### PR TITLE
dataconnect: testing: freeze mutable lists in tests to improve readability

### DIFF
--- a/firebase-dataconnect/testutil/src/test/kotlin/com/google/firebase/dataconnect/testutil/ProtoDiffUnitTest.kt
+++ b/firebase-dataconnect/testutil/src/test/kotlin/com/google/firebase/dataconnect/testutil/ProtoDiffUnitTest.kt
@@ -85,7 +85,7 @@ class ProtoDiffUnitTest {
     checkAll(propTestConfig, structArb, Arb.int(1..5)) { struct1, keyCount ->
       val mutableDifferences = mutableListOf<DifferencePathPair<*>>()
       val struct2 = prepare(struct1, keyCount, mutableDifferences)
-      val expectedDifferences = mutableDifferences
+      val expectedDifferences = mutableDifferences.toList()
 
       structFastEqual(struct1, struct2) shouldBe false
       structFastEqual(struct2, struct1) shouldBe false
@@ -245,7 +245,7 @@ class ProtoDiffUnitTest {
     checkAll(propTestConfig, listValueArb, Arb.int(1..5)) { listValue1, itemCount ->
       val mutableDifferences = mutableListOf<DifferencePathPair<*>>()
       val listValue2 = prepare(listValue1, itemCount, mutableDifferences)
-      val expectedDifferences = mutableDifferences
+      val expectedDifferences = mutableDifferences.toList()
 
       listValueFastEqual(listValue1, listValue2) shouldBe false
       listValueFastEqual(listValue2, listValue1) shouldBe false


### PR DESCRIPTION
This PR enhances the readability and robustness of Data Connect's property-based tests within the `ProtoDiffUnitTest` by ensuring that lists representing expected differences are treated as immutable once defined. This change prevents any subsequent modifications from affecting the test's assertion logic.

### Highlights

* **Test Readability**: Converted mutable lists to immutable lists using `.toList()` in `ProtoDiffUnitTest` to clearly define expected differences and prevent unintended modifications during test execution.

<details>
<summary><b>Changelog</b></summary>

* **ProtoDiffUnitTest.kt**
    * Changed `expectedDifferences = mutableDifferences` to `expectedDifferences = mutableDifferences.toList()` in two `checkAll` test blocks to freeze the list of differences.
</details>
