### PR TITLE
dataconnect(test): IntWithEvenNumDigitsDistributionUnitTest: fix test that checked for both positive and negative values

### DIFF
--- a/firebase-dataconnect/testutil/src/test/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/IntWithEvenNumDigitsDistributionUnitTest.kt
+++ b/firebase-dataconnect/testutil/src/test/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/IntWithEvenNumDigitsDistributionUnitTest.kt
@@ -21,12 +21,10 @@ package com.google.firebase.dataconnect.testutil.property.arbitrary
 import com.google.firebase.dataconnect.testutil.RandomSeedTestRule
 import com.google.firebase.dataconnect.testutil.countBase10Digits
 import com.google.firebase.dataconnect.testutil.registerDataConnectKotestTestutilPrinters
-import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.print.print
 import io.kotest.assertions.withClue
 import io.kotest.common.ExperimentalKotest
 import io.kotest.matchers.booleans.shouldBeFalse
-import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.ranges.shouldBeIn
 import io.kotest.property.Arb
@@ -60,23 +58,26 @@ class IntWithEvenNumDigitsDistributionUnitTest {
   fun `intWithEvenNumDigitsDistribution produces both positive and negative values`() = runTest {
     var positiveCount = 0
     var negativeCount = 0
-    var zeroCount = 0
 
     checkAll(propTestConfig, Arb.intWithEvenNumDigitsDistribution()) { value ->
       if (value > 0) {
         positiveCount++
       } else if (value < 0) {
         negativeCount++
-      } else {
-        check(value == 0)
-        zeroCount++
       }
     }
 
-    assertSoftly {
-      withClue("positiveCount") { positiveCount shouldBeGreaterThan 0 }
-      withClue("negativeCount") { negativeCount shouldBeGreaterThan 0 }
-      withClue("zeroCount") { zeroCount shouldBeGreaterThan 0 }
+    check(positiveCount > 0 && negativeCount > 0)
+    withClue("positiveCount=$positiveCount, negativeCount=$negativeCount") {
+      val iterations = positiveCount + negativeCount
+      val observedCounts = longArrayOf(positiveCount.toLong(), negativeCount.toLong())
+      val expectedObservedCount = iterations.toDouble() / observedCounts.size
+      val expectedCounts = DoubleArray(observedCounts.size) { expectedObservedCount }
+      val significanceResult = ChiSquareTest.withDefaults().test(expectedCounts, observedCounts)
+      withClue(significanceResult.print().value) {
+        // Note: Larger values to reject() make stronger guarantees of lack of bias.
+        significanceResult.reject(0.01).shouldBeFalse()
+      }
     }
   }
 

--- a/firebase-dataconnect/testutil/src/test/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/LongWithEvenNumDigitsDistributionUnitTest.kt
+++ b/firebase-dataconnect/testutil/src/test/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/LongWithEvenNumDigitsDistributionUnitTest.kt
@@ -21,12 +21,10 @@ package com.google.firebase.dataconnect.testutil.property.arbitrary
 import com.google.firebase.dataconnect.testutil.RandomSeedTestRule
 import com.google.firebase.dataconnect.testutil.countBase10Digits
 import com.google.firebase.dataconnect.testutil.registerDataConnectKotestTestutilPrinters
-import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.print.print
 import io.kotest.assertions.withClue
 import io.kotest.common.ExperimentalKotest
 import io.kotest.matchers.booleans.shouldBeFalse
-import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.ranges.shouldBeIn
 import io.kotest.property.Arb
@@ -60,23 +58,26 @@ class LongWithEvenNumDigitsDistributionUnitTest {
   fun `longWithEvenNumDigitsDistribution produces both positive and negative values`() = runTest {
     var positiveCount = 0
     var negativeCount = 0
-    var zeroCount = 0
 
     checkAll(propTestConfig, Arb.longWithEvenNumDigitsDistribution()) { value ->
       if (value > 0) {
         positiveCount++
       } else if (value < 0) {
         negativeCount++
-      } else {
-        check(value == 0L)
-        zeroCount++
       }
     }
 
-    assertSoftly {
-      withClue("positiveCount") { positiveCount shouldBeGreaterThan 0 }
-      withClue("negativeCount") { negativeCount shouldBeGreaterThan 0 }
-      withClue("zeroCount") { zeroCount shouldBeGreaterThan 0 }
+    check(positiveCount > 0 && negativeCount > 0)
+    withClue("positiveCount=$positiveCount, negativeCount=$negativeCount") {
+      val iterations = positiveCount + negativeCount
+      val observedCounts = longArrayOf(positiveCount.toLong(), negativeCount.toLong())
+      val expectedObservedCount = iterations.toDouble() / observedCounts.size
+      val expectedCounts = DoubleArray(observedCounts.size) { expectedObservedCount }
+      val significanceResult = ChiSquareTest.withDefaults().test(expectedCounts, observedCounts)
+      withClue(significanceResult.print().value) {
+        // Note: Larger values to reject() make stronger guarantees of lack of bias.
+        significanceResult.reject(0.01).shouldBeFalse()
+      }
     }
   }
 


### PR DESCRIPTION
This PR fixes the dataconnect tests for even-digit integer and long distributions to ensure they correctly verify unbiased production of both positive and negative values. The tests were updated to use a Chi-square significance test to validate the distribution.

This fixes the flaky test `longWithEvenNumDigitsDistribution produces both positive and negative values` from `LongWithEvenNumDigitsDistributionUnitTest` which would flakily fail with this error: "zeroCount 0 should be > 0".

### Highlights

*   Updated `IntWithEvenNumDigitsDistributionUnitTest` and `LongWithEvenNumDigitsDistributionUnitTest` to remove the zero count check, as these distributions are not expected to produce zero.
*   Implemented a Chi-square test in both unit tests to statistically verify that the generation of positive and negative values is unbiased.
*   Refactored the validation logic to use `ChiSquareTest` and removed unused `assertSoftly` and `shouldBeGreaterThan` imports.

### Changelog

<details>
<summary>Modified Files</summary>

*   `IntWithEvenNumDigitsDistributionUnitTest.kt`: Removed zero count tracking and replaced basic count assertions with a Chi-square test for unbiased distribution.
*   `LongWithEvenNumDigitsDistributionUnitTest.kt`: Removed zero count tracking and replaced basic count assertions with a Chi-square test for unbiased distribution.

</details>
