### PR TITLE
[AppCheck] Add missing changelog entries.

### DIFF
--- a/appcheck/firebase-appcheck-debug-testing/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-debug-testing/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [unchanged] Updated to keep [app_check] SDK versions aligned.
+
 # 19.0.1
 
 - [changed] Bumped internal dependencies.
@@ -80,4 +82,3 @@
 # 16.0.0-beta01
 
 - [feature] Initial beta release of the [app_check] Debug Testing SDK with abuse reduction features.
-

--- a/appcheck/firebase-appcheck-debug/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-debug/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [unchanged] Updated to keep [app_check] SDK versions aligned.
+
 # 19.0.1
 
 - [changed] Bumped internal dependencies.
@@ -85,4 +87,3 @@
 # 16.0.0-beta01
 
 - [feature] Initial beta release of the [app_check] Debug SDK with abuse reduction features.
-

--- a/appcheck/firebase-appcheck-playintegrity/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-playintegrity/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [unchanged] Updated to keep [app_check] SDK versions aligned.
+
 # 19.0.1
 
 - [changed] Bumped internal dependencies.
@@ -56,4 +58,3 @@
 
 - [feature] Added support for [Play Integrity](https://developer.android.com/google/play/integrity)
   as an attestation provider.
-


### PR DESCRIPTION
The change introduced in (#7640) triggers a release of app check, and all SDKs must contain a changelog entry for it.