### PR TITLE
Call back from the firebase transport runtime into the event-emitter …

### DIFF
--- a/transport/transport-api/CHANGELOG.md
+++ b/transport/transport-api/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [feature] Support callback when the pseudonymous id was updated
+
 # 4.1.0
 
 - [feature] Support multiple encrypted experiment IDs.

--- a/transport/transport-api/src/main/java/com/google/android/datatransport/EventContext.java
+++ b/transport/transport-api/src/main/java/com/google/android/datatransport/EventContext.java
@@ -36,6 +36,9 @@ public abstract class EventContext {
   @SuppressWarnings("mutable")
   public abstract List<byte[]> getExperimentIdsEncryptedList();
 
+  @Nullable
+  public abstract String getPseudonymousIdUpdateReceiverClassName();
+
   public static Builder builder() {
     return new AutoValue_EventContext.Builder();
   }
@@ -53,6 +56,9 @@ public abstract class EventContext {
 
     @NonNull
     public abstract Builder setExperimentIdsEncryptedList(List<byte[]> value);
+
+    @NonNull
+    public abstract Builder setPseudonymousIdUpdateReceiverClassName(String value);
 
     @NonNull
     public abstract EventContext build();

--- a/transport/transport-api/src/main/java/com/google/android/datatransport/PseudonymousIdUpdateReceiver.java
+++ b/transport/transport-api/src/main/java/com/google/android/datatransport/PseudonymousIdUpdateReceiver.java
@@ -1,0 +1,32 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.android.datatransport;
+
+import android.content.Context;
+import androidx.annotation.NonNull;
+
+/**
+ * This {@link PseudonymousIdUpdateReceiver} will be receiving pseudonymous id updates from the
+ * transport.
+ *
+ * <p>The constructor needs to take a single {@link Context} parameter.
+ *
+ * <p>Make sure that the constructor and the {@link #setUpdatedPseudonymousId} method are not
+ * removed by Proguard (add @Keep annotation if needed).
+ */
+public interface PseudonymousIdUpdateReceiver {
+  /** Sets the updated pseudonymous id. */
+  void setUpdatedPseudonymousId(@NonNull String updatedPseudonymousId);
+}

--- a/transport/transport-backend-cct/CHANGELOG.md
+++ b/transport/transport-backend-cct/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [feature] Support callback when the pseudonymous id was updated
+
 # 4.1.0
 
 - [feature] Support multiple encrypted experiment IDs.

--- a/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CctTransportBackend.java
+++ b/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CctTransportBackend.java
@@ -342,6 +342,27 @@ final class CctTransportBackend implements TransportBackend {
     return BatchedLogRequest.create(batchedRequests);
   }
 
+  private String getPseudonymousId(HttpURLConnection connection) {
+    String setCookieHeader = connection.getHeaderField("Set-Cookie");
+    if (setCookieHeader != null) {
+      String[] cookieHeaderParts = setCookieHeader.split(";");
+
+      for (String cookieHeaderPart : cookieHeaderParts) {
+        String[] cookieKeyValue = cookieHeaderPart.trim().split("=", 2);
+        if (cookieKeyValue.length != 2) {
+          continue;
+        }
+        String cookieKey = cookieKeyValue[0];
+        String cookieValue = cookieKeyValue[1];
+
+        if (cookieKey.equals("NID")) {
+          return cookieValue;
+        }
+      }
+    }
+    return null;
+  }
+
   private HttpResponse doSend(HttpRequest request) throws IOException {
     Logging.i(LOG_TAG, "Making request to: %s", request.url);
     HttpURLConnection connection = (HttpURLConnection) request.url.openConnection();
@@ -373,10 +394,10 @@ final class CctTransportBackend implements TransportBackend {
           request.requestBody, new BufferedWriter(new OutputStreamWriter(outputStream)));
     } catch (ConnectException | UnknownHostException e) {
       Logging.e(LOG_TAG, "Couldn't open connection, returning with 500", e);
-      return new HttpResponse(500, null, 0);
+      return new HttpResponse(500, null, 0, null);
     } catch (EncodingException | IOException e) {
       Logging.e(LOG_TAG, "Couldn't encode request, returning with 400", e);
-      return new HttpResponse(400, null, 0);
+      return new HttpResponse(400, null, 0, null);
     }
 
     int responseCode = connection.getResponseCode();
@@ -386,10 +407,10 @@ final class CctTransportBackend implements TransportBackend {
 
     if (responseCode == 302 || responseCode == 301 || responseCode == 307) {
       String redirect = connection.getHeaderField("Location");
-      return new HttpResponse(responseCode, new URL(redirect), 0);
+      return new HttpResponse(responseCode, new URL(redirect), 0, null);
     }
     if (responseCode != 200) {
-      return new HttpResponse(responseCode, null, 0);
+      return new HttpResponse(responseCode, null, 0, null);
     }
 
     try (InputStream connStream = connection.getInputStream();
@@ -398,7 +419,7 @@ final class CctTransportBackend implements TransportBackend {
       long nextRequestMillis =
           LogResponse.fromJson(new BufferedReader(new InputStreamReader(inputStream)))
               .getNextRequestWaitMillis();
-      return new HttpResponse(responseCode, null, nextRequestMillis);
+      return new HttpResponse(responseCode, null, nextRequestMillis, getPseudonymousId(connection));
     }
   }
 
@@ -469,7 +490,7 @@ final class CctTransportBackend implements TransportBackend {
               });
 
       if (response.code == 200) {
-        return BackendResponse.ok(response.nextRequestMillis);
+        return BackendResponse.ok(response.nextRequestMillis, response.updatedPseudonymousId);
       } else if (response.code >= 500 || response.code == 404) {
         return BackendResponse.transientError();
       } else if (response.code == 400) {
@@ -493,11 +514,17 @@ final class CctTransportBackend implements TransportBackend {
     final int code;
     @Nullable final URL redirectUrl;
     final long nextRequestMillis;
+    @Nullable final String updatedPseudonymousId;
 
-    HttpResponse(int code, @Nullable URL redirectUrl, long nextRequestMillis) {
+    HttpResponse(
+        int code,
+        @Nullable URL redirectUrl,
+        long nextRequestMillis,
+        @Nullable String updatedPseudonymousId) {
       this.code = code;
       this.redirectUrl = redirectUrl;
       this.nextRequestMillis = nextRequestMillis;
+      this.updatedPseudonymousId = updatedPseudonymousId;
     }
   }
 

--- a/transport/transport-backend-cct/src/test/java/com/google/android/datatransport/cct/CctTransportBackendTest.java
+++ b/transport/transport-backend-cct/src/test/java/com/google/android/datatransport/cct/CctTransportBackendTest.java
@@ -292,7 +292,7 @@ public class CctTransportBackendTest {
                         JSON_PAYLOAD_ESCAPED)))
             .withoutHeader("Cookie"));
 
-    assertEquals(BackendResponse.ok(3), response);
+    assertEquals(BackendResponse.ok(3, null), response);
   }
 
   @Test
@@ -391,7 +391,7 @@ public class CctTransportBackendTest {
                         JSON_PAYLOAD_ESCAPED)))
             .withoutHeader("Cookie"));
 
-    assertEquals(BackendResponse.ok(3), response);
+    assertEquals(BackendResponse.ok(3, null), response);
   }
 
   @Test
@@ -490,7 +490,7 @@ public class CctTransportBackendTest {
                         JSON_PAYLOAD_ESCAPED)))
             .withoutHeader("Cookie"));
 
-    assertEquals(BackendResponse.ok(3), response);
+    assertEquals(BackendResponse.ok(3, null), response);
   }
 
   @Test
@@ -536,7 +536,7 @@ public class CctTransportBackendTest {
                     String.format(
                         "$[?(@.logRequest[0].clientInfo.androidClientInfo.mccMnc == \"\")]"))));
 
-    assertEquals(BackendResponse.ok(3), response);
+    assertEquals(BackendResponse.ok(3, null), response);
   }
 
   @Test
@@ -570,7 +570,7 @@ public class CctTransportBackendTest {
                                 ApplicationProvider.getApplicationContext().getPackageName(),
                                 /* flags= */ 0)
                             .versionCode))));
-    assertEquals(BackendResponse.ok(3), response);
+    assertEquals(BackendResponse.ok(3, null), response);
   }
 
   @Test
@@ -806,7 +806,7 @@ public class CctTransportBackendTest {
         postRequestedFor(urlEqualTo("/api/hello"))
             .withHeader("Content-Type", equalTo("application/json")));
 
-    assertEquals(BackendResponse.ok(3), response);
+    assertEquals(BackendResponse.ok(3, null), response);
   }
 
   @Test
@@ -836,7 +836,7 @@ public class CctTransportBackendTest {
         postRequestedFor(urlEqualTo("/api/hello"))
             .withHeader("Content-Type", equalTo("application/json")));
 
-    assertEquals(BackendResponse.ok(3), response);
+    assertEquals(BackendResponse.ok(3, null), response);
   }
 
   @Test
@@ -895,7 +895,7 @@ public class CctTransportBackendTest {
             .withHeader("Content-Type", equalTo("application/json"))
             .withHeader("Content-Encoding", equalTo("gzip")));
 
-    assertEquals(BackendResponse.ok(3), response);
+    assertEquals(BackendResponse.ok(3, null), response);
   }
 
   @Test
@@ -952,7 +952,7 @@ public class CctTransportBackendTest {
                 matchingJsonPath(
                     String.format("$[?(@.logRequest[1].logSourceName == \"%s\")]", TEST_NAME))));
 
-    assertEquals(BackendResponse.ok(3), response);
+    assertEquals(BackendResponse.ok(3, null), response);
   }
 
   @Test
@@ -1006,7 +1006,7 @@ public class CctTransportBackendTest {
                     String.format("$[?(@.logRequest[1].logSourceName == \"%s\")]", TEST_NAME)))
             .withRequestBody(matchingJsonPath("$[?(@.logRequest[1].logEvent.size() == 1)]")));
 
-    assertEquals(BackendResponse.ok(3), response);
+    assertEquals(BackendResponse.ok(3, null), response);
   }
 
   @Test

--- a/transport/transport-runtime/CHANGELOG.md
+++ b/transport/transport-runtime/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [changed] Bumped internal dependencies.
+- [feature] Support callback when the pseudonymous id was updated
 
 # 4.1.0
 

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/EventInternal.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/EventInternal.java
@@ -58,6 +58,9 @@ public abstract class EventInternal {
   @Nullable
   public abstract List<byte[]> getExperimentIdsEncryptedList();
 
+  @Nullable
+  public abstract String getPseudonymousIdUpdateReceiverClassName();
+
   public final Map<String, String> getMetadata() {
     return Collections.unmodifiableMap(getAutoMetadata());
   }
@@ -91,6 +94,7 @@ public abstract class EventInternal {
         .setExperimentIdsClear(getExperimentIdsClear())
         .setExperimentIdsEncrypted(getExperimentIdsEncrypted())
         .setExperimentIdsEncryptedList(getExperimentIdsEncryptedList())
+        .setPseudonymousIdUpdateReceiverClassName(getPseudonymousIdUpdateReceiverClassName())
         .setEncodedPayload(getEncodedPayload())
         .setEventMillis(getEventMillis())
         .setUptimeMillis(getUptimeMillis())
@@ -124,6 +128,8 @@ public abstract class EventInternal {
     public abstract Builder setExperimentIdsEncrypted(byte[] value);
 
     public abstract Builder setExperimentIdsEncryptedList(List<byte[]> value);
+
+    public abstract Builder setPseudonymousIdUpdateReceiverClassName(String value);
 
     protected abstract Map<String, String> getAutoMetadata();
 

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportRuntime.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportRuntime.java
@@ -172,6 +172,10 @@ public class TransportRuntime implements TransportInternal {
       if (eventContext.getPseudonymousId() != null) {
         builder.setPseudonymousId(eventContext.getPseudonymousId());
       }
+      if (eventContext.getPseudonymousIdUpdateReceiverClassName() != null) {
+        builder.setPseudonymousIdUpdateReceiverClassName(
+            eventContext.getPseudonymousIdUpdateReceiverClassName());
+      }
       if (eventContext.getExperimentIdsClear() != null) {
         builder.setExperimentIdsClear(eventContext.getExperimentIdsClear());
       }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/BackendResponse.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/BackendResponse.java
@@ -14,6 +14,7 @@
 
 package com.google.android.datatransport.runtime.backends;
 
+import androidx.annotation.Nullable;
 import com.google.auto.value.AutoValue;
 
 /**
@@ -36,19 +37,24 @@ public abstract class BackendResponse {
   /** Time in millis to wait before attempting another request. */
   public abstract long getNextRequestWaitMillis();
 
+  /** Updated pseudonymous id from the backend or {@code null} if there is no update. */
+  @Nullable
+  public abstract String getUpdatedPseudonymousId();
+
   public static BackendResponse transientError() {
-    return new AutoValue_BackendResponse(Status.TRANSIENT_ERROR, -1);
+    return new AutoValue_BackendResponse(Status.TRANSIENT_ERROR, -1, null);
   }
 
   public static BackendResponse fatalError() {
-    return new AutoValue_BackendResponse(Status.FATAL_ERROR, -1);
+    return new AutoValue_BackendResponse(Status.FATAL_ERROR, -1, null);
   }
 
   public static BackendResponse invalidPayload() {
-    return new AutoValue_BackendResponse(Status.INVALID_PAYLOAD, -1);
+    return new AutoValue_BackendResponse(Status.INVALID_PAYLOAD, -1, null);
   }
 
-  public static BackendResponse ok(long nextRequestWaitMillis) {
-    return new AutoValue_BackendResponse(Status.OK, nextRequestWaitMillis);
+  public static BackendResponse ok(
+      long nextRequestWaitMillis, @Nullable String updatedPseudonymousId) {
+    return new AutoValue_BackendResponse(Status.OK, nextRequestWaitMillis, updatedPseudonymousId);
   }
 }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
@@ -21,6 +21,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.VisibleForTesting;
 import com.google.android.datatransport.Encoding;
+import com.google.android.datatransport.PseudonymousIdUpdateReceiver;
 import com.google.android.datatransport.runtime.EncodedPayload;
 import com.google.android.datatransport.runtime.EventInternal;
 import com.google.android.datatransport.runtime.TransportContext;
@@ -40,6 +41,7 @@ import com.google.android.datatransport.runtime.time.Clock;
 import com.google.android.datatransport.runtime.time.Monotonic;
 import com.google.android.datatransport.runtime.time.WallTime;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -121,7 +123,7 @@ public class Uploader {
     TransportBackend backend = backendRegistry.get(transportContext.getBackendName());
     long maxNextRequestWaitMillis = 0;
 
-    BackendResponse response = BackendResponse.ok(maxNextRequestWaitMillis);
+    BackendResponse response = BackendResponse.ok(maxNextRequestWaitMillis, null);
     while (guard.runCriticalSection(() -> eventStore.hasPendingEventsFor(transportContext))) {
       Iterable<PersistedEvent> persistedEvents =
           guard.runCriticalSection(() -> eventStore.loadBatch(transportContext));
@@ -142,12 +144,19 @@ public class Uploader {
 
         PersistedEvent oldestEvent = persistedEvents.iterator().next();
         String targetPseudonymousId = oldestEvent.getEvent().getPseudonymousId();
+        String targetPseudonymousIdUpdateReceiverClassName =
+            oldestEvent.getEvent().getPseudonymousIdUpdateReceiverClassName();
 
         for (PersistedEvent persistedEvent : persistedEvents) {
           EventInternal event = persistedEvent.getEvent();
           String pseudonymousId = event.getPseudonymousId();
+          String pseudonymousIdUpdateReceiverClassName =
+              event.getPseudonymousIdUpdateReceiverClassName();
 
-          if (Objects.equals(targetPseudonymousId, pseudonymousId)) {
+          if (Objects.equals(targetPseudonymousId, pseudonymousId)
+              && Objects.equals(
+                  targetPseudonymousIdUpdateReceiverClassName,
+                  pseudonymousIdUpdateReceiverClassName)) {
             eventInternals.add(event);
             sentEvents.add(persistedEvent);
           }
@@ -163,6 +172,31 @@ public class Uploader {
                     .setEvents(eventInternals)
                     .setExtras(transportContext.getExtras())
                     .build());
+        if (targetPseudonymousIdUpdateReceiverClassName != null
+            && response.getUpdatedPseudonymousId() != null) {
+          try {
+            Class<?> pseudonymousIdUpdateReceiverClass =
+                Class.forName(targetPseudonymousIdUpdateReceiverClassName);
+
+            if (PseudonymousIdUpdateReceiver.class.isAssignableFrom(
+                pseudonymousIdUpdateReceiverClass)) {
+              Constructor<?> constructor =
+                  pseudonymousIdUpdateReceiverClass.getConstructor(Context.class);
+              PseudonymousIdUpdateReceiver pseudonymousIdUpdateReceiver =
+                  (PseudonymousIdUpdateReceiver) constructor.newInstance(context);
+              if (pseudonymousIdUpdateReceiver != null) {
+                pseudonymousIdUpdateReceiver.setUpdatedPseudonymousId(
+                    response.getUpdatedPseudonymousId());
+              }
+            }
+          } catch (Exception e) {
+            Logging.e(
+                LOG_TAG,
+                "Could not update pseudonymous id via "
+                    + targetPseudonymousIdUpdateReceiverClassName,
+                e);
+          }
+        }
       }
       if (response.getStatus() == BackendResponse.Status.TRANSIENT_ERROR) {
         long finalMaxNextRequestWaitMillis1 = maxNextRequestWaitMillis;

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
@@ -144,6 +144,9 @@ public class SQLiteEventStore
               values.put(
                   "experiment_ids_encrypted_list_blob",
                   flattenListBlob(event.getExperimentIdsEncryptedList()));
+              values.put(
+                  "pseudonymous_id_update_receiver_class_name",
+                  event.getPseudonymousIdUpdateReceiverClassName());
               long newEventId = db.insert("events", null, values);
               if (!inline) {
                 int numChunks = (int) Math.ceil((double) payloadBytes.length / maxBlobSizePerRow);
@@ -461,7 +464,8 @@ public class SQLiteEventStore
               "pseudonymous_id",
               "experiment_ids_clear_blob",
               "experiment_ids_encrypted_blob",
-              "experiment_ids_encrypted_list_blob"
+              "experiment_ids_encrypted_list_blob",
+              "pseudonymous_id_update_receiver_class_name"
             },
             "context_id = ?",
             new String[] {contextId.toString()},
@@ -502,6 +506,9 @@ public class SQLiteEventStore
             }
             if (!cursor.isNull(12)) {
               event.setExperimentIdsEncryptedList(deFlattenBlob(cursor.getBlob(12)));
+            }
+            if (!cursor.isNull(13)) {
+              event.setPseudonymousIdUpdateReceiverClassName(cursor.getString(13));
             }
             events.add(PersistedEvent.create(id, transportContext, event.build()));
           }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
@@ -101,7 +101,7 @@ final class SchemaManager extends SQLiteOpenHelper {
   private static final String DROP_GLOBAL_LOG_EVENT_STATE_SQL =
       "DROP TABLE IF EXISTS global_log_event_state";
 
-  static int SCHEMA_VERSION = 8;
+  static int SCHEMA_VERSION = 9;
 
   private static final SchemaManager.Migration MIGRATE_TO_V1 =
       (db) -> {
@@ -153,6 +153,11 @@ final class SchemaManager extends SQLiteOpenHelper {
         db.execSQL("ALTER TABLE events ADD COLUMN experiment_ids_encrypted_list_blob BLOB");
       };
 
+  private static final SchemaManager.Migration MIGRATE_TO_V9 =
+      db -> {
+        db.execSQL("ALTER TABLE events ADD COLUMN pseudonymous_id_update_receiver_class_name TEXT");
+      };
+
   private static final List<Migration> INCREMENTAL_MIGRATIONS =
       Arrays.asList(
           MIGRATE_TO_V1,
@@ -162,7 +167,8 @@ final class SchemaManager extends SQLiteOpenHelper {
           MIGRATION_TO_V5,
           MIGRATE_TO_V6,
           MIGRATE_TO_V7,
-          MIGRATE_TO_V8);
+          MIGRATE_TO_V8,
+          MIGRATE_TO_V9);
 
   @Inject
   SchemaManager(

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/TransportRuntimeTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/TransportRuntimeTest.java
@@ -80,6 +80,8 @@ public class TransportRuntimeTest {
   private byte[] EXPERIMENT_IDS_CLEAR = "experiment ids clear".getBytes(Charset.defaultCharset());
   private byte[] EXPERIMENT_IDS_ENCRYPTED =
       "experiment ids encrypted".getBytes(Charset.defaultCharset());
+  private static final String PSEUDONYMOUS_ID_UPDATE_RECEIVER_CLASS_NAME =
+      "com.google.android.datatransport.runtime.TestPseudonymousIdUpdateReceiver";
 
   private static class StatefulTransportScheduleCallback implements TransportScheduleCallback {
     public boolean called = false;
@@ -113,6 +115,8 @@ public class TransportRuntimeTest {
                 .setExperimentIdsClear(EXPERIMENT_IDS_CLEAR)
                 .setExperimentIdsEncrypted(EXPERIMENT_IDS_ENCRYPTED)
                 .setExperimentIdsEncryptedList(List.of(EXPERIMENT_IDS_ENCRYPTED))
+                .setPseudonymousIdUpdateReceiverClassName(
+                    PSEUDONYMOUS_ID_UPDATE_RECEIVER_CLASS_NAME)
                 .build());
     Transformer<String, byte[]> transformer = String::getBytes;
     Transport<String> transport = factory.getTransport(testTransport, String.class, transformer);
@@ -164,6 +168,8 @@ public class TransportRuntimeTest {
                 .setExperimentIdsClear(EXPERIMENT_IDS_CLEAR)
                 .setExperimentIdsEncrypted(EXPERIMENT_IDS_ENCRYPTED)
                 .setExperimentIdsEncryptedList(List.of(EXPERIMENT_IDS_ENCRYPTED))
+                .setPseudonymousIdUpdateReceiverClassName(
+                    PSEUDONYMOUS_ID_UPDATE_RECEIVER_CLASS_NAME)
                 .build());
     EventInternal expectedEvent =
         EventInternal.builder()
@@ -179,6 +185,7 @@ public class TransportRuntimeTest {
             .setExperimentIdsClear(EXPERIMENT_IDS_CLEAR)
             .setExperimentIdsEncrypted(EXPERIMENT_IDS_ENCRYPTED)
             .setExperimentIdsEncryptedList(List.of(EXPERIMENT_IDS_ENCRYPTED))
+            .setPseudonymousIdUpdateReceiverClassName(PSEUDONYMOUS_ID_UPDATE_RECEIVER_CLASS_NAME)
             .build();
 
     StatefulTransportScheduleCallback callback = new StatefulTransportScheduleCallback();
@@ -225,6 +232,8 @@ public class TransportRuntimeTest {
                 .setExperimentIdsClear(EXPERIMENT_IDS_CLEAR)
                 .setExperimentIdsEncrypted(EXPERIMENT_IDS_ENCRYPTED)
                 .setExperimentIdsEncryptedList(List.of(EXPERIMENT_IDS_ENCRYPTED))
+                .setPseudonymousIdUpdateReceiverClassName(
+                    PSEUDONYMOUS_ID_UPDATE_RECEIVER_CLASS_NAME)
                 .build());
 
     StatefulTransportScheduleCallback callback = new StatefulTransportScheduleCallback();
@@ -270,6 +279,8 @@ public class TransportRuntimeTest {
                 .setExperimentIdsClear(EXPERIMENT_IDS_CLEAR)
                 .setExperimentIdsEncrypted(EXPERIMENT_IDS_ENCRYPTED)
                 .setExperimentIdsEncryptedList(List.of(EXPERIMENT_IDS_ENCRYPTED))
+                .setPseudonymousIdUpdateReceiverClassName(
+                    PSEUDONYMOUS_ID_UPDATE_RECEIVER_CLASS_NAME)
                 .build());
     EventInternal expectedEvent =
         EventInternal.builder()
@@ -285,6 +296,7 @@ public class TransportRuntimeTest {
             .setExperimentIdsClear(EXPERIMENT_IDS_CLEAR)
             .setExperimentIdsEncrypted(EXPERIMENT_IDS_ENCRYPTED)
             .setExperimentIdsEncryptedList(List.of(EXPERIMENT_IDS_ENCRYPTED))
+            .setPseudonymousIdUpdateReceiverClassName(PSEUDONYMOUS_ID_UPDATE_RECEIVER_CLASS_NAME)
             .build();
 
     StatefulTransportScheduleCallback callback = new StatefulTransportScheduleCallback();

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/backends/TestBackendFactory.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/backends/TestBackendFactory.java
@@ -32,7 +32,7 @@ public class TestBackendFactory implements BackendFactory {
 
     @Override
     public BackendResponse send(BackendRequest backendRequest) {
-      return BackendResponse.ok(0);
+      return BackendResponse.ok(0, null);
     }
   }
 }

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/UploaderTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/UploaderTest.java
@@ -24,8 +24,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.android.datatransport.Encoding;
+import com.google.android.datatransport.PseudonymousIdUpdateReceiver;
 import com.google.android.datatransport.runtime.EncodedPayload;
 import com.google.android.datatransport.runtime.EventInternal;
 import com.google.android.datatransport.runtime.TransportContext;
@@ -102,6 +104,9 @@ public class UploaderTest {
   private Runnable mockRunnable = mock(Runnable.class);
   private ClientHealthMetricsStore mockClientHealthMetricsStore =
       mock(ClientHealthMetricsStore.class);
+  // Needs to be static to be accessed by the static TestPseudonymousIdUpdateReceiver.
+  static String updatedPseudonymousId;
+
   private Uploader uploader =
       spy(
           new Uploader(
@@ -128,6 +133,15 @@ public class UploaderTest {
         .build();
   }
 
+  private static class TestPseudonymousIdUpdateReceiver implements PseudonymousIdUpdateReceiver {
+    public TestPseudonymousIdUpdateReceiver(Context context) {}
+
+    @Override
+    public void setUpdatedPseudonymousId(String updatedPseudonymousId) {
+      UploaderTest.updatedPseudonymousId = updatedPseudonymousId;
+    }
+  }
+
   @Before
   public void setUp() {
     when(mockRegistry.get(BACKEND_NAME)).thenReturn(mockBackend);
@@ -136,6 +150,7 @@ public class UploaderTest {
   @After
   public void cleanUp() {
     store.reset();
+    updatedPseudonymousId = null;
   }
 
   @Test
@@ -149,7 +164,7 @@ public class UploaderTest {
 
   @Test
   public void upload_yesNetwork() {
-    when(mockBackend.send(any())).thenReturn(BackendResponse.ok(1000));
+    when(mockBackend.send(any())).thenReturn(BackendResponse.ok(1000, null));
     when(uploader.isNetworkAvailable()).thenReturn(Boolean.TRUE);
     uploader.upload(TRANSPORT_CONTEXT, 1, mockRunnable);
     verify(uploader, times(1)).logAndUpdateState(TRANSPORT_CONTEXT, 1);
@@ -159,10 +174,25 @@ public class UploaderTest {
   @Test
   public void logAndUpdateStatus_okResponse() {
     store.persist(TRANSPORT_CONTEXT, EVENT);
-    when(mockBackend.send(any())).thenReturn(BackendResponse.ok(1000));
+    when(mockBackend.send(any())).thenReturn(BackendResponse.ok(1000, null));
     uploader.logAndUpdateState(TRANSPORT_CONTEXT, 1);
     verify(store, times(1)).recordSuccess(any());
     verify(store, times(1)).recordNextCallTime(TRANSPORT_CONTEXT, 1002);
+  }
+
+  @Test
+  public void logAndUpdateStatus_okResponse_withPseudonymousIdUpdate() {
+    store.persist(
+        TRANSPORT_CONTEXT,
+        EVENT.toBuilder()
+            .setPseudonymousIdUpdateReceiverClassName(
+                TestPseudonymousIdUpdateReceiver.class.getName())
+            .build());
+    when(mockBackend.send(any())).thenReturn(BackendResponse.ok(1000, "updatedId"));
+    uploader.logAndUpdateState(TRANSPORT_CONTEXT, 1);
+    verify(store, times(1)).recordSuccess(any());
+    verify(store, times(1)).recordNextCallTime(TRANSPORT_CONTEXT, 1002);
+    assertThat(updatedPseudonymousId).isEqualTo("updatedId");
   }
 
   @Test
@@ -209,7 +239,7 @@ public class UploaderTest {
 
   @Test
   public void logAndUpdateStatus_manyEvents_shouldUploadAll() {
-    when(mockBackend.send(any())).thenReturn(BackendResponse.ok(1000));
+    when(mockBackend.send(any())).thenReturn(BackendResponse.ok(1000, null));
     for (int i = 0; i < MANY_EVENT_COUNT; i++) {
       store.persist(TRANSPORT_CONTEXT, EVENT);
     }
@@ -223,7 +253,7 @@ public class UploaderTest {
   public void upload_toFlgServer_shouldIncludeClientHealthMetrics() {
     final ClientMetrics expectedClientMetrics = ClientMetrics.getDefaultInstance();
     when(mockRegistry.get(BACKEND_NAME)).thenReturn(mockBackend);
-    when(mockBackend.send(any())).thenReturn(BackendResponse.ok(1000));
+    when(mockBackend.send(any())).thenReturn(BackendResponse.ok(1000, null));
     when(mockBackend.decorate(any())).then(AdditionalAnswers.returnsFirstArg());
     when(mockClientHealthMetricsStore.loadClientMetrics()).thenReturn(expectedClientMetrics);
 
@@ -256,7 +286,7 @@ public class UploaderTest {
     EventInternal siblingEvent = makeEventWithPseudonymousId(targetId);
     EventInternal otherEvent = makeEventWithPseudonymousId(alternativeId);
 
-    when(mockBackend.send(any())).thenReturn(BackendResponse.ok(1000));
+    when(mockBackend.send(any())).thenReturn(BackendResponse.ok(1000, null));
 
     store.persist(TRANSPORT_CONTEXT, oldestEvent);
     store.persist(TRANSPORT_CONTEXT, EVENT);
@@ -286,7 +316,7 @@ public class UploaderTest {
     EventInternal oldestEvent = makeEventWithPseudonymousId(targetId);
     EventInternal otherEvent = makeEventWithPseudonymousId(alternativeId);
 
-    when(mockBackend.send(any())).thenReturn(BackendResponse.ok(1000));
+    when(mockBackend.send(any())).thenReturn(BackendResponse.ok(1000, null));
 
     store.persist(TRANSPORT_CONTEXT, oldestEvent);
     store.persist(TRANSPORT_CONTEXT, EVENT);
@@ -303,7 +333,7 @@ public class UploaderTest {
     EventInternal oldestEvent = makeEventWithPseudonymousId(targetId);
     EventInternal siblingEvent = makeEventWithPseudonymousId(targetId);
 
-    when(mockBackend.send(any())).thenReturn(BackendResponse.ok(1000));
+    when(mockBackend.send(any())).thenReturn(BackendResponse.ok(1000, null));
 
     store.persist(TRANSPORT_CONTEXT, EVENT);
     store.persist(TRANSPORT_CONTEXT, oldestEvent);
@@ -333,7 +363,7 @@ public class UploaderTest {
     EventInternal oldestEvent = makeEventWithPseudonymousId(targetId);
     EventInternal otherEvent = makeEventWithPseudonymousId(alternativeId);
 
-    when(mockBackend.send(any())).thenReturn(BackendResponse.ok(1000));
+    when(mockBackend.send(any())).thenReturn(BackendResponse.ok(1000, null));
 
     store.persist(TRANSPORT_CONTEXT, oldestEvent);
     store.persist(TRANSPORT_CONTEXT, EVENT);

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManagerMigrationTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManagerMigrationTest.java
@@ -42,6 +42,7 @@ public class SchemaManagerMigrationTest {
     simulatorMap.put(6, new StateSimulations.V6());
     simulatorMap.put(7, new StateSimulations.V7());
     simulatorMap.put(8, new StateSimulations.V8());
+    simulatorMap.put(9, new StateSimulations.V9());
   }
 
   @ParameterizedRobolectricTestRunner.Parameters(name = "lowVersion = {0}, highVersion = {1}")

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManagerTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManagerTest.java
@@ -123,9 +123,9 @@ public class SchemaManagerTest {
   }
 
   @Test
-  public void upgradingV4ToV8_nonEmptyDB_isLossless() {
+  public void upgradingV4ToV9_nonEmptyDB_isLossless() {
     int oldVersion = 4;
-    int newVersion = 8;
+    int newVersion = 9;
     SchemaManager schemaManager =
         new SchemaManager(ApplicationProvider.getApplicationContext(), DB_NAME, oldVersion);
     SQLiteEventStore store =

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/StateSimulations.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/StateSimulations.java
@@ -439,4 +439,69 @@ class StateSimulations {
       assertThat(stateId).isNotEqualTo(-1);
     }
   }
+
+  static class V9 implements StateSimulator {
+    @Override
+    public void simulate(SchemaManager schemaManager) {
+      SQLiteDatabase db = schemaManager.getWritableDatabase();
+      Random rd = new Random();
+      byte[] arr = new byte[7];
+      rd.nextBytes(arr);
+
+      ContentValues record = new ContentValues();
+      record.put("backend_name", "b1");
+      record.put("priority", PriorityMapping.toInt(Priority.DEFAULT));
+      record.put("next_request_ms", 0);
+      record.put("extras", arr);
+      long contextId = db.insert("transport_contexts", null, record);
+      assertThat(contextId).isNotEqualTo(-1);
+
+      ContentValues values = new ContentValues();
+      values.put("context_id", contextId);
+      values.put("transport_name", "42");
+      values.put("timestamp_ms", 1);
+      values.put("uptime_ms", 2);
+      values.put(
+          "payload",
+          new EncodedPayload(PROTOBUF_ENCODING, "Hello".getBytes(Charset.defaultCharset()))
+              .getBytes());
+      values.put("code", 1);
+      values.put("num_attempts", 0);
+      values.put("payload_encoding", "encoding");
+      values.put("inline", true);
+      values.put("product_id", 42);
+      values.put("pseudonymous_id", "pseudonymous id");
+      values.put(
+          "pseudonymous_id_update_receiver_class_name",
+          "com.google.android.data/transport.runtime.test.TestPseudonymousIdUpdateReceiver");
+      long newEventId = db.insert("events", null, values);
+      assertThat(newEventId).isNotEqualTo(-1);
+
+      ContentValues payloads = new ContentValues();
+      payloads.put("sequence_num", 1);
+      payloads.put("event_id", newEventId);
+      payloads.put("bytes", "event".getBytes());
+      long payloadId = db.insertOrThrow("event_payloads", null, payloads);
+      assertThat(payloadId).isNotEqualTo(-1);
+
+      ContentValues metadata = new ContentValues();
+      metadata.put("event_id", newEventId);
+      metadata.put("name", "key1");
+      metadata.put("value", "value1");
+      long metadataId = db.insert("event_metadata", null, metadata);
+      assertThat(metadataId).isNotEqualTo(-1);
+
+      ContentValues metrics = new ContentValues();
+      metrics.put("log_source", "source5");
+      metrics.put("reason", LogEventDropped.Reason.CACHE_FULL.getNumber());
+      metrics.put("events_dropped_count", 20);
+      long recordId = db.insert("log_event_dropped", null, metrics);
+      assertThat(recordId).isNotEqualTo(-1);
+
+      ContentValues globalState = new ContentValues();
+      globalState.put("last_metrics_upload_ms", 1711);
+      long stateId = db.insert("global_log_event_state", null, globalState);
+      assertThat(stateId).isNotEqualTo(-1);
+    }
+  }
 }

--- a/transport/transport-runtime/transport-runtime.gradle
+++ b/transport/transport-runtime/transport-runtime.gradle
@@ -109,6 +109,7 @@ dependencies {
     api "com.google.android.datatransport:transport-api:4.1.0"
     api 'com.google.firebase:firebase-encoders:17.0.0'
     api "com.google.firebase:firebase-encoders-proto:16.0.0"
+    api project(':transport:transport-api')
 
     implementation 'androidx.annotation:annotation:1.3.0'
     implementation libs.javax.inject


### PR DESCRIPTION
Call back from the firebase transport runtime into the event-emitter if there is an updated pseudonymous ID

This then allows the emitter to store the ID and attach it to future events.

Note: Ideally we would not even attach the ID to the event and rather resolve it directly before the http-call. Not sure why this was not done. But this is not really a big issue as long as the ids are very long living. Then we will we only end up with a small amount of events with stale IDs

I thought about how to best implement the callback.

- We can unfortunately not just use a regular Consumer class as the callback has to be persistable.
- Since the firebase transport runtime does not use Hilt's app-wide shared components I don't think we can inject the callback using dagger
- We could use Android functionality like e.g. a BroadcastReceiver, but this is pretty heavy handed

Internal b/490114654