### PR TITLE
dataconnect(test): QueryCachingIntegrationTest.kt updated with normalized caching tests for a multi-value entity.

### DIFF
--- a/firebase-dataconnect/emulator/dataconnect/connector/caching/caching_ops.gql
+++ b/firebase-dataconnect/emulator/dataconnect/connector/caching/caching_ops.gql
@@ -355,3 +355,140 @@ query CachingNullableAny_GetByTag($tag: String!) @auth(level: PUBLIC) {
 query CachingNullableAny_GetByTag2($tag: String!) @auth(level: PUBLIC) {
   items: cachingNullableAnies(where: {tag: {eq: $tag}}) { id any }
 }
+
+###############################################################################
+# CachingMixed
+###############################################################################
+
+mutation CachingMixed_Insert(
+  $string: String!,
+  $stringNullable: String,
+  $float: Float!,
+  $floatNullable: Float,
+  $boolean: Boolean!,
+  $booleanNullable: Boolean,
+  $any: Any!,
+  $anyNullable: Any,
+  $stringList: [String!],
+  $floatList: [Float!],
+  $booleanList: [Boolean!],
+  $anyList: [Any!],
+  $tag: String,
+) @auth(level: PUBLIC) {
+  key: cachingMixed_insert(data: {
+    string: $string,
+    stringNullable: $stringNullable,
+    float: $float,
+    floatNullable: $floatNullable,
+    boolean: $boolean,
+    booleanNullable: $booleanNullable,
+    any: $any,
+    anyNullable: $anyNullable,
+    stringList: $stringList,
+    floatList: $floatList,
+    booleanList: $booleanList,
+    anyList: $anyList,
+    tag: $tag,
+  })
+}
+
+mutation CachingMixed_Update(
+  $key: CachingMixed_Key!,
+  $string: String,
+  $stringNullable: String,
+  $float: Float,
+  $floatNullable: Float,
+  $boolean: Boolean,
+  $booleanNullable: Boolean,
+  $any: Any,
+  $anyNullable: Any,
+  $stringList: [String!],
+  $floatList: [Float!],
+  $booleanList: [Boolean!],
+  $anyList: [Any!]
+) @auth(level: PUBLIC) {
+  cachingMixed_update(key: $key, data: {
+    string: $string,
+    stringNullable: $stringNullable,
+    float: $float,
+    floatNullable: $floatNullable,
+    boolean: $boolean,
+    booleanNullable: $booleanNullable,
+    any: $any,
+    anyNullable: $anyNullable,
+    stringList: $stringList,
+    floatList: $floatList,
+    booleanList: $booleanList,
+    anyList: $anyList,
+  })
+}
+
+query CachingMixed_GetByKey( $key: CachingMixed_Key!) @auth(level: PUBLIC) {
+  item: cachingMixed(key: $key) {
+    string
+    stringNullable
+    float
+    floatNullable
+    boolean
+    booleanNullable
+    any
+    anyNullable
+    stringList
+    floatList
+    booleanList
+    anyList
+  }
+}
+
+query CachingMixed_GetByKey2( $key: CachingMixed_Key!) @auth(level: PUBLIC) {
+  item: cachingMixed(key: $key) {
+    string
+    stringNullable
+    float
+    floatNullable
+    boolean
+    booleanNullable
+    any
+    anyNullable
+    stringList
+    floatList
+    booleanList
+    anyList
+  }
+}
+
+query CachingMixed_GetByTag($tag: String!) @auth(level: PUBLIC) {
+  items: cachingMixeds(where: {tag: {eq: $tag}}) {
+    id
+    string
+    stringNullable
+    float
+    floatNullable
+    boolean
+    booleanNullable
+    any
+    anyNullable
+    stringList
+    floatList
+    booleanList
+    anyList
+  }
+}
+
+query CachingMixed_GetByTag2($tag: String!) @auth(level: PUBLIC) {
+  items: cachingMixeds(where: {tag: {eq: $tag}}) {
+    id
+    string
+    stringNullable
+    float
+    floatNullable
+    boolean
+    booleanNullable
+    any
+    anyNullable
+    stringList
+    floatList
+    booleanList
+    anyList
+  }
+}

--- a/firebase-dataconnect/emulator/dataconnect/schema/caching_schema.gql
+++ b/firebase-dataconnect/emulator/dataconnect/schema/caching_schema.gql
@@ -87,3 +87,23 @@ type CachingNullableAny @table {
   any: Any
   tag: String
 }
+
+###############################################################################
+# Mixed scalars
+###############################################################################
+
+type CachingMixed @table {
+  string: String!
+  stringNullable: String
+  float: Float!
+  floatNullable: Float
+  boolean: Boolean!
+  booleanNullable: Boolean
+  any: Any!
+  anyNullable: Any
+  stringList: [String]
+  floatList: [Float]
+  booleanList: [Boolean]
+  anyList: [Any]
+  tag: String
+}

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/QueryCachingIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/QueryCachingIntegrationTest.kt
@@ -19,6 +19,7 @@
 package com.google.firebase.dataconnect
 
 import com.google.firebase.FirebaseApp
+import com.google.firebase.dataconnect.AnyValueRoundTrip.Companion.dataConnectRoundTripValue
 import com.google.firebase.dataconnect.CacheSettings.Storage.MEMORY
 import com.google.firebase.dataconnect.CacheSettings.Storage.PERSISTENT
 import com.google.firebase.dataconnect.DataSource.CACHE
@@ -27,6 +28,7 @@ import com.google.firebase.dataconnect.testutil.DataConnectIntegrationTestBase
 import com.google.firebase.dataconnect.testutil.Quintuple
 import com.google.firebase.dataconnect.testutil.expectedAnyScalarDoubleRoundTripValue
 import com.google.firebase.dataconnect.testutil.map
+import com.google.firebase.dataconnect.testutil.property.arbitrary.DataConnectArb.FloatRoundTrip
 import com.google.firebase.dataconnect.testutil.property.arbitrary.dataConnect
 import com.google.firebase.dataconnect.testutil.property.arbitrary.distinctPair
 import com.google.firebase.dataconnect.testutil.property.arbitrary.proto
@@ -45,6 +47,10 @@ import com.google.firebase.dataconnect.testutil.schemas.verifyGetFloat
 import com.google.firebase.dataconnect.testutil.schemas.verifyGetFloat2
 import com.google.firebase.dataconnect.testutil.schemas.verifyGetFloatsByTag
 import com.google.firebase.dataconnect.testutil.schemas.verifyGetFloatsByTag2
+import com.google.firebase.dataconnect.testutil.schemas.verifyGetMixed
+import com.google.firebase.dataconnect.testutil.schemas.verifyGetMixed2
+import com.google.firebase.dataconnect.testutil.schemas.verifyGetMixedsByTag
+import com.google.firebase.dataconnect.testutil.schemas.verifyGetMixedsByTag2
 import com.google.firebase.dataconnect.testutil.schemas.verifyGetNullableAnyValue
 import com.google.firebase.dataconnect.testutil.schemas.verifyGetNullableAnyValue2
 import com.google.firebase.dataconnect.testutil.schemas.verifyGetNullableAnyValuesByTag
@@ -91,12 +97,14 @@ import io.kotest.property.PropTestConfig
 import io.kotest.property.ShrinkingMode
 import io.kotest.property.arbitrary.Codepoint
 import io.kotest.property.arbitrary.alphanumeric
+import io.kotest.property.arbitrary.bind
 import io.kotest.property.arbitrary.boolean
 import io.kotest.property.arbitrary.list
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.orNull
 import io.kotest.property.arbitrary.string
 import io.kotest.property.checkAll
+import java.util.UUID
 import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
@@ -644,6 +652,34 @@ class QueryCachingIntegrationTest : DataConnectIntegrationTestBase() {
       connector.verifyGetNullableAnyValue(key, "query4d", any4?.roundTripValue, CACHE)
     }
   }
+
+  @Test
+  fun normalizedMixed() = runTest {
+    val connector = newCachingConnector()
+    checkAll(propTestConfig, mixedArb().quintuple()) { (mixed1, mixed2, mixed3, mixed4, mixed5) ->
+      val tag = randomTag()
+      val key = connector.insertMixed(mixed1.toInsertVariables(tag))
+      connector.verifyGetMixed(key, "query1a", mixed1.toGetItem(), SERVER)
+      connector.updateMixed(key, mixed2.toUpdateBuilder())
+      connector.verifyGetMixed2(key, "query2a", mixed2.toGetItem(), SERVER)
+      connector.verifyGetMixed(key, "query2b", mixed2.toGetItem(), CACHE)
+      connector.updateMixed(key, mixed3.toUpdateBuilder())
+      connector.verifyGetMixedsByTag(tag, "query3a", mixed3.toGetManyItem(key), SERVER)
+      connector.verifyGetMixed2(key, "query3b", mixed3.toGetItem(), CACHE)
+      connector.verifyGetMixed(key, "query3c", mixed3.toGetItem(), CACHE)
+      val key2 = connector.insertMixed(mixed5.toInsertVariables(tag))
+      connector.updateMixed(key, mixed4.toUpdateBuilder())
+      connector.verifyGetMixedsByTag2(
+        tag,
+        "query4a",
+        listOf(mixed4.toGetManyItem(key), mixed5.toGetManyItem(key2)),
+        SERVER
+      )
+      connector.verifyGetMixedsByTag(tag, "query4b", mixed4.toGetManyItem(key), CACHE)
+      connector.verifyGetMixed2(key, "query4c", mixed4.toGetItem(), CACHE)
+      connector.verifyGetMixed(key, "query4d", mixed4.toGetItem(), CACHE)
+    }
+  }
 }
 
 private val propTestConfig =
@@ -658,18 +694,41 @@ private fun alphanumericStringArb(): Arb<String> = Arb.string(0..10, Codepoint.a
 private fun randomTag(): String = "tag_" + Random.nextAlphanumericString(50)
 
 private data class AnyValueRoundTrip(val value: AnyValue) {
-  val roundTripValue: AnyValue = value.expectedAnyScalarRoundTripValue()
+
+  val roundTripValue = value.dataConnectRoundTripValue()
 
   override fun toString() =
     "AnyValueRoundTrip(value=${value.print().value}, " +
-      "roundTripValue=${roundTripValue.print().value})"
+      "roundTripValue=${value.dataConnectRoundTripValue().print().value})"
 
   companion object {
 
-    fun AnyValue.expectedAnyScalarRoundTripValue(): AnyValue =
-      AnyValue(protoValue.expectedAnyScalarRoundTripValue())
+    @JvmName("dataConnectRoundTripValue_AnyValue")
+    fun AnyValue.dataConnectRoundTripValue(): AnyValue =
+      AnyValue(protoValue.anyScalarRoundTripValue())
 
-    fun ValueProto.expectedAnyScalarRoundTripValue(): ValueProto = map { _, value ->
+    @JvmName("dataConnectRoundTripValue_NullableAnyValue")
+    fun AnyValue?.dataConnectRoundTripValue(): AnyValue? = this?.dataConnectRoundTripValue()
+
+    @JvmName("dataConnectRoundTripValue_List_AnyValue")
+    fun List<AnyValue>.dataConnectRoundTripValue(): List<AnyValue> = map {
+      it.dataConnectRoundTripValue()
+    }
+
+    @JvmName("dataConnectRoundTripValue_NullableList_AnyValue")
+    fun List<AnyValue>?.dataConnectRoundTripValue(): List<AnyValue>? =
+      this?.map { it.dataConnectRoundTripValue() }
+
+    @JvmName("dataConnectRoundTripValue_List_NullableAnyValue")
+    fun List<AnyValue?>.dataConnectRoundTripValue(): List<AnyValue?> = map {
+      it?.dataConnectRoundTripValue()
+    }
+
+    @JvmName("dataConnectRoundTripValue_NullableList_NullableAnyValue")
+    fun List<AnyValue?>?.dataConnectRoundTripValue(): List<AnyValue?>? =
+      this?.map { it?.dataConnectRoundTripValue() }
+
+    fun ValueProto.anyScalarRoundTripValue(): ValueProto = map { _, value ->
       if (value.kindCase != ValueProto.KindCase.NUMBER_VALUE) {
         value
       } else {
@@ -678,6 +737,31 @@ private data class AnyValueRoundTrip(val value: AnyValue) {
     }
   }
 }
+
+@JvmName("dataConnectRoundTripValue_AnyValueRoundTrip")
+private fun AnyValueRoundTrip.dataConnectRoundTripValue(): AnyValue = roundTripValue
+
+@JvmName("dataConnectRoundTripValue_NullableAnyValueRoundTrip")
+private fun AnyValueRoundTrip?.dataConnectRoundTripValue(): AnyValue? =
+  this?.dataConnectRoundTripValue()
+
+@JvmName("dataConnectRoundTripValue_List_AnyValueRoundTrip")
+private fun List<AnyValueRoundTrip>.dataConnectRoundTripValue(): List<AnyValue> = map {
+  it.dataConnectRoundTripValue()
+}
+
+@JvmName("dataConnectRoundTripValue_List_NullableAnyValueRoundTrip")
+private fun List<AnyValueRoundTrip?>.dataConnectRoundTripValue(): List<AnyValue?> = map {
+  it.dataConnectRoundTripValue()
+}
+
+@JvmName("dataConnectRoundTripValue_NullableList_AnyValueRoundTrip")
+private fun List<AnyValueRoundTrip>?.dataConnectRoundTripValue(): List<AnyValue>? =
+  this?.map { it.dataConnectRoundTripValue() }
+
+@JvmName("dataConnectRoundTripValue_NullableList_NullableAnyValueRoundTrip")
+private fun List<AnyValueRoundTrip?>?.dataConnectRoundTripValue(): List<AnyValue?>? =
+  this?.map { it.dataConnectRoundTripValue() }
 
 private val anyValueArbValueProtoArbRecursiveExcludes =
   setOf(
@@ -690,3 +774,122 @@ private fun anyValueArb(): Arb<AnyValueRoundTrip> =
     .value(recursiveExcludes = anyValueArbValueProtoArbRecursiveExcludes)
     .map(::AnyValue)
     .map(::AnyValueRoundTrip)
+
+private data class MixedArbSample(
+  val string: String,
+  val stringNullable: String?,
+  val float: FloatRoundTrip,
+  val floatNullable: FloatRoundTrip?,
+  val boolean: Boolean,
+  val booleanNullable: Boolean?,
+  val any: AnyValueRoundTrip,
+  val anyNullable: AnyValueRoundTrip?,
+  val stringList: List<String?>?,
+  val floatList: List<FloatRoundTrip?>?,
+  val booleanList: List<Boolean?>?,
+  val anyList: List<AnyValueRoundTrip?>?,
+)
+
+private fun MixedArbSample.toInsertVariables(tag: String) =
+  CachingConnector.Variables.MixedInsert(
+    string,
+    stringNullable,
+    float.float,
+    floatNullable?.float,
+    boolean,
+    booleanNullable,
+    any.value,
+    anyNullable?.value,
+    stringList,
+    floatList?.map { it?.float },
+    booleanList,
+    anyList?.map { it?.value },
+    OptionalVariable.Value(tag),
+  )
+
+private fun MixedArbSample.toUpdateBuilder():
+  (CachingConnector.Variables.MixedUpdate.Builder.() -> Unit) {
+  return {
+    string = this@toUpdateBuilder.string
+    stringNullable = this@toUpdateBuilder.stringNullable
+    float = this@toUpdateBuilder.float.roundTripFloat
+    floatNullable = this@toUpdateBuilder.floatNullable?.roundTripFloat
+    boolean = this@toUpdateBuilder.boolean
+    booleanNullable = this@toUpdateBuilder.booleanNullable
+    any = this@toUpdateBuilder.any.value
+    anyNullable = this@toUpdateBuilder.anyNullable?.value
+    stringList = this@toUpdateBuilder.stringList
+    floatList = this@toUpdateBuilder.floatList?.map { it?.roundTripFloat }
+    booleanList = this@toUpdateBuilder.booleanList
+    anyList = this@toUpdateBuilder.anyList?.map { it?.value }
+  }
+}
+
+private fun MixedArbSample.toGetItem() =
+  CachingConnector.Data.MixedGet.Item(
+    string,
+    stringNullable,
+    float.roundTripFloat,
+    floatNullable?.roundTripFloat,
+    boolean,
+    booleanNullable,
+    any.dataConnectRoundTripValue(),
+    anyNullable.dataConnectRoundTripValue(),
+    stringList,
+    floatList?.map { it?.roundTripFloat },
+    booleanList,
+    anyList.dataConnectRoundTripValue(),
+  )
+
+private fun MixedArbSample.toGetManyItem(key: CachingConnector.Key) = toGetManyItem(key.id)
+
+private fun MixedArbSample.toGetManyItem(id: UUID) =
+  CachingConnector.Data.MixedGetMany.Item(
+    id,
+    string,
+    stringNullable,
+    float.roundTripFloat,
+    floatNullable?.roundTripFloat,
+    boolean,
+    booleanNullable,
+    any.dataConnectRoundTripValue(),
+    anyNullable.dataConnectRoundTripValue(),
+    stringList,
+    floatList?.map { it?.roundTripFloat },
+    booleanList,
+    anyList.dataConnectRoundTripValue(),
+  )
+
+private fun mixedArb(
+  stringArb: Arb<String> = alphanumericStringArb(),
+  stringNullableArb: Arb<String?> = stringArb.orNull(nullProbability = 0.2),
+  floatArb: Arb<FloatRoundTrip> = Arb.dataConnect.float(),
+  floatNullableArb: Arb<FloatRoundTrip?> = floatArb.orNull(nullProbability = 0.2),
+  booleanArb: Arb<Boolean> = Arb.boolean(),
+  booleanNullableArb: Arb<Boolean?> = booleanArb.orNull(nullProbability = 0.2),
+  anyArb: Arb<AnyValueRoundTrip> = anyValueArb(),
+  anyNullableArb: Arb<AnyValueRoundTrip?> = anyArb.orNull(nullProbability = 0.2),
+  stringListArb: Arb<List<String?>?> =
+    Arb.list(stringNullableArb, 0..3).orNull(nullProbability = 0.2),
+  floatListArb: Arb<List<FloatRoundTrip?>?> =
+    Arb.list(floatNullableArb, 0..3).orNull(nullProbability = 0.2),
+  booleanListArb: Arb<List<Boolean?>?> =
+    Arb.list(booleanNullableArb, 0..3).orNull(nullProbability = 0.2),
+  anyListArb: Arb<List<AnyValueRoundTrip?>?> =
+    Arb.list(anyNullableArb, 0..3).orNull(nullProbability = 0.2),
+): Arb<MixedArbSample> =
+  Arb.bind(
+    stringArb,
+    stringNullableArb,
+    floatArb,
+    floatNullableArb,
+    booleanArb,
+    booleanNullableArb,
+    anyArb,
+    anyNullableArb,
+    stringListArb,
+    floatListArb,
+    booleanListArb,
+    anyListArb,
+    ::MixedArbSample
+  )

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/testutil/schemas/CachingConnector.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/testutil/schemas/CachingConnector.kt
@@ -757,6 +757,55 @@ class CachingConnector(val dataConnect: FirebaseDataConnect) {
     return queryRef.execute()
   }
 
+  suspend fun insertMixed(variables: Variables.MixedInsert): Key {
+    val mutationRef =
+      dataConnect.mutation(
+        "CachingMixed_Insert",
+        variables,
+        serializer<Data.Insert>(),
+        serializer()
+      )
+
+    val result = mutationRef.execute()
+
+    return result.data.key
+  }
+
+  suspend fun updateMixed(key: Key, block: Variables.MixedUpdate.Builder.() -> Unit) {
+    val variables = Variables.MixedUpdate.build(key, block)
+    val mutationRef =
+      dataConnect.mutation("CachingMixed_Update", variables, serializer<Unit>(), serializer())
+    mutationRef.execute()
+  }
+
+  suspend fun getMixed(key: Key) = getMixed("CachingMixed_GetByKey", key)
+
+  suspend fun getMixed2(key: Key) = getMixed("CachingMixed_GetByKey2", key)
+
+  private suspend fun getMixed(
+    operationName: String,
+    key: Key
+  ): QueryResult<Data.MixedGet, Variables.GetByKey> {
+    val variables = Variables.GetByKey(key)
+    val queryRef =
+      dataConnect.query(operationName, variables, serializer<Data.MixedGet>(), serializer())
+    return queryRef.execute()
+  }
+
+  suspend fun getMixedsByTag(tag: String) = getMixedsByTag("CachingMixed_GetByTag", tag)
+
+  suspend fun getMixedsByTag2(tag: String) = getMixedsByTag("CachingMixed_GetByTag2", tag)
+
+  private suspend fun getMixedsByTag(
+    operationName: String,
+    tag: String
+  ): QueryResult<Data.MixedGetMany, Variables.GetByTag> {
+    val variables = Variables.GetByTag(tag)
+    val queryRef =
+      dataConnect.query(operationName, variables, serializer<Data.MixedGetMany>(), serializer())
+    return queryRef.execute()
+  }
+
   object Variables {
 
     @Serializable data class GetByKey(val key: Key)
@@ -928,6 +977,169 @@ class CachingConnector(val dataConnect: FirebaseDataConnect) {
         tag = if (tag === null) Undefined else Value(tag),
       )
     }
+
+    @Serializable
+    data class MixedUpdate(
+      val key: Key,
+      val string: OptionalVariable<String>,
+      val stringNullable: OptionalVariable<String?>,
+      val float: OptionalVariable<Double>,
+      val floatNullable: OptionalVariable<Double?>,
+      val boolean: OptionalVariable<Boolean>,
+      val booleanNullable: OptionalVariable<Boolean?>,
+      val any: OptionalVariable<AnyValue>,
+      val anyNullable: OptionalVariable<AnyValue?>,
+      val stringList: OptionalVariable<List<String?>?>,
+      val floatList: OptionalVariable<List<Double?>?>,
+      val booleanList: OptionalVariable<List<Boolean?>?>,
+      val anyList: OptionalVariable<List<AnyValue?>?>,
+    ) {
+
+      @DslMarker annotation class BuilderDsl
+
+      @BuilderDsl
+      interface Builder {
+        var string: String
+        var stringNullable: String?
+        var float: Double
+        var floatNullable: Double?
+        var boolean: Boolean
+        var booleanNullable: Boolean?
+        var any: AnyValue
+        var anyNullable: AnyValue?
+        var stringList: List<String?>?
+        var floatList: List<Double?>?
+        var booleanList: List<Boolean?>?
+        var anyList: List<AnyValue?>?
+      }
+
+      companion object {
+
+        fun build(key: Key, block: Builder.() -> Unit): MixedUpdate {
+          var string: OptionalVariable<String> = Undefined
+          var stringNullable: OptionalVariable<String?> = Undefined
+          var float: OptionalVariable<Double> = Undefined
+          var floatNullable: OptionalVariable<Double?> = Undefined
+          var boolean: OptionalVariable<Boolean> = Undefined
+          var booleanNullable: OptionalVariable<Boolean?> = Undefined
+          var any: OptionalVariable<AnyValue> = Undefined
+          var anyNullable: OptionalVariable<AnyValue?> = Undefined
+          var stringList: OptionalVariable<List<String?>?> = Undefined
+          var floatList: OptionalVariable<List<Double?>?> = Undefined
+          var booleanList: OptionalVariable<List<Boolean?>?> = Undefined
+          var anyList: OptionalVariable<List<AnyValue?>?> = Undefined
+
+          return object : Builder {
+              override var string: String
+                get() = string.valueOrThrow()
+                set(value) {
+                  string = Value(value)
+                }
+
+              override var stringNullable: String?
+                get() = stringNullable.valueOrThrow()
+                set(value) {
+                  stringNullable = Value(value)
+                }
+
+              override var float: Double
+                get() = float.valueOrThrow()
+                set(value) {
+                  float = Value(value)
+                }
+
+              override var floatNullable: Double?
+                get() = floatNullable.valueOrThrow()
+                set(value) {
+                  floatNullable = Value(value)
+                }
+
+              override var boolean: Boolean
+                get() = boolean.valueOrThrow()
+                set(value) {
+                  boolean = Value(value)
+                }
+
+              override var booleanNullable: Boolean?
+                get() = booleanNullable.valueOrThrow()
+                set(value) {
+                  booleanNullable = Value(value)
+                }
+
+              override var any: AnyValue
+                get() = any.valueOrThrow()
+                set(value) {
+                  any = Value(value)
+                }
+
+              override var anyNullable: AnyValue?
+                get() = anyNullable.valueOrThrow()
+                set(value) {
+                  anyNullable = Value(value)
+                }
+
+              override var stringList: List<String?>?
+                get() = stringList.valueOrThrow()
+                set(value) {
+                  stringList = Value(value)
+                }
+
+              override var floatList: List<Double?>?
+                get() = floatList.valueOrThrow()
+                set(value) {
+                  floatList = Value(value)
+                }
+
+              override var booleanList: List<Boolean?>?
+                get() = booleanList.valueOrThrow()
+                set(value) {
+                  booleanList = Value(value)
+                }
+
+              override var anyList: List<AnyValue?>?
+                get() = anyList.valueOrThrow()
+                set(value) {
+                  anyList = Value(value)
+                }
+            }
+            .apply(block)
+            .let {
+              MixedUpdate(
+                key = key,
+                string = string,
+                stringNullable = stringNullable,
+                float = float,
+                floatNullable = floatNullable,
+                boolean = boolean,
+                booleanNullable = booleanNullable,
+                any = any,
+                anyNullable = anyNullable,
+                stringList = stringList,
+                floatList = floatList,
+                booleanList = booleanList,
+                anyList = anyList,
+              )
+            }
+        }
+      }
+    }
+
+    @Serializable
+    data class MixedInsert(
+      val string: String,
+      val stringNullable: String?,
+      val float: Double,
+      val floatNullable: Double?,
+      val boolean: Boolean,
+      val booleanNullable: Boolean?,
+      val any: AnyValue,
+      val anyNullable: AnyValue?,
+      val stringList: List<String?>?,
+      val floatList: List<Double?>?,
+      val booleanList: List<Boolean?>?,
+      val anyList: List<AnyValue?>?,
+      val tag: OptionalVariable<String>,
+    )
   }
 
   object Data {
@@ -1099,6 +1311,45 @@ class CachingConnector(val dataConnect: FirebaseDataConnect) {
       data class Item(
         val id: @Serializable(with = UUIDSerializer::class) UUID,
         val any: AnyValue?,
+      )
+    }
+
+    @Serializable
+    data class MixedGet(val item: Item?) {
+      @Serializable
+      data class Item(
+        val string: String,
+        val stringNullable: String?,
+        val float: Double,
+        val floatNullable: Double?,
+        val boolean: Boolean,
+        val booleanNullable: Boolean?,
+        val any: AnyValue,
+        val anyNullable: AnyValue?,
+        val stringList: List<String?>?,
+        val floatList: List<Double?>?,
+        val booleanList: List<Boolean?>?,
+        val anyList: List<AnyValue?>?,
+      )
+    }
+
+    @Serializable
+    data class MixedGetMany(val items: List<Item>) {
+      @Serializable
+      data class Item(
+        val id: @Serializable(with = UUIDSerializer::class) UUID,
+        val string: String,
+        val stringNullable: String?,
+        val float: Double,
+        val floatNullable: Double?,
+        val boolean: Boolean,
+        val booleanNullable: Boolean?,
+        val any: AnyValue,
+        val anyNullable: AnyValue?,
+        val stringList: List<String?>?,
+        val floatList: List<Double?>?,
+        val booleanList: List<Boolean?>?,
+        val anyList: List<AnyValue?>?,
       )
     }
   }
@@ -1346,6 +1597,28 @@ fun QueryResult<CachingConnector.Data.NullableAnyValueGetMany, CachingConnector.
   .shouldBe(anys: Collection<AnyValue?>, dataSource: DataSource) {
   assertSoftly {
     this.data.items.map { it.any } shouldContainExactlyInAnyOrder anys
+    this.dataSource shouldBe dataSource
+  }
+}
+
+@JvmName("QueryResult_MixedGet_shouldBe")
+fun QueryResult<CachingConnector.Data.MixedGet, CachingConnector.Variables.GetByKey>.shouldBe(
+  item: CachingConnector.Data.MixedGet.Item,
+  dataSource: DataSource
+) {
+  assertSoftly {
+    this.data.item.shouldNotBeNull() shouldBe item
+    this.dataSource shouldBe dataSource
+  }
+}
+
+@JvmName("QueryResult_MixedGetMany_shouldBe")
+fun QueryResult<CachingConnector.Data.MixedGetMany, CachingConnector.Variables.GetByTag>.shouldBe(
+  items: Collection<CachingConnector.Data.MixedGetMany.Item>,
+  dataSource: DataSource
+) {
+  assertSoftly {
+    this.data.items shouldContainExactlyInAnyOrder items
     this.dataSource shouldBe dataSource
   }
 }
@@ -1921,4 +2194,49 @@ suspend fun CachingConnector.verifyGetNullableAnyValuesByTag2(
   expectedDataSource: DataSource
 ) {
   withClue(clue) { getNullableAnyValuesByTag2(tag).shouldBe(expectedAnyValues, expectedDataSource) }
+}
+
+suspend fun CachingConnector.verifyGetMixed(
+  key: CachingConnector.Key,
+  clue: String,
+  expectedItem: CachingConnector.Data.MixedGet.Item,
+  expectedDataSource: DataSource
+) {
+  withClue(clue) { getMixed(key).shouldBe(expectedItem, expectedDataSource) }
+}
+
+suspend fun CachingConnector.verifyGetMixed2(
+  key: CachingConnector.Key,
+  clue: String,
+  expectedItem: CachingConnector.Data.MixedGet.Item,
+  expectedDataSource: DataSource
+) {
+  withClue(clue) { getMixed2(key).shouldBe(expectedItem, expectedDataSource) }
+}
+
+suspend fun CachingConnector.verifyGetMixedsByTag(
+  tag: String,
+  clue: String,
+  expectedItem: CachingConnector.Data.MixedGetMany.Item,
+  expectedDataSource: DataSource
+) {
+  withClue(clue) { getMixedsByTag(tag).shouldBe(listOf(expectedItem), expectedDataSource) }
+}
+
+suspend fun CachingConnector.verifyGetMixedsByTag2(
+  tag: String,
+  clue: String,
+  expectedItem: CachingConnector.Data.MixedGetMany.Item,
+  expectedDataSource: DataSource
+) {
+  verifyGetMixedsByTag2(tag, clue, listOf(expectedItem), expectedDataSource)
+}
+
+suspend fun CachingConnector.verifyGetMixedsByTag2(
+  tag: String,
+  clue: String,
+  expectedItems: Collection<CachingConnector.Data.MixedGetMany.Item>,
+  expectedDataSource: DataSource
+) {
+  withClue(clue) { getMixedsByTag2(tag).shouldBe(expectedItems, expectedDataSource) }
 }

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/arbs.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/arbs.kt
@@ -81,6 +81,30 @@ object DataConnectArb {
 
       // -0.0 gets coerced to 0.0 due to lack of JSONB support for -0.0 (see b/339440054).
       fun roundTripFloat(float: Double): Double = if (float != -0.0) float else 0.0
+
+      @JvmName("dataConnectRoundTripValue_Double")
+      fun Double.dataConnectRoundTripValue(): Double = roundTripFloat(this)
+
+      @JvmName("dataConnectRoundTripValue_NullableDouble")
+      fun Double?.dataConnectRoundTripValue(): Double? = this?.dataConnectRoundTripValue()
+
+      @JvmName("dataConnectRoundTripValue_List_Double")
+      fun List<Double>.dataConnectRoundTripValue(): List<Double> = map {
+        it.dataConnectRoundTripValue()
+      }
+
+      @JvmName("dataConnectRoundTripValue_NullableList_Double")
+      fun List<Double>?.dataConnectRoundTripValue(): List<Double>? =
+        this?.map { it.dataConnectRoundTripValue() }
+
+      @JvmName("dataConnectRoundTripValue_List_NullableDouble")
+      fun List<Double?>.dataConnectRoundTripValue(): List<Double?> = map {
+        it?.dataConnectRoundTripValue()
+      }
+
+      @JvmName("dataConnectRoundTripValue_NullableList_NullableDouble")
+      fun List<Double?>?.dataConnectRoundTripValue(): List<Double?>? =
+        this?.map { it?.dataConnectRoundTripValue() }
     }
   }
 


### PR DESCRIPTION
This PR enhances dataconnect's `QueryCachingIntegrationTest.kt` with normalized caching tests of a multi-value entity. This builds upon the tests added by #7854, #7859, and #7863.

### Highlights

* Added extensive tests for normalized caching of an entity with mixed fields, covering various scalars (`String`, `Float`, `Boolean`, `Any`) and lists.
* Updated the `CachingConnector` test utility with new functions to support the added tests.
* Improved the handling of `Double` round-trip values in `arbs.kt`.

### Changelog

<details>

* `caching_ops.gql`: Added new mutations and queries for `CachingMixed`.
* `caching_schema.gql`: Added schema for the new `CachingMixed` type.
* `QueryCachingIntegrationTest.kt`: Added new integration tests for caching of a multi-value entity (`normalizedMixed`).
* `CachingConnector.kt`: Updated with new functions to support the new GraphQL operations and added `shouldBe` extension functions for new queries.
* `arbs.kt`: Added `dataConnectRoundTripValue` extension functions for `Double` to support round-tripping tests.

</details>
