### PR TITLE
Explicitly set permissions: contents: read only

### DIFF
--- a/.github/workflows/create-releases-buildtools.yml
+++ b/.github/workflows/create-releases-buildtools.yml
@@ -12,6 +12,9 @@ on:
           - crashlytics
           - performance
 
+permissions:
+  contents: read
+
 env:
   ARTIFACTS: ${{ github.workspace }}/build/artifacts
 

--- a/.github/workflows/perf-gradle-compatibility-tests.yml
+++ b/.github/workflows/perf-gradle-compatibility-tests.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 6 * * *' # Run daily at 6 AM
   workflow_dispatch: # Allow manual triggering
 
+permissions:
+  contents: read
+
 jobs:
   performance-plugin:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Explicitly set permissions: contents: read only

Based on warning from https://github.com/firebase/firebase-android-sdk/security/code-scanning/469