### PR TITLE
[Infra] Update `fireci` project dependencies

### DIFF
--- a/ci/fireci/pyproject.toml
+++ b/ci/fireci/pyproject.toml
@@ -1,17 +1,17 @@
 [build-system]
-requires = ["setuptools ~= 70.0"]
+requires = ["setuptools ~= 80.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "fireci"
 version = "0.1"
 dependencies = [
-  "protobuf==4.25.8",
+  "protobuf==5.29.6",
   "click==8.1.7",
   "google-cloud-storage==2.18.2",
-  "mypy==1.6.0",
-  "numpy==1.24.4",
-  "pandas==1.5.3",
+  "mypy==1.17.1",
+  "numpy==2.4.2",
+  "pandas==2.3.3",
   "PyGithub==1.58.2",
   "pystache==0.6.0",
   "requests==2.32.4",
@@ -32,13 +32,13 @@ strict_optional = false
 
 [[tool.mypy.overrides]]
   module = [
-	"google.cloud",
-	"matplotlib",
-	"matplotlib.pyplot",
-	"pandas",
-	"pystache",
-	"requests",
-	"seaborn",
-	"yaml"
+    "google.cloud",
+    "matplotlib",
+    "matplotlib.pyplot",
+    "pandas",
+    "pystache",
+    "requests",
+    "seaborn",
+    "yaml"
   ]
   ignore_missing_imports = true


### PR DESCRIPTION
Upgrades several dependencies in `ci/fireci/pyproject.toml`:
- `setuptools` from `~=70.0` to `~=80.0`
- `protobuf` from `==4.25.8` to `==5.29.6`
- `mypy` from `==1.6.0` to `==1.17.1`
- `numpy` from `==1.24.4` to `==2.4.2`
- `pandas` from `==1.5.3` to `==2.3.3`

Also corrects minor whitespace in the `mypy` overrides section.

Internal b/486246272