### PR TITLE
[Infra] Fix `transport-runtime` test error

### DIFF
--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/TestService.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/TestService.java
@@ -18,7 +18,7 @@ import android.app.Service;
 import android.content.Intent;
 import android.os.IBinder;
 import android.util.Log;
-import com.google.android.datatransport.runtime.DaggerSynchronizationComponent;
+import com.google.android.datatransport.runtime.SynchronizationComponent;
 import java.util.concurrent.Executors;
 
 /** Base class fore the rpc test service. */
@@ -28,12 +28,12 @@ public abstract class TestService extends Service {
     Log.i("TransportService", "My Pid: " + android.os.Process.myPid());
     return new RemoteLockRpc(
         Executors.newCachedThreadPool(),
-        DaggerSynchronizationComponent.getGuard(getApplicationContext()));
+        SynchronizationComponent.getGuard(getApplicationContext()));
   }
 
   @Override
   public boolean onUnbind(Intent intent) {
-    DaggerSynchronizationComponent.shutdown();
+    SynchronizationComponent.shutdown();
     return false;
   }
 

--- a/transport/transport-runtime/transport-runtime.gradle
+++ b/transport/transport-runtime/transport-runtime.gradle
@@ -120,7 +120,7 @@ dependencies {
     annotationProcessor "com.google.auto.value:auto-value:1.6.5"
     annotationProcessor libs.dagger.compiler
 
-    androidTestAnnotationProcessor 'com.google.dagger:dagger-compiler:2.27'
+    androidTestAnnotationProcessor libs.dagger.compiler
 
     testImplementation libs.androidx.test.core
     testImplementation libs.androidx.test.junit


### PR DESCRIPTION
Updated `TestService` to directly use `SynchronizationComponent` methods (`getGuard`, `shutdown`) instead of
`DaggerSynchronizationComponent`. This simplifies the interaction with the synchronization component and potentially reduces boilerplate related to Dagger's generated classes in test contexts.

Standardized the `androidTestAnnotationProcessor` dependency in `transport-runtime.gradle` to use `libs.dagger.compiler`, aligning it with other Dagger dependency declarations.