### PR TITLE
[AI] Enhance generative model fallback to include on-device exceptions

### DIFF
--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/generativemodel/FallbackGenerativeModelProvider.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/generativemodel/FallbackGenerativeModelProvider.kt
@@ -17,6 +17,7 @@
 package com.google.firebase.ai.generativemodel
 
 import android.util.Log
+import com.google.firebase.ai.ondevice.interop.FirebaseAIOnDeviceException
 import com.google.firebase.ai.type.Content
 import com.google.firebase.ai.type.CountTokensResponse
 import com.google.firebase.ai.type.FirebaseAIException
@@ -88,8 +89,10 @@ internal class FallbackGenerativeModelProvider(
     }
     return try {
       defaultModel.block()
-    } catch (e: FirebaseAIException) {
-      if (shouldFallbackInException) {
+    } catch (e: Exception) {
+      if (
+        shouldFallbackInException && (e is FirebaseAIException || e is FirebaseAIOnDeviceException)
+      ) {
         Log.w(
           TAG,
           "Error running `$methodName` on `${defaultModel.javaClass.simpleName}`. Falling back to `${fallbackModel.javaClass.simpleName}`",


### PR DESCRIPTION
Update the `FallbackGenerativeModelProvider` to trigger fallback behavior for `FirebaseAIOnDeviceException` in addition to `FirebaseAIException`.

This issue was preventing the fallback behaviour when using on-device models as primary, and cloud as fallback.

Internal b/483748535