### PR TITLE
dataconnect(test): be more lax in the ChiSquareTest significance result assertion to reduce false positives in unit tests

### DIFF
--- a/firebase-dataconnect/testutil/src/test/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/AbstractWithEvenNumDigitsDistributionUnitTest.kt
+++ b/firebase-dataconnect/testutil/src/test/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/AbstractWithEvenNumDigitsDistributionUnitTest.kt
@@ -119,7 +119,7 @@ abstract class AbstractWithEvenNumDigitsDistributionUnitTest<T : Comparable<T>, 
       val expectedCounts = DoubleArray(observedCounts.size) { expectedObservedCount }
       val significanceResult = ChiSquareTest.withDefaults().test(expectedCounts, observedCounts)
       withClue(significanceResult.print().value) {
-        significanceResult.reject(0.0001).shouldBeFalse()
+        significanceResult.reject(0.00001).shouldBeFalse()
       }
     }
   }
@@ -147,7 +147,7 @@ abstract class AbstractWithEvenNumDigitsDistributionUnitTest<T : Comparable<T>, 
       val expectedCounts = DoubleArray(observedCounts.size) { expectedObservedCount }
       val significanceResult = ChiSquareTest.withDefaults().test(expectedCounts, observedCounts)
       withClue(significanceResult.print().value) {
-        significanceResult.reject(0.0001).shouldBeFalse()
+        significanceResult.reject(0.00001).shouldBeFalse()
       }
     }
   }
@@ -180,7 +180,7 @@ abstract class AbstractWithEvenNumDigitsDistributionUnitTest<T : Comparable<T>, 
         withClue(
           "expectedObservedCount=$expectedObservedCount, ${significanceResult.print().value}"
         ) {
-          significanceResult.reject(0.0001).shouldBeFalse()
+          significanceResult.reject(0.00001).shouldBeFalse()
         }
       }
     }


### PR DESCRIPTION
This PR updates the `ChiSquareTest` significance result assertions in the `firebase-dataconnect` unit tests to be more lax. By changing the rejection threshold from `0.0001` to `0.00001`, this change aims to reduce the number of false positives encountered during test execution.

The flaky test failure that motivated this PR was https://github.com/firebase/firebase-android-sdk/actions/runs/23309337787/job/67792345315?pr=7936 which had the following counts:

<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/ab3ecffd-db94-43d9-b85b-00e1f74d788f" />

```
AssertionFailedError: observations.size=19, observations=[(1, 5146L), (2, 5306L), (3, 5329L), (4, 5216L), (5, 5109L), (6, 5324L), (7, 5113L), (8, 5414L), (9, 5426L), (10, 5299L), (11, 5256L), (12, 5269L), (13, 5319L), (14, 5273L), (15, 5130L), (16, 5305L), (17, 5250L), (18, 5497L), (19, 5019L)]
expectedObservedCount=5263.1578947368425, SignificanceResult(statistic=49.3887, pValue=0.00009333452)
```

From looking at the chart, the counts definitely have a reasonable standard deviation. Therefore, lowering the rejection threshold makes sense so that a distribution like this in the future does _not_ result in a test failure.

### Highlights

* **Test Stability**: Reduced the strictness of the `ChiSquareTest` significance assertions to decrease the frequency of false positives in property-based unit tests.

<details>

<summary><b>Changelog</b></summary>

* **AbstractWithEvenNumDigitsDistributionUnitTest.kt**
  * Updated the rejection threshold for `ChiSquareTest.withDefaults().test()` from `0.0001` to `0.00001`.
</details>