### PR TITLE
[Plugin] Update release machinery to include firebase-java-library modules

### DIFF
--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/ReleaseGenerator.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/ReleaseGenerator.kt
@@ -63,7 +63,7 @@ data class ReleaseReport(
       |${changesByLibraryName.entries.joinToString("\n") {
       """
       |## ${it.key}
-      
+
       |${it.value.joinToString("\n") { it.toString() }}
       """.trimMargin()
       }
@@ -142,7 +142,10 @@ abstract class ReleaseGenerator : DefaultTask() {
   @Throws(Exception::class)
   fun generateReleaseConfig() {
     val rootDir = project.rootDir
-    val availableModules = project.subprojects.filter { it.plugins.hasPlugin("firebase-library") }
+    val availableModules =
+      project.subprojects.filter {
+        it.plugins.hasPlugin("firebase-library") || it.plugins.hasPlugin("firebase-java-library")
+      }
 
     val repo = Git.open(rootDir)
     val headRef = repo.repository.resolve(Constants.HEAD)


### PR DESCRIPTION
The old code, publish in march 2023, restricted the publication of artifacts to the modules depending on the `firebase-library` plugin, which is most of the SDKs. The jar-only SDKs, like annotations, depend on the `firebase-java-library` and were not being included in the release process.

Discovered because the release was missing the `firebase-ai-ksp` sdk