### PR TITLE
dataconnect: temporarily remove public apis for offline caching

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -1,13 +1,11 @@
 # Unreleased
 
-- [changed] Added public APIs for offline caching.
-  [#7716](https://github.com/firebase/firebase-android-sdk/pull/7716))
-- [changed] Added hydration and dehydration logic for use in offline caching.
-  [#7714](https://github.com/firebase/firebase-android-sdk/pull/7714))
-- [changed] Added sqlite database logic for use in offline caching.
-  [#7720](https://github.com/firebase/firebase-android-sdk/pull/7720))
-- [changed] Wired up implementation for serving query responses from cache.
-  [#7759](https://github.com/firebase/firebase-android-sdk/pull/7759))
+- [changed] Internal changes to support future offline caching functionality.
+  [#7716](https://github.com/firebase/firebase-android-sdk/pull/7716)),
+  [#7714](https://github.com/firebase/firebase-android-sdk/pull/7714)),
+  [#7720](https://github.com/firebase/firebase-android-sdk/pull/7720)),
+  [#7759](https://github.com/firebase/firebase-android-sdk/pull/7759)),
+  [#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
 
 # 17.1.3
 

--- a/firebase-dataconnect/api.txt
+++ b/firebase-dataconnect/api.txt
@@ -24,21 +24,6 @@ package com.google.firebase.dataconnect {
     method public static com.google.firebase.dataconnect.AnyValue? fromNullableAny(com.google.firebase.dataconnect.AnyValue.Companion, Object? value);
   }
 
-  public final class CacheSettings {
-    ctor public CacheSettings(com.google.firebase.dataconnect.CacheSettings.Storage storage = com.google.firebase.dataconnect.CacheSettings.Storage.PERSISTENT);
-    method public com.google.firebase.dataconnect.CacheSettings.Storage getStorage();
-    property public final com.google.firebase.dataconnect.CacheSettings.Storage storage;
-  }
-
-  public enum CacheSettings.Storage {
-    enum_constant public static final com.google.firebase.dataconnect.CacheSettings.Storage MEMORY;
-    enum_constant public static final com.google.firebase.dataconnect.CacheSettings.Storage PERSISTENT;
-  }
-
-  public final class CacheSettingsKt {
-    method public static com.google.firebase.dataconnect.CacheSettings copy(com.google.firebase.dataconnect.CacheSettings, com.google.firebase.dataconnect.CacheSettings.Storage storage = storage);
-  }
-
   public final class ConnectorConfig {
     ctor public ConnectorConfig(String connector, String location, String serviceId);
     method public String getConnector();
@@ -100,23 +85,14 @@ package com.google.firebase.dataconnect {
 
   public final class DataConnectSettings {
     ctor public DataConnectSettings(String host = "firebasedataconnect.googleapis.com", boolean sslEnabled = true);
-    ctor public DataConnectSettings(String host = "firebasedataconnect.googleapis.com", boolean sslEnabled = true, com.google.firebase.dataconnect.CacheSettings? cacheSettings);
-    method public com.google.firebase.dataconnect.CacheSettings? getCacheSettings();
     method public String getHost();
     method public boolean getSslEnabled();
-    property public final com.google.firebase.dataconnect.CacheSettings? cacheSettings;
     property public final String host;
     property public final boolean sslEnabled;
   }
 
   public final class DataConnectSettingsKt {
     method public static com.google.firebase.dataconnect.DataConnectSettings copy(com.google.firebase.dataconnect.DataConnectSettings, String host = host, boolean sslEnabled = sslEnabled);
-    method public static com.google.firebase.dataconnect.DataConnectSettings copy(com.google.firebase.dataconnect.DataConnectSettings, String host = host, boolean sslEnabled = sslEnabled, com.google.firebase.dataconnect.CacheSettings? cacheSettings);
-  }
-
-  public enum DataSource {
-    enum_constant public static final com.google.firebase.dataconnect.DataSource CACHE;
-    enum_constant public static final com.google.firebase.dataconnect.DataSource SERVER;
   }
 
   public sealed interface EnumValue<T extends java.lang.Enum<? extends T>> {
@@ -304,23 +280,14 @@ package com.google.firebase.dataconnect {
 
   public interface QueryRef<Data, Variables> extends com.google.firebase.dataconnect.OperationRef<Data,Variables> {
     method @com.google.firebase.dataconnect.ExperimentalFirebaseDataConnect public com.google.firebase.dataconnect.QueryRef<Data,Variables> copy(String operationName, Variables variables, kotlinx.serialization.DeserializationStrategy<? extends Data> dataDeserializer, kotlinx.serialization.SerializationStrategy<? super Variables> variablesSerializer, com.google.firebase.dataconnect.FirebaseDataConnect.CallerSdkType callerSdkType, kotlinx.serialization.modules.SerializersModule? dataSerializersModule, kotlinx.serialization.modules.SerializersModule? variablesSerializersModule);
-    method public suspend Object? execute(com.google.firebase.dataconnect.QueryRef.FetchPolicy fetchPolicy, kotlin.coroutines.Continuation<? super com.google.firebase.dataconnect.QueryResult<Data,Variables>>);
     method public suspend Object? execute(kotlin.coroutines.Continuation<? super com.google.firebase.dataconnect.QueryResult<Data,Variables>>);
     method public com.google.firebase.dataconnect.QuerySubscription<Data,Variables> subscribe();
     method @com.google.firebase.dataconnect.ExperimentalFirebaseDataConnect public <NewData> com.google.firebase.dataconnect.QueryRef<NewData,Variables> withDataDeserializer(kotlinx.serialization.DeserializationStrategy<? extends NewData> dataDeserializer, kotlinx.serialization.modules.SerializersModule? dataSerializersModule);
     method @com.google.firebase.dataconnect.ExperimentalFirebaseDataConnect public <NewVariables> com.google.firebase.dataconnect.QueryRef<Data,NewVariables> withVariablesSerializer(NewVariables variables, kotlinx.serialization.SerializationStrategy<? super NewVariables> variablesSerializer, kotlinx.serialization.modules.SerializersModule? variablesSerializersModule);
   }
 
-  public enum QueryRef.FetchPolicy {
-    enum_constant public static final com.google.firebase.dataconnect.QueryRef.FetchPolicy CACHE_ONLY;
-    enum_constant public static final com.google.firebase.dataconnect.QueryRef.FetchPolicy PREFER_CACHE;
-    enum_constant public static final com.google.firebase.dataconnect.QueryRef.FetchPolicy SERVER_ONLY;
-  }
-
   public interface QueryResult<Data, Variables> extends com.google.firebase.dataconnect.OperationResult<Data,Variables> {
-    method public com.google.firebase.dataconnect.DataSource getDataSource();
     method public com.google.firebase.dataconnect.QueryRef<Data,Variables> getRef();
-    property public abstract com.google.firebase.dataconnect.DataSource dataSource;
     property public abstract com.google.firebase.dataconnect.QueryRef<Data,Variables> ref;
   }
 

--- a/firebase-dataconnect/gradle.properties
+++ b/firebase-dataconnect/gradle.properties
@@ -1,2 +1,2 @@
-version=17.2.0
+version=17.1.4
 latestReleasedVersion=17.1.3

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/CacheSettings.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/CacheSettings.kt
@@ -24,14 +24,15 @@ import java.util.Objects
  *
  * @property storage The type of storage to use to store the cache data.
  */
-public class CacheSettings(
-  public val storage: Storage = Storage.PERSISTENT,
+// TODO: make public when offline caching goes public
+internal class CacheSettings(
+  val storage: Storage = Storage.PERSISTENT,
 ) {
 
   /**
    * The types of cache storage supported by [FirebaseDataConnect] in its [CacheSettings] setting.
    */
-  public enum class Storage {
+  enum class Storage {
     MEMORY,
     PERSISTENT,
   }
@@ -66,7 +67,7 @@ public class CacheSettings(
    * changes.
    *
    * @return a string representation of this object, which includes the class name and the values of
-   * all public properties.
+   * all properties.
    */
   override fun toString(): String {
     return "CacheSettings(storage=$storage)"
@@ -74,6 +75,7 @@ public class CacheSettings(
 }
 
 /** Creates and returns a new [CacheSettings] object with the given property values. */
-public fun CacheSettings.copy(
+// TODO: make public when offline caching goes public
+internal fun CacheSettings.copy(
   storage: CacheSettings.Storage = this.storage,
 ): CacheSettings = CacheSettings(storage = storage)

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/DataConnectSettings.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/DataConnectSettings.kt
@@ -31,21 +31,11 @@ import java.util.Objects
  * @property sslEnabled Whether to use SSL for the connection; if `true`, then the connection will
  * be encrypted using SSL and, if false, the connection will _not_ be encrypted and all network
  * transmission will happen in plaintext.
- * @property cacheSettings The local caching settings; if `null` then do not perform any local
- * caching.
  */
 public class DataConnectSettings(
   public val host: String = "firebasedataconnect.googleapis.com",
-  public val sslEnabled: Boolean = true,
-  public val cacheSettings: CacheSettings?,
+  public val sslEnabled: Boolean = true
 ) {
-
-  // TODO(BreakingChange): Delete this constructor and set the default value for `cacheSettings`
-  //  in the primary constructor.
-  public constructor(
-    host: String = "firebasedataconnect.googleapis.com",
-    sslEnabled: Boolean = true,
-  ) : this(host = host, sslEnabled = sslEnabled, cacheSettings = null)
 
   /**
    * Compares this object with another object for equality.
@@ -56,10 +46,7 @@ public class DataConnectSettings(
    * object.
    */
   override fun equals(other: Any?): Boolean =
-    (other is DataConnectSettings) &&
-      other.host == host &&
-      other.sslEnabled == sslEnabled &&
-      other.cacheSettings == cacheSettings
+    (other is DataConnectSettings) && other.host == host && other.sslEnabled == sslEnabled
 
   /**
    * Calculates and returns the hash code for this object.
@@ -69,8 +56,7 @@ public class DataConnectSettings(
    * @return the hash code for this object, that incorporates the values of this object's public
    * properties.
    */
-  override fun hashCode(): Int =
-    Objects.hash(DataConnectSettings::class, host, sslEnabled, cacheSettings)
+  override fun hashCode(): Int = Objects.hash(DataConnectSettings::class, host, sslEnabled)
 
   /**
    * Returns a string representation of this object, useful for debugging.
@@ -84,25 +70,13 @@ public class DataConnectSettings(
    * @return a string representation of this object, which includes the class name and the values of
    * all public properties.
    */
-  override fun toString(): String =
-    "DataConnectSettings(host=$host, sslEnabled=$sslEnabled, cacheSettings=$cacheSettings)"
+  override fun toString(): String = "DataConnectSettings(host=$host, sslEnabled=$sslEnabled)"
 }
 
 /** Creates and returns a new [DataConnectSettings] instance with the given property values. */
-// TODO(BreakingChange): Delete this method and set the default value for `cacheSettings` in the
-//  remaining copy() method.
 public fun DataConnectSettings.copy(
   host: String = this.host,
-  sslEnabled: Boolean = this.sslEnabled,
-): DataConnectSettings =
-  DataConnectSettings(host = host, sslEnabled = sslEnabled, cacheSettings = cacheSettings)
-
-/** Creates and returns a new [DataConnectSettings] instance with the given property values. */
-public fun DataConnectSettings.copy(
-  host: String = this.host,
-  sslEnabled: Boolean = this.sslEnabled,
-  cacheSettings: CacheSettings?,
-): DataConnectSettings =
-  DataConnectSettings(host = host, sslEnabled = sslEnabled, cacheSettings = cacheSettings)
+  sslEnabled: Boolean = this.sslEnabled
+): DataConnectSettings = DataConnectSettings(host = host, sslEnabled = sslEnabled)
 
 internal fun DataConnectSettings.isDefaultHost() = host == DataConnectSettings().host

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/QueryRef.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/QueryRef.kt
@@ -34,42 +34,7 @@ import kotlinx.serialization.modules.SerializersModule
  * might be added to this interface or contracts of the existing methods can be changed.
  */
 public interface QueryRef<Data, Variables> : OperationRef<Data, Variables> {
-
-  /**
-   * Executes this operation with the fetch policy [FetchPolicy.PREFER_CACHE] and returns the
-   * result.
-   */
-  // TODO(BreakingChange) Implement the method here to call execute(PREFER_CACHE) instead of
-  //  having QueryRefImpl do it.
-  public override suspend fun execute(): QueryResult<Data, Variables>
-
-  /** Executes this operation with the given fetch policy, and returns the result. */
-  public suspend fun execute(fetchPolicy: FetchPolicy): QueryResult<Data, Variables>
-
-  /** The caching policy to use in [QueryRef.execute]. */
-  public enum class FetchPolicy {
-
-    /**
-     * If the query has a cached result that has not expired, then return it without any
-     * communication with the server, just as [CACHE_ONLY] would do. Otherwise, if there is no
-     * cached data for the query or the cached data has expired, then get the latest result from the
-     * server, just as [SERVER_ONLY] would do.
-     */
-    PREFER_CACHE,
-
-    /**
-     * Return the query result from the cache without any communication with the server. If there is
-     * no cached data for the query then return an empty/null result, just as the server would have
-     * returned in that case.
-     */
-    CACHE_ONLY,
-
-    /**
-     * Unconditionally get the latest result from the server, even if there is a locally-cached
-     * result for the query. The local cache will be updated with the result, if successful.
-     */
-    SERVER_ONLY,
-  }
+  override suspend fun execute(): QueryResult<Data, Variables>
 
   /**
    * Subscribes to a query to be notified of updates to the query's data when the query is executed.
@@ -122,13 +87,4 @@ public interface QueryRef<Data, Variables> : OperationRef<Data, Variables> {
  */
 public interface QueryResult<Data, Variables> : OperationResult<Data, Variables> {
   override val ref: QueryRef<Data, Variables>
-
-  /** The source of the query results provided by this object. */
-  public val dataSource: DataSource
-}
-
-/** Indicator of the source of a query's results. */
-public enum class DataSource {
-  CACHE,
-  SERVER,
 }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImpl.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImpl.kt
@@ -20,7 +20,6 @@ import android.content.Context
 import com.google.firebase.FirebaseApp
 import com.google.firebase.appcheck.interop.InteropAppCheckTokenProvider
 import com.google.firebase.auth.internal.InternalAuthProvider
-import com.google.firebase.dataconnect.CacheSettings
 import com.google.firebase.dataconnect.ConnectorConfig
 import com.google.firebase.dataconnect.DataConnectSettings
 import com.google.firebase.dataconnect.FirebaseDataConnect
@@ -240,19 +239,6 @@ internal class FirebaseDataConnectImpl(
         backendInfoFromEmulatorSettings
       }
 
-    val cacheSettings =
-      settings.cacheSettings?.run {
-        val dbFile =
-          when (storage) {
-            CacheSettings.Storage.MEMORY -> null
-            CacheSettings.Storage.PERSISTENT -> {
-              val dbName = "dataconnect_" + calculateCacheDbUniqueName(backendInfo)
-              context.getDatabasePath(dbName)
-            }
-          }
-        DataConnectGrpcRPCs.CacheSettings(dbFile)
-      }
-
     logger.debug { "connecting to Data Connect backend: $backendInfo" }
     val grpcMetadata =
       DataConnectGrpcMetadata.forSystemVersions(
@@ -269,7 +255,7 @@ internal class FirebaseDataConnectImpl(
         sslEnabled = backendInfo.sslEnabled,
         blockingCoroutineDispatcher = blockingDispatcher,
         grpcMetadata = grpcMetadata,
-        cacheSettings = cacheSettings,
+        cacheSettings = null, // TODO: pass cache settings once implemented
         parentLogger = logger,
       )
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/QueryRefImpl.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/QueryRefImpl.kt
@@ -18,10 +18,8 @@
 
 package com.google.firebase.dataconnect.core
 
-import com.google.firebase.dataconnect.DataSource
 import com.google.firebase.dataconnect.FirebaseDataConnect
 import com.google.firebase.dataconnect.QueryRef
-import com.google.firebase.dataconnect.QueryRef.FetchPolicy
 import com.google.firebase.dataconnect.QueryResult
 import com.google.firebase.dataconnect.QuerySubscription
 import java.util.Objects
@@ -50,12 +48,8 @@ internal class QueryRefImpl<Data, Variables>(
     dataSerializersModule = dataSerializersModule,
     variablesSerializersModule = variablesSerializersModule,
   ) {
-  override suspend fun execute(): QueryResultImpl = execute(FetchPolicy.PREFER_CACHE)
-
-  override suspend fun execute(fetchPolicy: FetchPolicy): QueryResultImpl =
-    dataConnect.queryManager.execute(this).let {
-      QueryResultImpl(it.ref.getOrThrow(), DataSource.SERVER)
-    }
+  override suspend fun execute(): QueryResultImpl =
+    dataConnect.queryManager.execute(this).let { QueryResultImpl(it.ref.getOrThrow()) }
 
   override fun subscribe(): QuerySubscription<Data, Variables> = QuerySubscriptionImpl(this)
 
@@ -140,18 +134,16 @@ internal class QueryRefImpl<Data, Variables>(
       "variablesSerializersModule=$variablesSerializersModule" +
       ")"
 
-  inner class QueryResultImpl(data: Data, override val dataSource: DataSource) :
+  inner class QueryResultImpl(data: Data) :
     QueryResult<Data, Variables>, OperationRefImpl<Data, Variables>.OperationResultImpl(data) {
 
     override val ref = this@QueryRefImpl
 
     override fun equals(other: Any?) =
-      other is QueryRefImpl<*, *>.QueryResultImpl &&
-        super.equals(other) &&
-        other.dataSource == dataSource
+      other is QueryRefImpl<*, *>.QueryResultImpl && super.equals(other)
 
-    override fun hashCode() = Objects.hash(QueryResultImpl::class, data, ref, dataSource)
+    override fun hashCode() = Objects.hash(QueryResultImpl::class, data, ref)
 
-    override fun toString() = "QueryResultImpl(data=$data, ref=$ref, dataSource=$dataSource)"
+    override fun toString() = "QueryResultImpl(data=$data, ref=$ref)"
   }
 }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImpl.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImpl.kt
@@ -18,7 +18,6 @@
 
 package com.google.firebase.dataconnect.core
 
-import com.google.firebase.dataconnect.DataSource
 import com.google.firebase.dataconnect.QuerySubscriptionResult
 import com.google.firebase.dataconnect.util.NullableReference
 import com.google.firebase.dataconnect.util.SequencedReference
@@ -107,7 +106,7 @@ internal class QuerySubscriptionImpl<Data, Variables>(query: QueryRefImpl<Data, 
     override val query: QueryRefImpl<Data, Variables>,
     val sequencedResult: SequencedReference<Result<Data>>
   ) : QuerySubscriptionResult<Data, Variables> {
-    override val result = sequencedResult.ref.map { query.QueryResultImpl(it, DataSource.SERVER) }
+    override val result = sequencedResult.ref.map { query.QueryResultImpl(it) }
 
     override fun equals(other: Any?) =
       other is QuerySubscriptionImpl<*, *>.QuerySubscriptionResultImpl &&

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/CacheSettingsUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/CacheSettingsUnitTest.kt
@@ -38,6 +38,7 @@ import io.kotest.property.PropTestConfig
 import io.kotest.property.arbitrary.choice
 import io.kotest.property.arbitrary.enum
 import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.shuffle
 import io.kotest.property.arbitrary.string
 import io.kotest.property.checkAll
@@ -64,7 +65,7 @@ class CacheSettingsUnitTest {
 
   @Test
   fun `toString() returns a string that incorporates all property values`() = runTest {
-    checkAll(propTestConfig, Arb.dataConnect.cacheSettings()) { cacheSettings: CacheSettings ->
+    checkAll(propTestConfig, cacheSettingsArb()) { cacheSettings: CacheSettings ->
       val toStringResult = cacheSettings.toString()
       assertSoftly {
         toStringResult shouldStartWith "CacheSettings("
@@ -76,14 +77,14 @@ class CacheSettingsUnitTest {
 
   @Test
   fun `equals() should return true for the exact same instance`() = runTest {
-    checkAll(propTestConfig, Arb.dataConnect.cacheSettings()) { cacheSettings: CacheSettings ->
+    checkAll(propTestConfig, cacheSettingsArb()) { cacheSettings: CacheSettings ->
       cacheSettings.equals(cacheSettings) shouldBe true
     }
   }
 
   @Test
   fun `equals() should return true for an equal instance`() = runTest {
-    checkAll(propTestConfig, Arb.dataConnect.cacheSettings()) { cacheSettings1: CacheSettings ->
+    checkAll(propTestConfig, cacheSettingsArb()) { cacheSettings1: CacheSettings ->
       val cacheSettings2 = cacheSettings1.copy()
       withClue("cacheSettings1=$cacheSettings1 cacheSettings2=$cacheSettings2") {
         cacheSettings1.equals(cacheSettings2) shouldBe true
@@ -93,7 +94,7 @@ class CacheSettingsUnitTest {
 
   @Test
   fun `equals() should return false for null`() = runTest {
-    checkAll(propTestConfig, Arb.dataConnect.cacheSettings()) { cacheSettings: CacheSettings ->
+    checkAll(propTestConfig, cacheSettingsArb()) { cacheSettings: CacheSettings ->
       cacheSettings.equals(null) shouldBe false
     }
   }
@@ -107,7 +108,7 @@ class CacheSettingsUnitTest {
         Arb.dataConnect.dataConnectPath(),
         Arb.enum<Storage>(),
       )
-    checkAll(propTestConfig, Arb.dataConnect.cacheSettings(), otherArb) {
+    checkAll(propTestConfig, cacheSettingsArb(), otherArb) {
       cacheSettings: CacheSettings,
       other: Any ->
       cacheSettings.equals(other) shouldBe false
@@ -128,7 +129,7 @@ class CacheSettingsUnitTest {
   @Test
   fun `hashCode() should return the same value each time it is invoked on a given object`() =
     runTest {
-      checkAll(propTestConfig, Arb.dataConnect.cacheSettings()) { cacheSettings: CacheSettings ->
+      checkAll(propTestConfig, cacheSettingsArb()) { cacheSettings: CacheSettings ->
         val hashCode1 = cacheSettings.hashCode()
         cacheSettings.hashCode() shouldBe hashCode1
         cacheSettings.hashCode() shouldBe hashCode1
@@ -137,7 +138,7 @@ class CacheSettingsUnitTest {
 
   @Test
   fun `hashCode() should return the same value on equal objects`() = runTest {
-    checkAll(propTestConfig, Arb.dataConnect.cacheSettings()) { cacheSettings1: CacheSettings ->
+    checkAll(propTestConfig, cacheSettingsArb()) { cacheSettings1: CacheSettings ->
       val cacheSettings2 = cacheSettings1.copy()
       withClue("cacheSettings1=$cacheSettings1 cacheSettings2=$cacheSettings2") {
         cacheSettings1.hashCode() shouldBe cacheSettings2.hashCode()
@@ -158,7 +159,7 @@ class CacheSettingsUnitTest {
 
   @Test
   fun `copy with no arguments should create a distinct, but equal object`() = runTest {
-    checkAll(propTestConfig, Arb.dataConnect.cacheSettings()) { cacheSettings1: CacheSettings ->
+    checkAll(propTestConfig, cacheSettingsArb()) { cacheSettings1: CacheSettings ->
       val cacheSettings2 = cacheSettings1.copy()
       withClue("cacheSettings1=$cacheSettings1 cacheSettings2=$cacheSettings2") {
         assertSoftly {
@@ -191,3 +192,8 @@ class CacheSettingsUnitTest {
       )
   }
 }
+
+// TODO: Move to cacheSettingsArb() once cache api goes public
+private fun cacheSettingsArb(
+  storage: Arb<Storage> = Arb.enum<Storage>(),
+): Arb<CacheSettings> = storage.map(::CacheSettings)

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/DataConnectSettingsUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/DataConnectSettingsUnitTest.kt
@@ -19,15 +19,11 @@
 
 package com.google.firebase.dataconnect
 
-import com.google.firebase.dataconnect.testutil.property.arbitrary.TwoValues
 import com.google.firebase.dataconnect.testutil.property.arbitrary.dataConnect
 import com.google.firebase.dataconnect.testutil.shouldContainWithNonAbuttingText
 import io.kotest.assertions.assertSoftly
-import io.kotest.assertions.withClue
 import io.kotest.common.ExperimentalKotest
-import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldEndWith
 import io.kotest.matchers.string.shouldStartWith
 import io.kotest.matchers.types.shouldBeSameInstanceAs
@@ -36,11 +32,7 @@ import io.kotest.property.Arb
 import io.kotest.property.PropTestConfig
 import io.kotest.property.arbitrary.boolean
 import io.kotest.property.arbitrary.choice
-import io.kotest.property.arbitrary.flatMap
 import io.kotest.property.arbitrary.int
-import io.kotest.property.arbitrary.map
-import io.kotest.property.arbitrary.of
-import io.kotest.property.arbitrary.orNull
 import io.kotest.property.arbitrary.string
 import io.kotest.property.assume
 import io.kotest.property.checkAll
@@ -53,46 +45,31 @@ class DataConnectSettingsUnitTest {
   fun `default constructor arguments are correct`() {
     val settings = DataConnectSettings()
 
-    assertSoftly {
-      withClue("host") { settings.host shouldBe "firebasedataconnect.googleapis.com" }
-      withClue("sslEnabled") { settings.sslEnabled shouldBe true }
-      withClue("cacheSettings") { settings.cacheSettings.shouldBeNull() }
-    }
+    settings.host shouldBe "firebasedataconnect.googleapis.com"
+    settings.sslEnabled shouldBe true
   }
 
   @Test
   fun `properties should be the same objects given to the constructor`() = runTest {
-    checkAll(
-      propTestConfig,
-      Arb.string(),
-      Arb.boolean(),
-      Arb.dataConnect.cacheSettings().orNull(nullProbability = 0.33),
-    ) { host, sslEnabled, cacheSettings ->
-      val settings = DataConnectSettings(host, sslEnabled, cacheSettings)
+    checkAll(propTestConfig, Arb.string(), Arb.boolean()) { host, sslEnabled ->
+      val settings = DataConnectSettings(host, sslEnabled)
       assertSoftly {
-        withClue("host") { settings.host shouldBeSameInstanceAs host }
-        withClue("sslEnabled") { settings.sslEnabled shouldBe sslEnabled }
-        withClue("cacheSettings") { settings.cacheSettings shouldBeSameInstanceAs cacheSettings }
+        settings.host shouldBeSameInstanceAs host
+        settings.sslEnabled shouldBe sslEnabled
       }
     }
   }
 
   @Test
   fun `toString() returns a string that incorporates all property values`() = runTest {
-    checkAll(
-      propTestConfig,
-      Arb.string(),
-      Arb.boolean(),
-      Arb.dataConnect.cacheSettings().orNull(nullProbability = 0.33),
-    ) { host, sslEnabled, cacheSettings ->
-      val settings = DataConnectSettings(host, sslEnabled, cacheSettings)
+    checkAll(propTestConfig, Arb.string(), Arb.boolean()) { host, sslEnabled ->
+      val settings = DataConnectSettings(host, sslEnabled)
       val toStringResult = settings.toString()
       assertSoftly {
         toStringResult shouldStartWith "DataConnectSettings("
         toStringResult shouldEndWith ")"
         toStringResult shouldContainWithNonAbuttingText "host=${settings.host}"
         toStringResult shouldContainWithNonAbuttingText "sslEnabled=${settings.sslEnabled}"
-        toStringResult shouldContainWithNonAbuttingText "cacheSettings=${settings.cacheSettings}"
       }
     }
   }
@@ -146,14 +123,6 @@ class DataConnectSettingsUnitTest {
   }
 
   @Test
-  fun `equals() should return false when only 'cacheSettings' differs`() = runTest {
-    checkAll(propTestConfig, dataConnectSettingsPairWithDifferingCacheSettings()) {
-      (settings1, settings2) ->
-      settings1.equals(settings2) shouldBe false
-    }
-  }
-
-  @Test
   fun `hashCode() should return the same value each time it is invoked on a given object`() =
     runTest {
       checkAll(propTestConfig, Arb.dataConnect.dataConnectSettings()) { settings ->
@@ -167,36 +136,26 @@ class DataConnectSettingsUnitTest {
   fun `hashCode() should return the same value on equal objects`() = runTest {
     checkAll(propTestConfig, Arb.dataConnect.dataConnectSettings()) { settings1 ->
       val settings2 = settings1.copy()
-      settings1.hashCode() shouldBe settings2.hashCode()
+      settings1.equals(settings2) shouldBe true
     }
   }
 
   @Test
   fun `hashCode() should return a different value when only 'host' differs`() = runTest {
-    checkAll(
-      hashEqualityPropTestConfig,
-      Arb.dataConnect.dataConnectSettings(),
-      Arb.dataConnect.string()
-    ) { settings1, newHost ->
+    checkAll(propTestConfig, Arb.dataConnect.dataConnectSettings(), Arb.dataConnect.string()) {
+      settings1,
+      newHost ->
       assume { settings1.host.hashCode() != newHost.hashCode() }
       val settings2 = settings1.copy(host = newHost)
-      settings1.hashCode() shouldNotBe settings2.hashCode()
+      settings1.equals(settings2) shouldBe false
     }
   }
 
   @Test
   fun `hashCode() should return a different value when only 'sslEnabled' differs`() = runTest {
-    checkAll(hashEqualityPropTestConfig, Arb.dataConnect.dataConnectSettings()) { settings1 ->
+    checkAll(propTestConfig, Arb.dataConnect.dataConnectSettings()) { settings1 ->
       val settings2 = settings1.copy(sslEnabled = !settings1.sslEnabled)
-      settings1.hashCode() shouldNotBe settings2.hashCode()
-    }
-  }
-
-  @Test
-  fun `hashCode() should return a different value when only 'cacheSettings' differs`() = runTest {
-    checkAll(hashEqualityPropTestConfig, dataConnectSettingsPairWithDifferingCacheSettings()) {
-      (settings1, settings2) ->
-      settings1.hashCode() shouldNotBe settings2.hashCode()
+      settings1.equals(settings2) shouldBe false
     }
   }
 
@@ -210,7 +169,6 @@ class DataConnectSettingsUnitTest {
           settings1.equals(settings2) shouldBe true
           settings1.host shouldBeSameInstanceAs settings2.host
           settings1.sslEnabled shouldBe settings2.sslEnabled
-          settings1.cacheSettings shouldBeSameInstanceAs settings2.cacheSettings
         }
       }
     }
@@ -222,9 +180,9 @@ class DataConnectSettingsUnitTest {
       newHost ->
       val settings2 = settings1.copy(host = newHost)
       assertSoftly {
+        settings1 shouldNotBeSameInstanceAs settings2
+        settings1.equals(settings2) shouldBe false
         settings2.host shouldBeSameInstanceAs newHost
-        settings2.sslEnabled shouldBe settings1.sslEnabled
-        settings2.cacheSettings shouldBeSameInstanceAs settings1.cacheSettings
       }
     }
   }
@@ -236,25 +194,9 @@ class DataConnectSettingsUnitTest {
       newSslEnabled ->
       val settings2 = settings1.copy(sslEnabled = newSslEnabled)
       assertSoftly {
-        settings2.host shouldBeSameInstanceAs settings1.host
+        settings1 shouldNotBeSameInstanceAs settings2
+        settings1.equals(settings2) shouldBe (settings1.sslEnabled == newSslEnabled)
         settings2.sslEnabled shouldBe newSslEnabled
-        settings2.cacheSettings shouldBeSameInstanceAs settings1.cacheSettings
-      }
-    }
-  }
-
-  @Test
-  fun `copy() should return an object with the given 'cacheSettings'`() = runTest {
-    checkAll(
-      propTestConfig,
-      Arb.dataConnect.dataConnectSettings(),
-      Arb.dataConnect.cacheSettings().orNull(nullProbability = 0.33),
-    ) { settings1, newCacheSettings ->
-      val settings2 = settings1.copy(cacheSettings = newCacheSettings)
-      assertSoftly {
-        settings2.host shouldBeSameInstanceAs settings1.host
-        settings2.sslEnabled shouldBe settings1.sslEnabled
-        settings2.cacheSettings shouldBeSameInstanceAs newCacheSettings
       }
     }
   }
@@ -265,41 +207,19 @@ class DataConnectSettingsUnitTest {
       propTestConfig,
       Arb.dataConnect.dataConnectSettings(),
       Arb.dataConnect.string(),
-      Arb.boolean(),
-      Arb.dataConnect.cacheSettings().orNull(nullProbability = 0.33),
-    ) { settings1, newHost, newSslEnabled, newCacheSettings ->
-      val settings2 =
-        settings1.copy(host = newHost, sslEnabled = newSslEnabled, cacheSettings = newCacheSettings)
+      Arb.boolean()
+    ) { settings1, newHost, newSslEnabled ->
+      val settings2 = settings1.copy(host = newHost, sslEnabled = newSslEnabled)
       assertSoftly {
+        settings1 shouldNotBeSameInstanceAs settings2
+        settings1.equals(settings2) shouldBe false
         settings2.host shouldBeSameInstanceAs newHost
         settings2.sslEnabled shouldBe newSslEnabled
-        settings2.cacheSettings shouldBeSameInstanceAs newCacheSettings
       }
     }
   }
 
   private companion object {
     val propTestConfig = PropTestConfig(iterations = 20)
-
-    // Allow a small number of failures to account for the rare, but possible situation where two
-    // distinct instances produce the same hash code.
-    val hashEqualityPropTestConfig =
-      propTestConfig.copy(
-        minSuccess = propTestConfig.iterations!! - 2,
-        maxFailure = 2,
-      )
-
-    private fun dataConnectSettingsPairWithDifferingCacheSettings():
-      Arb<TwoValues<DataConnectSettings>> {
-      val cacheSettingsValues = listOf(null) + CacheSettings.Storage.entries.map(::CacheSettings)
-      return Arb.dataConnect.dataConnectSettings().flatMap { dataConnectSettings1 ->
-        val cacheSettings2Arb =
-          Arb.of(cacheSettingsValues.filterNot { it == dataConnectSettings1.cacheSettings })
-        cacheSettings2Arb.map { cacheSettings2 ->
-          val dataConnectSettings2 = dataConnectSettings1.copy(cacheSettings = cacheSettings2)
-          TwoValues(dataConnectSettings1, dataConnectSettings2)
-        }
-      }
-    }
   }
 }

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/arbs.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/arbs.kt
@@ -18,7 +18,6 @@
 
 package com.google.firebase.dataconnect.testutil.property.arbitrary
 
-import com.google.firebase.dataconnect.CacheSettings
 import com.google.firebase.dataconnect.ConnectorConfig
 import com.google.firebase.dataconnect.DataConnectPathSegment
 import com.google.firebase.dataconnect.DataConnectSettings
@@ -36,7 +35,6 @@ import io.kotest.property.arbitrary.choose
 import io.kotest.property.arbitrary.cyrillic
 import io.kotest.property.arbitrary.double
 import io.kotest.property.arbitrary.egyptianHieroglyphs
-import io.kotest.property.arbitrary.enum
 import io.kotest.property.arbitrary.filterNot
 import io.kotest.property.arbitrary.hex
 import io.kotest.property.arbitrary.int
@@ -126,18 +124,13 @@ object DataConnectArb {
       "host_${string.bind()}"
     }
 
-  fun cacheSettings(
-    storage: Arb<CacheSettings.Storage> = Arb.enum<CacheSettings.Storage>(),
-  ): Arb<CacheSettings> = storage.map(::CacheSettings)
-
   fun dataConnectSettings(
     prefix: String? = null,
     host: Arb<String> = host(),
     sslEnabled: Arb<Boolean> = Arb.boolean(),
-    cacheSettings: Arb<CacheSettings?> = cacheSettings().orNull(nullProbability = 0.33),
   ): Arb<DataConnectSettings> {
     val wrappedHost = prefix?.let { host.withPrefix(it) } ?: host
-    return Arb.bind(wrappedHost, sslEnabled, cacheSettings, ::DataConnectSettings)
+    return Arb.bind(wrappedHost, sslEnabled, ::DataConnectSettings)
   }
 
   fun tag(string: Arb<String> = Arb.string(size = 50, Codepoint.alphanumeric())): Arb<String> =


### PR DESCRIPTION
Revert commit 506716b711 (PR #7716) which added public APIs for offline caching.

The implementation is not ready for release, so hiding it for now. The plan is to re-introduce it in the next release.

Note that the APIs were later added by in PR https://github.com/firebase/firebase-android-sdk/pull/7833