### PR TITLE
firestore(test): AggregationTest.java: update tests for now-supported enterprise aggregations in emulator

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AggregationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AggregationTest.java
@@ -540,26 +540,12 @@ public class AggregationTest {
             "b", map("author", "authorB", "title", "titleB", "rating", Long.MAX_VALUE));
     CollectionReference collection = testCollectionWithDocs(testDocs);
 
-    switch (getBackendEdition()) {
-      case STANDARD:
-        {
-          AggregateQuerySnapshot snapshot =
-              waitFor(collection.aggregate(sum("rating")).get(AggregateSource.SERVER));
+    AggregateQuerySnapshot snapshot =
+        waitFor(collection.aggregate(sum("rating")).get(AggregateSource.SERVER));
 
-          Object sum = snapshot.get(sum("rating"));
-          assertTrue(sum instanceof Double);
-          assertEquals(sum, (double) Long.MAX_VALUE + (double) Long.MAX_VALUE);
-          break;
-        }
-      case ENTERPRISE:
-        {
-          assertThrows(
-              RuntimeException.class,
-              () -> {
-                waitFor(collection.aggregate(sum("rating")).get(AggregateSource.SERVER));
-              });
-        }
-    }
+    Object sum = snapshot.get(sum("rating"));
+    assertTrue(sum instanceof Double);
+    assertEquals(sum, (double) Long.MAX_VALUE + (double) Long.MAX_VALUE);
   }
 
   @Test
@@ -589,20 +575,10 @@ public class AggregationTest {
             "d", map("author", "authorD", "title", "titleD", "rating", -10000));
     CollectionReference collection = testCollectionWithDocs(testDocs);
 
-    switch (getBackendEdition()) {
-      case STANDARD:
-        AggregateQuerySnapshot snapshot =
-            waitFor(collection.aggregate(sum("rating")).get(AggregateSource.SERVER));
+    AggregateQuerySnapshot snapshot =
+        waitFor(collection.aggregate(sum("rating")).get(AggregateSource.SERVER));
 
-        assertEquals(snapshot.get(sum("rating")), -10101L);
-        break;
-      case ENTERPRISE:
-        assertThrows(
-            RuntimeException.class,
-            () -> {
-              waitFor(collection.aggregate(sum("rating")).get(AggregateSource.SERVER));
-            });
-    }
+    assertEquals(snapshot.get(sum("rating")), -10101L);
   }
 
   @Test
@@ -675,13 +651,7 @@ public class AggregationTest {
                 .aggregate(sum("pages"))
                 .get(AggregateSource.SERVER));
 
-    switch (getBackendEdition()) {
-      case STANDARD:
-        assertEquals(snapshot.get(sum("pages")), 0L);
-        break;
-      case ENTERPRISE:
-        assertNull(snapshot.get(sum("pages")));
-    }
+    assertEquals(snapshot.get(sum("pages")), 0L);
   }
 
   @Test


### PR DESCRIPTION
This PR updates `AggregationTest.java` to reflect that the Firestore emulator now supports aggregations that were previously only available in the standard edition. The tests have been updated to remove the conditional logic that differentiated between backend editions, and now assert the same behavior for all editions.

### Highlights
* Updated `AggregationTest.java` to reflect new emulator capabilities.
* Removed conditional logic for backend editions in aggregation tests.
* Tests for sum aggregations with overflow, negative numbers, and zero documents are now unified.

<details>

<summary><b>Changelog</b></summary>

* `AggregationTest.java`
  * Removed backend edition checks for `testPerformsSumThatOverflowsMaxLong`.
  * Removed backend edition checks for `testPerformsSumThatIsNegative`.
  * Removed backend edition checks for `testPerformsSumOverResultSetOfZeroDocuments`.
</details>