### PR TITLE
[Components] Fix typo when logging error

### DIFF
--- a/firebase-components/CHANGELOG.md
+++ b/firebase-components/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+
 - [fixed] fixed typo in message logged when a class is not found during component discovery.
 
 # 19.0.0

--- a/firebase-components/src/main/java/com/google/firebase/components/ComponentDiscovery.java
+++ b/firebase-components/src/main/java/com/google/firebase/components/ComponentDiscovery.java
@@ -126,7 +126,7 @@ public final class ComponentDiscovery<T> {
       return (ComponentRegistrar) loadedClass.getDeclaredConstructor().newInstance();
     } catch (ClassNotFoundException e) {
       Log.w(TAG, String.format("Class %s was not found.", registrarName));
-      
+
       return null;
     } catch (IllegalAccessException e) {
       throw new InvalidRegistrarException(


### PR DESCRIPTION
The previous message was "Class %s is not an found." and it should be ""Class %s was not found." 