### PR TITLE
dataconnect(test): QueryCachingIntegrationTest.kt added

### DIFF
--- a/firebase-dataconnect/androidTestutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/DataConnectBackend.kt
+++ b/firebase-dataconnect/androidTestutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/DataConnectBackend.kt
@@ -18,17 +18,14 @@ package com.google.firebase.dataconnect.testutil
 
 import androidx.annotation.VisibleForTesting
 import com.google.firebase.FirebaseApp
+import com.google.firebase.dataconnect.CacheSettings
 import com.google.firebase.dataconnect.ConnectorConfig
 import com.google.firebase.dataconnect.DataConnectSettings
 import com.google.firebase.dataconnect.FirebaseDataConnect
 import com.google.firebase.dataconnect.copy
 import com.google.firebase.dataconnect.getInstance
-import com.google.firebase.dataconnect.testutil.DataConnectBackend.Autopush
+import com.google.firebase.dataconnect.testutil.DataConnectBackend.Companion.INSTRUMENTATION_ARGUMENT
 import com.google.firebase.dataconnect.testutil.DataConnectBackend.Companion.fromInstrumentationArguments
-import com.google.firebase.dataconnect.testutil.DataConnectBackend.Custom
-import com.google.firebase.dataconnect.testutil.DataConnectBackend.Emulator
-import com.google.firebase.dataconnect.testutil.DataConnectBackend.Production
-import com.google.firebase.dataconnect.testutil.DataConnectBackend.Staging
 import java.net.MalformedURLException
 import java.net.URI
 import java.net.URISyntaxException
@@ -56,8 +53,8 @@ import java.net.URL
  * ```
  * -Pandroid.testInstrumentationRunnerArguments.DATA_CONNECT_BACKEND=[backend]
  * ```
- * where `[backend]` is one of the values specified above. For example, to run against production,
- * the tests could be run as follows:
+ * where `backend` is one of the values specified above. For example, to run against production, the
+ * tests could be run as follows:
  * ```
  * ./gradlew :firebase-dataconnect:connectedDebugAndroidTest \
  *   -Pandroid.testInstrumentationRunnerArguments.DATA_CONNECT_BACKEND=prod
@@ -89,26 +86,34 @@ import java.net.URL
  */
 sealed interface DataConnectBackend {
 
-  val dataConnectSettings: DataConnectSettings
   val authBackend: FirebaseAuthBackend
 
-  fun getDataConnect(app: FirebaseApp, config: ConnectorConfig): FirebaseDataConnect =
-    FirebaseDataConnect.getInstance(app, config, dataConnectSettings)
+  fun getDataConnectSettings(cacheSettings: CacheSettings?): DataConnectSettings
+
+  fun getDataConnect(
+    app: FirebaseApp,
+    config: ConnectorConfig,
+    cacheSettings: CacheSettings?
+  ): FirebaseDataConnect =
+    FirebaseDataConnect.getInstance(app, config, getDataConnectSettings(cacheSettings))
 
   /** The "production" Data Connect server, which is used by customers. */
   object Production : DataConnectBackend {
-    override val dataConnectSettings
-      get() = DataConnectSettings()
     override val authBackend: FirebaseAuthBackend
       get() = FirebaseAuthBackend.Production
+
+    override fun getDataConnectSettings(cacheSettings: CacheSettings?) =
+      DataConnectSettings().copy(cacheSettings = cacheSettings)
+
     override fun toString() = "DataConnectBackend.Production"
   }
 
   sealed class PredefinedDataConnectBackend(val host: String) : DataConnectBackend {
-    override val dataConnectSettings
-      get() = DataConnectSettings().copy(host = host, sslEnabled = true)
     override val authBackend: FirebaseAuthBackend
       get() = FirebaseAuthBackend.Production
+
+    override fun getDataConnectSettings(cacheSettings: CacheSettings?) =
+      DataConnectSettings().copy(host = host, sslEnabled = true, cacheSettings = cacheSettings)
   }
 
   /**
@@ -135,23 +140,32 @@ sealed interface DataConnectBackend {
 
   /** A custom Data Connect server. */
   data class Custom(val host: String, val sslEnabled: Boolean) : DataConnectBackend {
-    override val dataConnectSettings
-      get() = DataConnectSettings().copy(host = host, sslEnabled = sslEnabled)
     override val authBackend: FirebaseAuthBackend
       get() = FirebaseAuthBackend.Production
+
+    override fun getDataConnectSettings(cacheSettings: CacheSettings?) =
+      DataConnectSettings()
+        .copy(host = host, sslEnabled = sslEnabled, cacheSettings = cacheSettings)
+
     override fun toString() = "DataConnectBackend.Custom(host=$host, sslEnabled=$sslEnabled)"
   }
 
   /** The Data Connect emulator. */
   data class Emulator(val host: String? = null, val port: Int? = null) : DataConnectBackend {
-    override val dataConnectSettings
-      get() = DataConnectSettings()
     override val authBackend: FirebaseAuthBackend
       get() = FirebaseAuthBackend.Emulator()
+
+    override fun getDataConnectSettings(cacheSettings: CacheSettings?) =
+      DataConnectSettings().copy(cacheSettings = cacheSettings)
+
     override fun toString() = "DataConnectBackend.Emulator(host=$host, port=$port)"
 
-    override fun getDataConnect(app: FirebaseApp, config: ConnectorConfig): FirebaseDataConnect =
-      super.getDataConnect(app, config).apply {
+    override fun getDataConnect(
+      app: FirebaseApp,
+      config: ConnectorConfig,
+      cacheSettings: CacheSettings?
+    ): FirebaseDataConnect =
+      super.getDataConnect(app, config, cacheSettings).apply {
         if (host !== null && port !== null) {
           useEmulator(host = host, port = port)
         } else if (host !== null) {

--- a/firebase-dataconnect/androidTestutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/TestDataConnectFactory.kt
+++ b/firebase-dataconnect/androidTestutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/TestDataConnectFactory.kt
@@ -34,6 +34,18 @@ class TestDataConnectFactory(val firebaseAppFactory: TestFirebaseAppFactory) :
       newInstance(Params(connector = connector, location = location, serviceId = serviceId))
     }
 
+  fun newInstance(config: ConnectorConfig, cacheSettings: CacheSettings?): FirebaseDataConnect =
+    config.run {
+      newInstance(
+        Params(
+          connector = connector,
+          location = location,
+          serviceId = serviceId,
+          cacheSettings = cacheSettings,
+        )
+      )
+    }
+
   fun newInstance(backend: DataConnectBackend): FirebaseDataConnect =
     newInstance(Params(backend = backend))
 
@@ -44,6 +56,21 @@ class TestDataConnectFactory(val firebaseAppFactory: TestFirebaseAppFactory) :
         connector = config.connector,
         location = config.location,
         serviceId = config.serviceId
+      )
+    )
+
+  fun newInstance(
+    firebaseApp: FirebaseApp,
+    config: ConnectorConfig,
+    cacheSettings: CacheSettings?
+  ): FirebaseDataConnect =
+    newInstance(
+      Params(
+        firebaseApp = firebaseApp,
+        connector = config.connector,
+        location = config.location,
+        serviceId = config.serviceId,
+        cacheSettings = cacheSettings
       )
     )
 
@@ -60,7 +87,7 @@ class TestDataConnectFactory(val firebaseAppFactory: TestFirebaseAppFactory) :
       )
 
     val backend = params?.backend ?: DataConnectBackend.fromInstrumentationArguments()
-    return backend.getDataConnect(firebaseApp, connectorConfig)
+    return backend.getDataConnect(firebaseApp, connectorConfig, params?.cacheSettings)
   }
 
   override fun destroyInstance(instance: FirebaseDataConnect) {
@@ -73,5 +100,6 @@ class TestDataConnectFactory(val firebaseAppFactory: TestFirebaseAppFactory) :
     val location: String? = null,
     val serviceId: String? = null,
     val backend: DataConnectBackend? = null,
+    val cacheSettings: CacheSettings? = null,
   )
 }

--- a/firebase-dataconnect/connectors/src/androidTest/kotlin/com/google/firebase/dataconnect/connectors/testutil/TestConnectorFactory.kt
+++ b/firebase-dataconnect/connectors/src/androidTest/kotlin/com/google/firebase/dataconnect/connectors/testutil/TestConnectorFactory.kt
@@ -31,14 +31,15 @@ import com.google.firebase.dataconnect.testutil.TestFirebaseAppFactory
 abstract class TestConnectorFactory<T : GeneratedConnector<T>>(
   private val firebaseAppFactory: TestFirebaseAppFactory,
   private val dataConnectFactory: TestDataConnectFactory
-) : FactoryTestRule<T, Nothing>() {
+) : FactoryTestRule<T, CacheSettings>() {
 
   abstract fun createConnector(firebaseApp: FirebaseApp, settings: DataConnectSettings): T
 
-  override fun createInstance(params: Nothing?): T {
+  override fun createInstance(params: CacheSettings?): T {
     val firebaseApp = firebaseAppFactory.newInstance()
 
-    val dataConnectSettings = DataConnectBackend.fromInstrumentationArguments().dataConnectSettings
+    val dataConnectSettings =
+      DataConnectBackend.fromInstrumentationArguments().getDataConnectSettings(params)
     val connector = createConnector(firebaseApp, dataConnectSettings)
 
     // Get the instance of `FirebaseDataConnect` from the `TestDataConnectFactory` so that it will

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/QueryCachingIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/QueryCachingIntegrationTest.kt
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalKotest::class)
+
+package com.google.firebase.dataconnect
+
+import com.google.firebase.dataconnect.CacheSettings.Storage.MEMORY
+import com.google.firebase.dataconnect.CacheSettings.Storage.PERSISTENT
+import com.google.firebase.dataconnect.DataSource.CACHE
+import com.google.firebase.dataconnect.DataSource.SERVER
+import com.google.firebase.dataconnect.testutil.DataConnectIntegrationTestBase
+import com.google.firebase.dataconnect.testutil.DataConnectIntegrationTestBase.Companion.testConnectorConfig
+import com.google.firebase.dataconnect.testutil.Quintuple
+import com.google.firebase.dataconnect.testutil.property.arbitrary.distinctPair
+import com.google.firebase.dataconnect.testutil.schemas.PersonSchema
+import com.google.firebase.dataconnect.testutil.schemas.PersonSchema.Companion.CONNECTOR as personSchemaConnector
+import com.google.firebase.dataconnect.testutil.schemas.PersonSchema.GetPersonQuery
+import com.google.firebase.util.nextAlphanumericString
+import io.kotest.assertions.asClue
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.withClue
+import io.kotest.common.ExperimentalKotest
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.EdgeConfig
+import io.kotest.property.PropTestConfig
+import io.kotest.property.ShrinkingMode
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbs.usernames
+import io.kotest.property.checkAll
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.serializer
+import org.junit.Test
+
+class QueryCachingIntegrationTest : DataConnectIntegrationTestBase() {
+
+  @Test
+  fun cachingDisabledAlwaysReturnsFromServer() =
+    executeCreateQueryUpdateQueryTest(cacheSettings = null) { name1, name2 ->
+      query1ResultShouldBe(name1, SERVER)
+      query2ResultShouldBe(name2, SERVER)
+      useSameDataConnectInstanceForQuery2()
+    }
+
+  @Test
+  fun cachingMemoryReturnsFromCacheBeforeMaxAge() =
+    executeCreateQueryUpdateQueryTest(
+      cacheSettings = CacheSettings(storage = MEMORY, maxAge = 1.hours)
+    ) { name1, _ ->
+      query1ResultShouldBe(name1, SERVER)
+      query2ResultShouldBe(name1, CACHE)
+      useSameDataConnectInstanceForQuery2()
+    }
+
+  @Test
+  fun cachingPersistentReturnsFromCacheBeforeMaxAge() =
+    executeCreateQueryUpdateQueryTest(
+      cacheSettings = CacheSettings(storage = PERSISTENT, maxAge = 1.hours)
+    ) { name1, _ ->
+      query1ResultShouldBe(name1, SERVER)
+      query2ResultShouldBe(name1, CACHE)
+      useSameDataConnectInstanceForQuery2()
+    }
+
+  @Test
+  fun cachingMemoryReturnsFromServerAfterMaxAge() =
+    executeCreateQueryUpdateQueryTest(
+      cacheSettings = CacheSettings(storage = MEMORY, maxAge = 1.nanoseconds)
+    ) { name1, name2 ->
+      query1ResultShouldBe(name1, SERVER)
+      query2ResultShouldBe(name2, SERVER)
+      useSameDataConnectInstanceForQuery2()
+    }
+
+  @Test
+  fun cachingPersistentReturnsFromServerAfterMaxAge() =
+    executeCreateQueryUpdateQueryTest(
+      cacheSettings = CacheSettings(storage = PERSISTENT, maxAge = 1.nanoseconds)
+    ) { name1, name2 ->
+      query1ResultShouldBe(name1, SERVER)
+      query2ResultShouldBe(name2, SERVER)
+      useSameDataConnectInstanceForQuery2()
+    }
+
+  @Test
+  fun cachingMemoryReturnsFromServerWhenMaxAgeIsZero() =
+    executeCreateQueryUpdateQueryTest(
+      cacheSettings = CacheSettings(storage = MEMORY, maxAge = Duration.ZERO)
+    ) { name1, name2 ->
+      query1ResultShouldBe(name1, SERVER)
+      query2ResultShouldBe(name2, SERVER)
+      useSameDataConnectInstanceForQuery2()
+    }
+
+  @Test
+  fun cachingPersistentReturnsFromServerWhenMaxAgeIsZero() =
+    executeCreateQueryUpdateQueryTest(
+      cacheSettings = CacheSettings(storage = PERSISTENT, maxAge = Duration.ZERO)
+    ) { name1, name2 ->
+      query1ResultShouldBe(name1, SERVER)
+      query2ResultShouldBe(name2, SERVER)
+      useSameDataConnectInstanceForQuery2()
+    }
+
+  @Test
+  fun cachingMemoryIsClearedBetweenDataConnectInstances() =
+    executeCreateQueryUpdateQueryTest(
+      cacheSettings = CacheSettings(storage = MEMORY, maxAge = 1.hours)
+    ) { name1, name2 ->
+      query1ResultShouldBe(name1, SERVER)
+      query2ResultShouldBe(name2, SERVER)
+      useNewDataConnectInstanceForQuery2()
+    }
+
+  @Test
+  fun cachingPersistentPersistsBetweenDataConnectInstances() =
+    executeCreateQueryUpdateQueryTest(
+      cacheSettings = CacheSettings(storage = PERSISTENT, maxAge = 1.hours)
+    ) { name1, _ ->
+      query1ResultShouldBe(name1, SERVER)
+      query2ResultShouldBe(name1, CACHE)
+      useNewDataConnectInstanceForQuery2()
+    }
+
+  private data class CreateQueryUpdateQueryTestConfig(
+    var query1Name: String? = null,
+    var query1DataSource: DataSource? = null,
+    var query2Name: String? = null,
+    var query2DataSource: DataSource? = null,
+    var query2DataConnectInstance: DataConnectInstance? = null,
+  ) {
+
+    enum class DataConnectInstance {
+      /** Use the same [FirebaseDataConnect] instance to run query1 and query2. */
+      Same,
+
+      /**
+       * After running query1, close the [FirebaseDataConnect] instance and use a new one to run
+       * query2.
+       */
+      New,
+    }
+
+    fun query1ResultShouldBe(name: String, dataSource: DataSource) {
+      query1Name = name
+      query1DataSource = dataSource
+    }
+
+    fun query2ResultShouldBe(name: String, dataSource: DataSource) {
+      query2Name = name
+      query2DataSource = dataSource
+    }
+
+    fun useSameDataConnectInstanceForQuery2() {
+      query2DataConnectInstance = DataConnectInstance.Same
+    }
+
+    fun useNewDataConnectInstanceForQuery2() {
+      query2DataConnectInstance = DataConnectInstance.New
+    }
+
+    fun verify(): Quintuple<String, DataSource, String, DataSource, DataConnectInstance> {
+      val query1Name = checkNotNull(query1Name)
+      val query1DataSource = checkNotNull(query1DataSource)
+      val query2Name = checkNotNull(query2Name)
+      val query2DataSource = checkNotNull(query2DataSource)
+      val query2DataConnectInstance = checkNotNull(query2DataConnectInstance)
+      return Quintuple(
+        query1Name,
+        query1DataSource,
+        query2Name,
+        query2DataSource,
+        query2DataConnectInstance
+      )
+    }
+  }
+
+  /**
+   * Executes a series of create, query, and update operations to test query caching behavior.
+   *
+   * This function sets up a [FirebaseDataConnect] instance with the given [cacheSettings], then
+   * performs the following steps within a property-based test:
+   * 1. Inserts a row into the `Person` table with a randomly-generated `name1`.
+   * 2. Executes a query to retrieve the person and asserts its data and data source based on
+   * [CreateQueryUpdateQueryTestConfig.query1Name] and
+   * [CreateQueryUpdateQueryTestConfig.query1DataSource].
+   * 3. Updates the person's name to `name2`.
+   * 4. Executes the same query again and asserts its data and data source based on
+   * [CreateQueryUpdateQueryTestConfig.query2Name] and
+   * [CreateQueryUpdateQueryTestConfig.query2DataSource].
+   *
+   * @param cacheSettings The [CacheSettings] to use for the [FirebaseDataConnect] instance; this
+   * value is passed directly to [getInstance].
+   * @param configBlock A lambda that configures a [CreateQueryUpdateQueryTestConfig] instance. The
+   * `name1` and `name2` parameters are the names that will be used in the initial insert of the
+   * person and the subsequent update, respectively.
+   */
+  private fun executeCreateQueryUpdateQueryTest(
+    cacheSettings: CacheSettings?,
+    configBlock: CreateQueryUpdateQueryTestConfig.(name1: String, name2: String) -> Unit,
+  ) = runTest {
+    fun newDataConnectInstance() =
+      dataConnectFactory.newInstance(personConnectorConfig, cacheSettings)
+    var dataConnect = newDataConnectInstance()
+    val firebaseApp = dataConnect.app
+    val nameArb = Arb.usernames().map { it.value }
+
+    checkAll(propTestConfig, nameArb.distinctPair()) { (name1, name2) ->
+      val id = randomSource().random.nextAlphanumericString(32)
+      val (query1Name, query1DataSource, query2Name, query2DataSource, query2DataConnectInstance) =
+        CreateQueryUpdateQueryTestConfig().also { configBlock(it, name1, name2) }.verify()
+      val personSchema = PersonSchema(dataConnect)
+
+      personSchema.createPerson(id = id, name = name1).execute()
+
+      val queryRef1 = dataConnect.getPersonByIdQueryRef(id)
+      withClue("QueryRef.execute() #1") {
+        queryRef1.execute().asClue { queryResult ->
+          assertSoftly {
+            queryResult.data.person.shouldNotBeNull().name shouldBe query1Name
+            queryResult.dataSource shouldBe query1DataSource
+          }
+        }
+      }
+
+      personSchema.updatePerson(id = id, name = name2).execute()
+
+      val queryRef2 =
+        when (query2DataConnectInstance) {
+          CreateQueryUpdateQueryTestConfig.DataConnectInstance.Same -> queryRef1
+          CreateQueryUpdateQueryTestConfig.DataConnectInstance.New -> {
+            dataConnect.suspendingClose()
+            dataConnect =
+              dataConnectFactory.newInstance(firebaseApp, personConnectorConfig, cacheSettings)
+            dataConnect.getPersonByIdQueryRef(id)
+          }
+        }
+
+      withClue("QueryRef.execute() #2") {
+        queryRef2.execute().asClue { queryResult ->
+          assertSoftly {
+            queryResult.data.person.shouldNotBeNull().name shouldBe query2Name
+            queryResult.dataSource shouldBe query2DataSource
+          }
+        }
+      }
+    }
+  }
+}
+
+private val propTestConfig =
+  PropTestConfig(
+    iterations = 5,
+    edgeConfig = EdgeConfig(edgecasesGenerationProbability = 0.2),
+    shrinkingMode = ShrinkingMode.Off,
+  )
+
+private val personConnectorConfig = testConnectorConfig.copy(connector = personSchemaConnector)
+
+private fun FirebaseDataConnect.getPersonByIdQueryRef(
+  id: String
+): QueryRef<GetPersonQuery.Data, GetPersonQuery.Variables> =
+  query(
+    operationName = GetPersonQuery.operationName,
+    variables = GetPersonQuery.Variables(id = id),
+    dataDeserializer = serializer<GetPersonQuery.Data>(),
+    variablesSerializer = serializer<GetPersonQuery.Variables>(),
+  )

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/KotestTestutilPrinters.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/KotestTestutilPrinters.kt
@@ -32,6 +32,7 @@ fun registerDataConnectKotestTestutilPrinters() {
   Printers.add(Pair::class, PairPrint)
   Printers.add(Triple::class, TriplePrint)
   Printers.add(Quadruple::class, QuadruplePrint)
+  Printers.add(Quintuple::class, QuintuplePrint)
 
   try {
     Printers.add(SignificanceResult::class, SignificanceResultPrint)
@@ -87,6 +88,17 @@ private object QuadruplePrint : Print<Quadruple<*, *, *, *>> {
     get() =
       "Quadruple(${first.print().value}, ${second.print().value}, " +
         "${third.print().value}, ${fourth.print().value})"
+}
+
+private object QuintuplePrint : Print<Quintuple<*, *, *, *, *>> {
+
+  @Suppress("OVERRIDE_DEPRECATION")
+  override fun print(a: Quintuple<*, *, *, *, *>): Printed = a.printString.printed()
+
+  private val Quintuple<*, *, *, *, *>.printString: String
+    get() =
+      "Quintuple(${first.print().value}, ${second.print().value}, " +
+        "${third.print().value}, ${fourth.print().value}, ${fifth.print().value})"
 }
 
 private object SignificanceResultPrint : Print<SignificanceResult> {

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/Quintuple.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/Quintuple.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.dataconnect.testutil
+
+import java.io.Serializable
+
+// Note: the code below was adapted from the Triple class in the Kotlin standard library.
+
+data class Quintuple<out A, out B, out C, out D, out E>(
+  val first: A,
+  val second: B,
+  val third: C,
+  val fourth: D,
+  val fifth: E
+) : Serializable {
+
+  /**
+   * Returns string representation of the [Quintuple] including its [first], [second], [third],
+   * [fourth], and [fifth] values.
+   */
+  override fun toString(): String = "($first, $second, $third, $fourth, $fifth)"
+}
+
+/** Converts this quintuple into a list. */
+fun <T> Quintuple<T, T, T, T, T>.toList(): List<T> = listOf(first, second, third, fourth, fifth)


### PR DESCRIPTION
This PR adds `QueryCachingIntegrationTest.kt` to dataconnect's integration test suite. It performs some basic tests that results are served from cache when expected. The suite will be enhanced to test entity normalization in a future PR. These tests were augmented by PRs https://github.com/firebase/firebase-android-sdk/pull/7859, https://github.com/firebase/firebase-android-sdk/pull/7863, and https://github.com/firebase/firebase-android-sdk/pull/7869.

### Highlights

*   **QueryCachingIntegrationTest Added:** Added `QueryCachingIntegrationTest` to test that `QueryRef.execute()` returns cached or non-cached results, depending on the scenario.
*   **Enhanced Test Utilities:** Introduced a `Quintuple` data class, similar to the `Triple` class from the Kotlin standard library.

### Changelog

<details>
<summary>Changelog</summary>

*   **`DataConnectBackend.kt`**:
    *   Refactored `DataConnectBackend` interface to accept `CacheSettings` for `getDataConnectSettings` and `getDataConnect` functions.
    *   Removed unused imports related to `DataConnectBackend` sealed classes.
*   **`TestDataConnectFactory.kt`**:
    *   Added new `newInstance` overloads to `TestDataConnectFactory` to support `CacheSettings`.
    *   Updated `createInstance` to pass `CacheSettings` to the `DataConnectBackend`.
    *   Included `cacheSettings` in `TestDataConnectFactory.Params`.
*   **`TestConnectorFactory.kt`**:
    *   Modified `TestConnectorFactory` to accept `CacheSettings` in its `createInstance` method.
    *   Updated `dataConnectSettings` retrieval to use `getDataConnectSettings(params)`.
*   **`QueryCachingIntegrationTest.kt`**:
    *   Added a new file containing integration tests for query caching.
    *   Tests various combinations of `CacheSettings` (disabled, memory, persistent), `maxAge` (1.hour, 1.nanosecond, ZERO), and `FirebaseDataConnect` instance usage (same, new).
    *   Utilizes property-based testing with Kotest.
*   **`KotestTestutilPrinters.kt`**:
    *   Added `QuintuplePrint` to register a custom printer for the `Quintuple` class in Kotest.
*   **`Quintuple.kt`**:
    *   Added a new data class `Quintuple` to hold five values, extending test utility functionality.

</details>