### PR TITLE
dataconnect(chore): Fix CHANGELOG.md misplaced entries caused by mergeback of M178

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+- [changed] Ensure exceptions are not silently ignored when closing
+  `FirebaseDataConnect` instances.
+  ([#7909](https://github.com/firebase/firebase-android-sdk/pull/7909))
+- [changed] Internal change to use `SecureRandom` when generating operation IDs.
+  ([#7910](https://github.com/firebase/firebase-android-sdk/pull/7910))
+
 # 17.2.0
 
 - [changed] Added offline caching APIs
@@ -11,11 +17,6 @@
   [#7887](https://github.com/firebase/firebase-android-sdk/pull/7887))
 - [fixed] Fix UnsupportedOperationException when serializing lists of *nullable* AnyValue.
   ([#7864](https://github.com/firebase/firebase-android-sdk/pull/7864))
-- [changed] Ensure exceptions are not silently ignored when closing
-  `FirebaseDataConnect` instances.
-  ([#7909](https://github.com/firebase/firebase-android-sdk/pull/7909))
-- [changed] Internal change to use `SecureRandom` when generating operation IDs.
-  ([#7910](https://github.com/firebase/firebase-android-sdk/pull/7910))
 
 # 17.1.4
 


### PR DESCRIPTION
Fix dataconnect changelog entries that were incorrectly placed under the "17.2.0" heading by the M178 mergeback PR #7947 (commit b20ffc2e93) when they should have remained under the "Unreleased" heading.