### PR TITLE
[AI] Consolidate `generateContent` and `countTokens` overloads

### DIFF
--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/GenerativeModel.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/GenerativeModel.kt
@@ -290,9 +290,8 @@ internal constructor(
    * @throws [FirebaseAIException] if the request failed.
    * @see [FirebaseAIException] for types of errors.
    */
-  public suspend fun countTokens(prompt: String): CountTokensResponse {
-    return countTokens(listOf(content { text(prompt) }))
-  }
+  public suspend fun countTokens(prompt: String): CountTokensResponse =
+    countTokens(listOf(content { text(prompt) }))
 
   /**
    * Counts the number of tokens in an image prompt using the model's tokenizer.
@@ -302,9 +301,8 @@ internal constructor(
    * @throws [FirebaseAIException] if the request failed.
    * @see [FirebaseAIException] for types of errors.
    */
-  public suspend fun countTokens(prompt: Bitmap): CountTokensResponse {
-    return countTokens(listOf(content { image(prompt) }))
-  }
+  public suspend fun countTokens(prompt: Bitmap): CountTokensResponse =
+    countTokens(listOf(content { image(prompt) }))
 
   internal fun hasFunction(call: FunctionCallPart): Boolean {
     return tools


### PR DESCRIPTION
Refactored `GenerativeModel` to use a consistent `List<Content>` input for its core `generateContent`, `generateContentStream`, `generateObject`, and `countTokens` methods.

This change:

- Consolidates internal request building logic into `buildGenerateContentRequest` and `buildCountTokensRequest`.

- Removes the need for `ExperimentalSerializationApi` annotation.

- Renames `constructRequest` to `buildGenerateContentRequest` for better readability