### PR TITLE
dataconnect(chore): dataconnect_set_cli.toml gemini command added

### DIFF
--- a/firebase-dataconnect/.gemini/commands/dataconnect_set_cli.toml
+++ b/firebase-dataconnect/.gemini/commands/dataconnect_set_cli.toml
@@ -1,0 +1,17 @@
+description = "Sets the local path to the Data Connect emulator binary to use in gradle builds by setting the dataConnectExecutable.file property in dataconnect.local.properties"
+
+prompt = """
+Set the `dataConnectExecutable.file` property in `dataconnect.local.properties` to the value provided in the arguments: {{args}}
+
+First check if `dataconnect.local.properties` exists in the current directory.
+If `dataconnect.local.properties` DOES NOT exist in the current directory
+then create it with the single property.
+
+On the other hand, if it DOES exist, then follow these steps:
+1. Read the file content.
+2. If `dataConnectExecutable.file` is already present, update its value.
+3. If it is not present, append it to the end of the file.
+4. If `dataConnectExecutable.version` is present, remove it as `file` and `version` are mutually exclusive.
+
+Ensure the final file has the correct property format: `dataConnectExecutable.file=<value>`.
+"""


### PR DESCRIPTION
This PR adds a new Gemini command, `dataconnect_set_cli`, to the `firebase-dataconnect` module. This command automates the configuration of the local Data Connect emulator binary by updating the `dataconnect.local.properties` file.

To use this command, start gemini-cli in the `firebase-dataconnect` folder and enter the following prompt:

```
/dataconnect_set_cli /path/to/cli
```

where `/path/to/cli` is the path (preferably absolute) to the emulator binary to use, which can be compiled by Google employees, for example, by running

```
blaze build --config=darwin_arm64 //third_party/firebase/dataconnect/emulator/cli:cli_macos
```

### Highlights

* **Gemini Command Addition**: Introduced the `dataconnect_set_cli` command to simplify the configuration of the Data Connect emulator binary path.
* **Properties Management**: The command handles the creation or updating of the `dataconnect.local.properties` file, ensuring the `dataConnectExecutable.file` property is correctly set and any conflicting `dataConnectExecutable.version` properties are removed.

<details>

<summary><b>Changelog</b></summary>

* **dataconnect_set_cli.toml**
  * Added a new Gemini command configuration file to manage the local path of the Data Connect emulator binary via `dataconnect.local.properties`.
</details>