### PR TITLE
chore(refdocs): fix broken ".Companion" links in generated refdocs

### DIFF
--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
@@ -73,7 +73,7 @@ abstract class FiresiteTransformTask : DefaultTask() {
   }
 
   private fun File.fixHTMLFile() {
-    val fixedContent = readText().fixBookPath().fixHyperlinksInSeeBlocks()
+    val fixedContent = readText().fixBookPath().fixHyperlinksInSeeBlocks().fixCompanionLinks()
     writeText(fixedContent)
   }
 
@@ -186,4 +186,17 @@ abstract class FiresiteTransformTask : DefaultTask() {
   // TODO(b/243674303): Remove when dackka exposes configuration for this
   private fun String.fixBookPath() =
     remove(Regex("(?<=setvar book_path ?%})(.+)(?=/_book.yaml\\{% ?endsetvar)"))
+
+  /**
+   * Removes ".Companion" from hyperlinks in the rendered HTML.
+   *
+   * Companion object members are flattened into the parent class page, but dackka still generates
+   * links that point to the non-existent Companion object page.
+   *
+   * Example input:
+   * `.../com/google/firebase/ai/type/ImagenEditMode.Companion.html#INPAINT_INSERTION()`
+   *
+   * Example output: `.../com/google/firebase/ai/type/ImagenEditMode.html#INPAINT_INSERTION()`
+   */
+  private fun String.fixCompanionLinks() = replace(".Companion.html", ".html")
 }


### PR DESCRIPTION
This should fix an issue where dackka-generated refdocs contains broken links to Kotlin companion object members (e.g., `ImagenEditMode.Companion.html#INPAINT_INSERTION()`).

Because companion members are flattened into the parent class page and the companion object's own page is not published, these links currently result in 404 errors.

More context in [b/441887676](http://b/441887676)

Manually tested by @rlazo and working as intended 😃 