### PR TITLE
Standardize kotlin regex syntax

### DIFF
--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/Changelog.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/Changelog.kt
@@ -62,7 +62,7 @@ data class Changelog(val releases: List<ReleaseEntry>) {
      * ]
      * ```
      */
-    val RELEASE_VERSION_REGEX = Regex("^# (.+)", RegexOption.MULTILINE)
+    val RELEASE_VERSION_REGEX = Regex("""^# (.+)""", RegexOption.MULTILINE)
 
     /**
      * Parses a [Changelog] from a [String].
@@ -177,7 +177,7 @@ data class ReleaseEntry(
      * "## Kotlin"
      * ```
      */
-    val KOTLIN_TITLE_REGEX = Regex("^## Kotlin\n", RegexOption.MULTILINE)
+    val KOTLIN_TITLE_REGEX = Regex("""^## Kotlin\n""", RegexOption.MULTILINE)
 
     /**
      * Parses a [ReleaseEntry] from a [String], given the version name.
@@ -288,7 +288,7 @@ data class ReleaseContent(val subtext: String, val changes: List<Change>) {
      * "This release contains a known bug. We will address this in a future bugfix."
      * ```
      */
-    val SUBTEXT_REGEX = Regex("^([^\\*\\s][\\s\\S]+?)(\\n\\n|(?![\\s\\S]))")
+    val SUBTEXT_REGEX = Regex("""^([^\*\s][\s\S]+?)(\n\n|(?![\s\S]))""")
 
     /**
      * Parses [ReleaseContent] from a [String].
@@ -350,7 +350,7 @@ data class Change(val type: ChangeType, val message: String) {
      * ]
      * ```
      */
-    val REGEX = Regex("^ ?\\[ ?(?<type>\\w+) ?\\](?<content>[\\s\\S]*)", RegexOption.MULTILINE)
+    val REGEX = Regex("""^ ?\[ ?(?<type>\w+) ?\](?<content>[\s\S]*)""", RegexOption.MULTILINE)
 
     /**
      * Parses [Change] from a [String].

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/CopyGoogleServicesPlugin.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/CopyGoogleServicesPlugin.kt
@@ -69,7 +69,7 @@ abstract class CopyGoogleServicesPlugin : Plugin<Project> {
       val library = project.extensions.getByType<BaseExtension>()
 
       val targetPackageLine = "\"package_name\": \"${library.namespace}\""
-      val packageLineRegex = Regex("\"package_name\":\\s+\".*\"")
+      val packageLineRegex = Regex("""\"package_name":\s+".*\"""")
 
       from(path)
       into(project.projectDir)

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
@@ -105,7 +105,7 @@ abstract class FiresiteTransformTask : DefaultTask() {
    *
    * TODO(b/378717454): Migrate to the param packagePrefixToRemoveInToc in dackka when fixed
    */
-  private fun String.removePackagePrefix() = remove(Regex("(?<=title: \")(com\\.google\\.)"))
+  private fun String.removePackagePrefix() = remove(Regex("""(?<=title: ")(com\.google\.)"""))
 
   /**
    * Fixes broken hyperlinks in the rendered HTML
@@ -163,7 +163,7 @@ abstract class FiresiteTransformTask : DefaultTask() {
    */
   // TODO(b/310964911): Remove when we drop ktx modules
   private fun String.addDeprecatedStatus(): String =
-    replace(Regex("- title: \"(.+ktx)\"")) {
+    replace(Regex("""- title: "(.+ktx)\"""")) {
       val packageName = it.firstCapturedValue
 
       """
@@ -177,13 +177,13 @@ abstract class FiresiteTransformTask : DefaultTask() {
   // so these headers will throw not found errors if not removed.
   // TODO(b/243674302): Remove when dackka exposes configuration for this
   private fun String.removeClassHeader() =
-    remove(Regex("- title: \"Class Index\"\n {2}path: \".+\"\n\n"))
+    remove(Regex("""- title: "Class Index"\n {2}path: ".+"\n\n"""))
 
   private fun String.removeIndexHeader() =
-    remove(Regex("- title: \"Package Index\"\n {2}path: \".+\"\n\n"))
+    remove(Regex("""- title: "Package Index"\n {2}path: ".+"\n\n"""))
 
   // We use a common book for all sdks, wheres dackka expects each sdk to have its own book.
   // TODO(b/243674303): Remove when dackka exposes configuration for this
   private fun String.fixBookPath() =
-    remove(Regex("(?<=setvar book_path ?%})(.+)(?=/_book.yaml\\{% ?endsetvar)"))
+    remove(Regex("""(?<=setvar book_path ?%})(.+)(?=/_book.yaml\{% ?endsetvar)"""))
 }

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/MakeReleaseNotesTask.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/MakeReleaseNotesTask.kt
@@ -221,7 +221,7 @@ abstract class MakeReleaseNotesTask : DefaultTask() {
      */
     private val LINK_REGEX =
       Regex(
-        "(?:GitHub )?(?:\\[|\\()#(\\d+)(?:\\]|\\))(?:\\(.+?\\))?(?:\\{:\\s*\\.external\\})?",
+        """(?:GitHub )?(?:\[|\()#(\d+)(?:\]|\))(?:\(.+?\))?(?:\{:\s*\.external\})?""",
         RegexOption.MULTILINE,
       )
 

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/ReleaseGenerator.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/ReleaseGenerator.kt
@@ -87,7 +87,7 @@ data class CommitDiff(
   companion object {
     // This is a meant to capture the PR number from PR Titles
     // ex: "Fix a problem (#1234)" -> "1234"
-    private val PR_ID_EXTRACTOR = Regex(".*\\(#(\\d+)\\).*")
+    private val PR_ID_EXTRACTOR = Regex(""".*\(#(\d+)\).*""")
 
     public fun fromRevCommit(commit: RevCommit): CommitDiff {
       val commitId = commit.id.name

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/SemVerTask.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/SemVerTask.kt
@@ -65,7 +65,7 @@ abstract class SemVerTask @Inject constructor(private val execOperations: ExecOp
     )
 
     val string = String(stream.toByteArray())
-    val reg = Regex("(.*)\\s+error:\\s+(.*\\s+\\[(.*)\\])")
+    val reg = Regex("""(.*)\s+error:\s+(.*\s+\[(.*)\])""")
     val minorChanges = mutableListOf<String>()
     val majorChanges = mutableListOf<String>()
     for (match in reg.findAll(string)) {

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/UpdatePinnedDependenciesTask.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/UpdatePinnedDependenciesTask.kt
@@ -156,7 +156,7 @@ abstract class UpdatePinnedDependenciesTask : DefaultTask() {
      * ```
      */
     val DEPENDENCY_REGEX =
-      Regex("(?<=\\s{1,20}\\w{1,20}(?:\\s|\\())project\\((?:'|\")(:\\S+)(?:'|\")\\)")
+      Regex("""(?<=\s{1,20}\w{1,20}(?:\s|\())project\((?:'|")(:\\S+)(?:'|\")\)""")
 
     val DEPENDENCIES_TO_IGNORE = listOf(":protolite-well-known-types")
   }

--- a/plugins/src/test/kotlin/com/google/firebase/gradle/plugins/FirebaseTestController.kt
+++ b/plugins/src/test/kotlin/com/google/firebase/gradle/plugins/FirebaseTestController.kt
@@ -66,7 +66,7 @@ class FirebaseTestController(val rootDirectory: TemporaryFolder) {
    * @see pom
    */
   fun Project.pomOrNull(): Pom? {
-    val regex = Regex(".*/${group.replace('.', '/')}/$name/$expectedVersion.*/.*\\.pom$")
+    val regex = Regex(""".*/${group.replace('.', '/')}/$name/$expectedVersion.*/.*\.pom$""")
     val repository = rootDirectory.root.childFile("build/m2repository")
     val pomFile = repository.walk().find { it.isFile && it.path.matches(regex) }
 


### PR DESCRIPTION
Utilizes kotlin triple quote strings to reduce hard to understand escapes in regexes. Only modified plugin code, dataconnect uses single quote escape strings but was left unmodified.