### PR TITLE
[Firestore] Update setup instructions

### DIFF
--- a/firebase-firestore/README.md
+++ b/firebase-firestore/README.md
@@ -11,7 +11,7 @@ including Cloud Functions.
 
 > **Note**: All Gradle commands listed below must be run from the **monorepo source root** (one level up from this directory).
 
-## Building 
+## Building
 
 To build the Firestore component release archive:
 


### PR DESCRIPTION
Refactors Firestore README to fix setup inaccuracies I found when setting up my local dev environment and improves the documentation for running integration tests.
- Corrected `google-services.json` path: The previous instruction for placing `google-services.json` at the root dir was incorrect, and caused the tests to fallback to using a dummy config, which caused my tests to fail. After moving the file to `firebase-firestore/google-services.json` the tests passed for me.
- Documented hidden CLI flags (`-PtargetBackend`, `-PbackendEdition`, `-PtargetDatabaseId`)
- Removed IDE-specific Run Configurations, which I couldn't find in Android Studio anywhere. I don't think they exist anymore.
- Moved prerequisites section to the very of the testing section, instead of being buried below build commands