### PR TITLE
[Infra] Update minSdkVersion reference to 23 in AndroidManifests

### DIFF
--- a/ai-logic/firebase-ai/src/main/AndroidManifest.xml
+++ b/ai-logic/firebase-ai/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-  <!--<uses-sdk android:minSdkVersion="21"/>-->
+  <!--<uses-sdk android:minSdkVersion="23"/>-->
 
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.INTERNET" />

--- a/appcheck/firebase-appcheck-debug-testing/src/main/AndroidManifest.xml
+++ b/appcheck/firebase-appcheck-debug-testing/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-  <!--<uses-sdk android:minSdkVersion="21"/>-->
+  <!--<uses-sdk android:minSdkVersion="23"/>-->
   <application>
     <service android:name="com.google.firebase.components.ComponentDiscoveryService"
         android:exported="false">

--- a/appcheck/firebase-appcheck-debug/src/main/AndroidManifest.xml
+++ b/appcheck/firebase-appcheck-debug/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
 
 <manifest  xmlns:android="http://schemas.android.com/apk/res/android">
   <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-  <!--<uses-sdk android:minSdkVersion="21"/>-->
+  <!--<uses-sdk android:minSdkVersion="23"/>-->
   <application>
     <service android:name="com.google.firebase.components.ComponentDiscoveryService"
         android:exported="false">

--- a/appcheck/firebase-appcheck-interop/src/main/AndroidManifest.xml
+++ b/appcheck/firebase-appcheck-interop/src/main/AndroidManifest.xml
@@ -15,6 +15,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="21"/>-->
+    <!--<uses-sdk android:minSdkVersion="23"/>-->
     <application />
 </manifest>

--- a/appcheck/firebase-appcheck-playintegrity/src/main/AndroidManifest.xml
+++ b/appcheck/firebase-appcheck-playintegrity/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-  <!--<uses-sdk android:minSdkVersion="21"/>-->
+  <!--<uses-sdk android:minSdkVersion="23"/>-->
   <application>
     <service android:name="com.google.firebase.components.ComponentDiscoveryService"
         android:exported="false">

--- a/appcheck/firebase-appcheck/src/main/AndroidManifest.xml
+++ b/appcheck/firebase-appcheck/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
 <!-- limitations under the License. -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="21"/>-->
+    <!--<uses-sdk android:minSdkVersion="23"/>-->
     <application>
         <service android:name="com.google.firebase.components.ComponentDiscoveryService"
             android:exported="false"> <meta-data android:name="com.google.firebase.components:com.google.firebase.appcheck.FirebaseAppCheckKtxRegistrar" android:value="com.google.firebase.components.ComponentRegistrar"/>

--- a/encoders/firebase-encoders-json/src/main/AndroidManifest.xml
+++ b/encoders/firebase-encoders-json/src/main/AndroidManifest.xml
@@ -15,5 +15,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="21"/>-->
+    <!--<uses-sdk android:minSdkVersion="23"/>-->
 </manifest>

--- a/encoders/firebase-encoders-reflective/src/main/AndroidManifest.xml
+++ b/encoders/firebase-encoders-reflective/src/main/AndroidManifest.xml
@@ -15,5 +15,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="21"/>-->
+    <!--<uses-sdk android:minSdkVersion="23"/>-->
 </manifest>

--- a/firebase-abt/src/main/AndroidManifest.xml
+++ b/firebase-abt/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-  <!--<uses-sdk android:minSdkVersion="21"/>-->
+  <!--<uses-sdk android:minSdkVersion="23"/>-->
   <application>
     <service android:name="com.google.firebase.components.ComponentDiscoveryService">
       <meta-data

--- a/firebase-common/src/androidTest/AndroidManifest.xml
+++ b/firebase-common/src/androidTest/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-sdk android:minSdkVersion="21" tools:overrideLibrary="com.google.firebase.auth"/>
+    <uses-sdk android:minSdkVersion="23" tools:overrideLibrary="com.google.firebase.auth"/>
     <application>
         <service android:name="com.google.firebase.components.ComponentDiscoveryService"
             android:exported="false">

--- a/firebase-common/src/main/AndroidManifest.xml
+++ b/firebase-common/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="21"/>-->
+    <!--<uses-sdk android:minSdkVersion="23"/>-->
     <application>
 
         <provider

--- a/firebase-components/firebase-dynamic-module-support/src/main/AndroidManifest.xml
+++ b/firebase-components/firebase-dynamic-module-support/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="21"/>-->
+    <!--<uses-sdk android:minSdkVersion="23"/>-->
 
   <application>
     <service

--- a/firebase-components/src/main/AndroidManifest.xml
+++ b/firebase-components/src/main/AndroidManifest.xml
@@ -15,5 +15,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="21"/>-->
+    <!--<uses-sdk android:minSdkVersion="23"/>-->
 </manifest>

--- a/firebase-config/bandwagoner/src/androidTest/AndroidManifest.xml
+++ b/firebase-config/bandwagoner/src/androidTest/AndroidManifest.xml
@@ -21,7 +21,7 @@
     android:versionName="1.0" >
 
   <uses-sdk
-      android:minSdkVersion="21"
+      android:minSdkVersion="23"
       android:targetSdkVersion="33" />
 
   <application>

--- a/firebase-config/src/main/AndroidManifest.xml
+++ b/firebase-config/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <!--<uses-sdk android:minSdkVersion="21" />-->
+    <!--<uses-sdk android:minSdkVersion="23" />-->
 
     <application>
         <service

--- a/firebase-config/src/test/AndroidManifest.xml
+++ b/firebase-config/src/test/AndroidManifest.xml
@@ -21,7 +21,7 @@
     android:versionName="1">
 
 
-  <!--<uses-sdk android:minSdkVersion="21"/>-->
+  <!--<uses-sdk android:minSdkVersion="23"/>-->
 
   <application android:label="FirebaseCommonTests" >
     <uses-library android:name="android.test.runner" />

--- a/firebase-crashlytics/src/main/AndroidManifest.xml
+++ b/firebase-crashlytics/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="21"/>-->
+    <!--<uses-sdk android:minSdkVersion="23"/>-->
 
     <application>
         <service android:name="com.google.firebase.components.ComponentDiscoveryService" android:exported="false"> <meta-data android:name="com.google.firebase.components:com.google.firebase.crashlytics.FirebaseCrashlyticsKtxRegistrar" android:value="com.google.firebase.components.ComponentRegistrar"/>

--- a/firebase-database-collection/src/main/AndroidManifest.xml
+++ b/firebase-database-collection/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for bazel builds-->
-    <!--<uses-sdk android:minSdkVersion="21" />-->
+    <!--<uses-sdk android:minSdkVersion="23" />-->
 </manifest>

--- a/firebase-database/src/androidTest/AndroidManifest.xml
+++ b/firebase-database/src/androidTest/AndroidManifest.xml
@@ -15,7 +15,7 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools">
-    <!--<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="33"/>-->
+    <!--<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="33"/>-->
     <uses-permission android:name="android.permission.INTERNET"/>
     <application android:label="FirebaseDatabaseTests" android:largeHeap="true">
         <uses-library android:name="android.test.runner"/>

--- a/firebase-database/src/main/AndroidManifest.xml
+++ b/firebase-database/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="21"/>-->
+    <!--<uses-sdk android:minSdkVersion="23"/>-->
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/firebase-dataconnect/src/androidTest/AndroidManifest.xml
+++ b/firebase-dataconnect/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-  <!--<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="23" />-->
+  <!--<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="23" />-->
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.INTERNET"/>
   <application

--- a/firebase-dataconnect/src/main/AndroidManifest.xml
+++ b/firebase-dataconnect/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="14" />-->
+    <!--<uses-sdk android:minSdkVersion="23" />-->
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/firebase-dataconnect/src/test/AndroidManifest.xml
+++ b/firebase-dataconnect/src/test/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="14"/>-->
+    <!--<uses-sdk android:minSdkVersion="23"/>-->
     <application
         android:label="FirebaseDataConnectTests" >
         <uses-library android:name="android.test.runner" />

--- a/firebase-datatransport/src/main/AndroidManifest.xml
+++ b/firebase-datatransport/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android">
   <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-  <!--<uses-sdk android:minSdkVersion="21"/>-->
+  <!--<uses-sdk android:minSdkVersion="23"/>-->
   <application>
     <service android:name="com.google.firebase.components.ComponentDiscoveryService" android:exported="false">
       <meta-data android:name="com.google.firebase.components:com.google.firebase.datatransport.TransportRegistrar"

--- a/firebase-firestore/src/androidTest/AndroidManifest.xml
+++ b/firebase-firestore/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-  <!--<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="33" />-->
+  <!--<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="33" />-->
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.INTERNET"/>
   <application>

--- a/firebase-firestore/src/main/AndroidManifest.xml
+++ b/firebase-firestore/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="21" />-->
+    <!--<uses-sdk android:minSdkVersion="23" />-->
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/firebase-firestore/src/test/AndroidManifest.xml
+++ b/firebase-firestore/src/test/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="21"/>-->
+    <!--<uses-sdk android:minSdkVersion="23"/>-->
     <application
         android:label="FirebaseCommonTests" >
         <uses-library android:name="android.test.runner" />

--- a/firebase-functions/src/androidTest/AndroidManifest.xml
+++ b/firebase-functions/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-  <!--<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="33" />-->
+  <!--<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="33" />-->
   <uses-permission android:name="android.permission.INTERNET"/>
   <application
       android:usesCleartextTraffic="true">

--- a/firebase-functions/src/main/AndroidManifest.xml
+++ b/firebase-functions/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="21" />-->
+    <!--<uses-sdk android:minSdkVersion="23" />-->
     <uses-permission android:name="android.permission.INTERNET" />
     <application>
         <service android:name="com.google.firebase.components.ComponentDiscoveryService" android:exported="false"> <meta-data android:name="com.google.firebase.components:com.google.firebase.functions.FirebaseFunctionsKtxRegistrar" android:value="com.google.firebase.components.ComponentRegistrar"/>

--- a/firebase-inappmessaging/src/androidTest/AndroidManifest.xml
+++ b/firebase-inappmessaging/src/androidTest/AndroidManifest.xml
@@ -2,7 +2,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
   <uses-sdk
-      android:minSdkVersion="21"
+      android:minSdkVersion="23"
       android:targetSdkVersion="34"/>
   <uses-permission android:name="android.permission.INTERNET"/>
   <application>

--- a/firebase-inappmessaging/src/test/AndroidManifest.xml
+++ b/firebase-inappmessaging/src/test/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-sdk android:minSdkVersion="21"/>
+    <uses-sdk android:minSdkVersion="23"/>
     <application
         android:label="FirebaseCommonTests" >
         <uses-library android:name="android.test.runner" />

--- a/firebase-installations-interop/src/main/AndroidManifest.xml
+++ b/firebase-installations-interop/src/main/AndroidManifest.xml
@@ -14,5 +14,5 @@
 <!-- limitations under the License. -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" >
-    <!--<uses-sdk android:minSdkVersion="21"/>-->
+    <!--<uses-sdk android:minSdkVersion="23"/>-->
 </manifest>

--- a/firebase-installations/src/main/AndroidManifest.xml
+++ b/firebase-installations/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="21"/>-->
+    <!--<uses-sdk android:minSdkVersion="23"/>-->
     <application>
         <service
             android:name="com.google.firebase.components.ComponentDiscoveryService"

--- a/firebase-messaging-directboot/src/main/AndroidManifest.xml
+++ b/firebase-messaging-directboot/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="21"/>-->
+    <!--<uses-sdk android:minSdkVersion="23"/>-->
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/firebase-sessions/src/main/AndroidManifest.xml
+++ b/firebase-sessions/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-  <!--<uses-sdk android:minSdkVersion="21"/>-->
+  <!--<uses-sdk android:minSdkVersion="23"/>-->
 
   <application>
     <service

--- a/firebase-storage/src/androidTest/AndroidManifest.xml
+++ b/firebase-storage/src/androidTest/AndroidManifest.xml
@@ -14,7 +14,7 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-  <!--<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="33" />-->
+  <!--<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="33" />-->
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>

--- a/firebase-storage/src/main/AndroidManifest.xml
+++ b/firebase-storage/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="21"/>-->
+    <!--<uses-sdk android:minSdkVersion="23"/>-->
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/firebase-storage/src/test/AndroidManifest.xml
+++ b/firebase-storage/src/test/AndroidManifest.xml
@@ -16,7 +16,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!--Although the *SdkVersion is captured in gradle build files, this is required for bazel builds-->
-    <!--<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="33"/>-->
+    <!--<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="33"/>-->
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/integ-testing/src/main/AndroidManifest.xml
+++ b/integ-testing/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools">
   <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-  <!--<uses-sdk android:minSdkVersion="21"/>-->
+  <!--<uses-sdk android:minSdkVersion="23"/>-->
 </manifest>

--- a/transport/transport-api/src/main/AndroidManifest.xml
+++ b/transport/transport-api/src/main/AndroidManifest.xml
@@ -15,5 +15,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.google.android.datatransport">
   <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-  <!--<uses-sdk android:minSdkVersion="21"/>-->
+  <!--<uses-sdk android:minSdkVersion="23"/>-->
 </manifest>

--- a/transport/transport-backend-cct/src/main/AndroidManifest.xml
+++ b/transport/transport-backend-cct/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.google.android.datatransport.backend.cct">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="21"/>-->
+    <!--<uses-sdk android:minSdkVersion="23"/>-->
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/transport/transport-runtime-testing/src/main/AndroidManifest.xml
+++ b/transport/transport-runtime-testing/src/main/AndroidManifest.xml
@@ -15,5 +15,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.google.android.datatransport.runtime.testing">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="21"/>-->
+    <!--<uses-sdk android:minSdkVersion="23"/>-->
 </manifest>

--- a/transport/transport-runtime/src/androidTest/AndroidManifest.xml
+++ b/transport/transport-runtime/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="21"/>-->
+    <!--<uses-sdk android:minSdkVersion="23"/>-->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application>
         <service

--- a/transport/transport-runtime/src/main/AndroidManifest.xml
+++ b/transport/transport-runtime/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="21"/>-->
+    <!--<uses-sdk android:minSdkVersion="23"/>-->
 
     <application>
         <service

--- a/transport/transport-runtime/src/test/AndroidManifest.xml
+++ b/transport/transport-runtime/src/test/AndroidManifest.xml
@@ -14,7 +14,7 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <!--<uses-sdk android:minSdkVersion="21"/>-->
+    <!--<uses-sdk android:minSdkVersion="23"/>-->
 
     <application>
         <service


### PR DESCRIPTION
Updated the commented-out `minSdkVersion` reference from 21 to 23 in `AndroidManifest.xml` files across various Firebase modules. This change reflects the actual minimum API level support.

b/493629449

NO_RELEASE_CHANGE