### PR TITLE
 Rethrow `CancellationException` directly

### DIFF
--- a/firebase-ai-ondevice-interop/src/main/kotlin/com/google/firebase/ai/ondevice/interop/FirebaseAIOnDeviceException.kt
+++ b/firebase-ai-ondevice-interop/src/main/kotlin/com/google/firebase/ai/ondevice/interop/FirebaseAIOnDeviceException.kt
@@ -16,6 +16,8 @@
 
 package com.google.firebase.ai.ondevice.interop
 
+import kotlinx.coroutines.CancellationException
+
 /** Parent class for any errors that occur from the Firebase AI OnDevice SDK. */
 public abstract class FirebaseAIOnDeviceException
 internal constructor(message: String, cause: Throwable? = null) : RuntimeException(message, cause) {
@@ -30,6 +32,7 @@ internal constructor(message: String, cause: Throwable? = null) : RuntimeExcepti
     public fun from(cause: Exception): FirebaseAIOnDeviceException =
       when (cause) {
         is FirebaseAIOnDeviceException -> cause
+        is CancellationException -> throw cause
         else -> FirebaseAIOnDeviceUnknownException("Something unexpected happened.", cause)
       }
   }

--- a/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/Exceptions.kt
+++ b/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/Exceptions.kt
@@ -18,6 +18,7 @@ package com.google.firebase.ai.type
 
 import com.google.firebase.ai.FirebaseAI
 import com.google.firebase.ai.ondevice.interop.FirebaseAIOnDeviceException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 
 /** Parent class for any errors that occur from the [FirebaseAI] SDK. */
@@ -46,6 +47,7 @@ internal constructor(message: String, cause: Throwable? = null) : RuntimeExcepti
           }
         is TimeoutCancellationException ->
           RequestTimeoutException("The request failed to complete in the allotted time.")
+        is CancellationException -> throw cause
         else -> UnknownException("Something unexpected happened.", cause)
       }
 

--- a/firebase-ai/src/test/java/com/google/firebase/ai/generativeModel/FallbackGenerativeModelProviderTests.kt
+++ b/firebase-ai/src/test/java/com/google/firebase/ai/generativeModel/FallbackGenerativeModelProviderTests.kt
@@ -156,4 +156,29 @@ internal class FallbackGenerativeModelProviderTests {
     response shouldBe expectedResponse
     coVerify { fallbackModel.generateObject(schema, prompt) }
   }
+
+  @Test
+  fun `generateContent rethrows CancellationException and does not fall back`() = runBlocking {
+    val exception = kotlinx.coroutines.CancellationException("cancelled")
+    coEvery { defaultModel.generateContent(prompt) } throws exception
+
+    val provider = FallbackGenerativeModelProvider(defaultModel, fallbackModel)
+
+    shouldThrow<kotlinx.coroutines.CancellationException> { provider.generateContent(prompt) }
+    coVerify(exactly = 0) { fallbackModel.generateContent(any()) }
+  }
+
+  @Test
+  fun `generateContentStream rethrows CancellationException and does not fall back`() =
+    runBlocking {
+      val exception = kotlinx.coroutines.CancellationException("cancelled")
+      every { defaultModel.generateContentStream(prompt) } throws exception
+
+      val provider = FallbackGenerativeModelProvider(defaultModel, fallbackModel)
+
+      shouldThrow<kotlinx.coroutines.CancellationException> {
+        provider.generateContentStream(prompt)
+      }
+      verify(exactly = 0) { fallbackModel.generateContentStream(any()) }
+    }
 }


### PR DESCRIPTION
Modify exception handling in `FirebaseAIOnDeviceException.from` and `FirebaseAIException.from` to rethrow
`kotlinx.coroutines.CancellationException` directly instead of wrapping it. This ensures proper propagation of coroutine cancellations.