### PR TITLE
Fix performance issue in ObjectValue.equals for large documents

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+- [fixed] Fix a performance regression in `ObjectValue.equals()` that caused exponential execution
+  time for large or deeply nested documents.
+  [#7877](https://github.com/firebase/firebase-android-sdk/issues/7877)
+
 # 26.1.1
 
 - [feature] Added support for `regexFind` and `regexFindAll` Pipeline expressions.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/ObjectValue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/ObjectValue.java
@@ -304,7 +304,7 @@ public final class ObjectValue implements Cloneable {
     if (this == o) {
       return true;
     } else if (o instanceof ObjectValue) {
-      return buildProto().equals(((ObjectValue) o).buildProto());
+      return Values.equals(buildProto(), ((ObjectValue) o).buildProto());
     }
     return false;
   }


### PR DESCRIPTION
Revert to using Values.equals() instead of buildProto().equals() to avoid exponential execution time on large/deeply nested documents. Fixes #7877