### PR TITLE
Update Perf e2e workflow to use OSS_BOT_BUILDTOOLS_CHECKOUT_PAT to fix permissions issues

### DIFF
--- a/.github/workflows/fireperf-e2e.yml
+++ b/.github/workflows/fireperf-e2e.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: FirebasePrivate/firebase-android-buildtools
-          token: ${{ secrets.GOOGLE_OSS_BOT_TOKEN }}
+          token: ${{ secrets.OSS_BOT_BUILDTOOLS_CHECKOUT_PAT }}
           path: firebase-android-buildtools
       - name: Set up JDK 17
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0


### PR DESCRIPTION
- `GOOGLE_OSS_BOT_TOKEN` did not have readaccess to firebase-android-buildtools