### PR TITLE
Enable javadoc publishing for on-device

### DIFF
--- a/firebase-ai-ondevice/firebase-ai-ondevice.gradle.kts
+++ b/firebase-ai-ondevice/firebase-ai-ondevice.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 
 firebaseLibrary {
   testLab.enabled = false
-  publishJavadoc = false
+  publishJavadoc = true
   releaseNotes {
     name.set("{{firebase_ai_logic_ondevice}}")
     versionName.set("ai_ondevice")


### PR DESCRIPTION
The download API is hosted in this SDK, thus it requires the javadocs to be published.