### PR TITLE
[Infra] Ignore GHA generated credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ vertexai-sdk-test-data/
 *.tfstate
 *.tfstate.*
 firebase-appdistribution-gradle/service-credentials.json
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
Add `gha-creds-*.json` to `.gitignore` to prevent committing temporary credential files generated by the `google-github-actions/auth` action.

This is listed on the documentation as a [pre-requisite](https://github.com/google-github-actions/auth?tab=readme-ov-file#prerequisites) if artifacts are generated.

Internal b/492161931