### PR TITLE
[FCM] Fix changelog format

### DIFF
--- a/firebase-messaging/CHANGELOG.md
+++ b/firebase-messaging/CHANGELOG.md
@@ -90,6 +90,7 @@ The Kotlin extensions library transitively includes the updated `firebase-messag
 Kotlin extensions library has no additional updates.
 
 # 23.4.0
+
 * [changed] Called messageHandled() after a message has been handled to indicate
   that the message has been handled successfully.
 * [changed] Added an internal identifier to Firelog logging for compliance.


### PR DESCRIPTION
The changes introduced in a previous PR did not include running the formatter and caused a malformed file to be modified.