### PR TITLE
dataconnect(change): Internal refactor to use immutable byte arrays when calculating SHA512 hashes

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+- [changed] Ensure exceptions are not silently ignored when closing
+  `FirebaseDataConnect` instances.
+  ([#7909](https://github.com/firebase/firebase-android-sdk/pull/7909))
+- [changed] Internal change to use `SecureRandom` when generating operation IDs.
+  ([#7910](https://github.com/firebase/firebase-android-sdk/pull/7910))
+
 # 17.2.0
 
 - [changed] Added offline caching APIs
@@ -11,11 +17,6 @@
   [#7887](https://github.com/firebase/firebase-android-sdk/pull/7887))
 - [fixed] Fix UnsupportedOperationException when serializing lists of *nullable* AnyValue.
   ([#7864](https://github.com/firebase/firebase-android-sdk/pull/7864))
-- [changed] Ensure exceptions are not silently ignored when closing
-  `FirebaseDataConnect` instances.
-  ([#7909](https://github.com/firebase/firebase-android-sdk/pull/7909))
-- [changed] Internal change to use `SecureRandom` when generating operation IDs.
-  ([#7910](https://github.com/firebase/firebase-android-sdk/pull/7910))
 
 # 17.1.4
 

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -5,6 +5,8 @@
   ([#7909](https://github.com/firebase/firebase-android-sdk/pull/7909))
 - [changed] Internal change to use `SecureRandom` when generating operation IDs.
   ([#7910](https://github.com/firebase/firebase-android-sdk/pull/7910))
+- [changed] Internal refactor to use immutable byte arrays.
+  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
 
 # 17.2.0
 

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -6,7 +6,7 @@
 - [changed] Internal change to use `SecureRandom` when generating operation IDs.
   ([#7910](https://github.com/firebase/firebase-android-sdk/pull/7910))
 - [changed] Internal refactor to use immutable byte arrays.
-  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
+  ([#7957](https://github.com/firebase/firebase-android-sdk/pull/7957))
 
 # 17.2.0
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -242,7 +242,7 @@ internal class DataConnectGrpcRPCs(
       QueryCacheInfo(
         cacheDb,
         authUid = authToken?.authUid,
-        queryId = request.toQueryId(),
+        queryId = request.calculateQueryId(),
         maxAge = maxAge,
       )
     }
@@ -545,10 +545,8 @@ internal class DataConnectGrpcRPCs(
   }
 }
 
-private fun ExecuteQueryRequest.toQueryId(): ImmutableByteArray {
-  val queryId = variables.calculateSha512(preamble = operationName)
-  return ImmutableByteArray.adopt(queryId)
-}
+private fun ExecuteQueryRequest.calculateQueryId(): ImmutableByteArray =
+  variables.calculateSha512(preamble = operationName)
 
 @JvmName("getEntityIdForPathFunction_ExecuteQueryResponse")
 private fun ExecuteQueryResponse.getEntityIdForPathFunction(): GetEntityIdForPathFunction? =

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/querymgr/LiveQueries.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/querymgr/LiveQueries.kt
@@ -20,7 +20,7 @@ import com.google.firebase.dataconnect.*
 import com.google.firebase.dataconnect.core.Logger
 import com.google.firebase.dataconnect.core.LoggerGlobals.Logger
 import com.google.firebase.dataconnect.core.LoggerGlobals.debug
-import com.google.firebase.dataconnect.util.AlphanumericStringUtil.toAlphaNumericString
+import com.google.firebase.dataconnect.util.ImmutableByteArray
 import com.google.firebase.dataconnect.util.ProtoUtil.calculateSha512
 import com.google.firebase.dataconnect.util.ProtoUtil.encodeToStruct
 import com.google.firebase.dataconnect.util.ProtoUtil.toStructProto
@@ -75,10 +75,10 @@ internal class LiveQueries(
         }
       }
 
-    val variablesHash =
-      withContext(blockingDispatcher) { variablesStruct.calculateSha512().toAlphaNumericString() }
+    val variablesHash: ImmutableByteArray =
+      withContext(blockingDispatcher) { variablesStruct.calculateSha512() }
 
-    val key = LiveQuery.Key(operationName = query.operationName, variablesHash = variablesHash)
+    val key = LiveQuery.Key(query.operationName, variablesHash)
 
     val referenceCountedLiveQuery =
       referenceCountedLiveQueryByKey.getOrPut(key) {

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/querymgr/LiveQuery.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/querymgr/LiveQuery.kt
@@ -23,6 +23,7 @@ import com.google.firebase.dataconnect.core.DataConnectGrpcClient.OperationResul
 import com.google.firebase.dataconnect.core.Logger
 import com.google.firebase.dataconnect.core.LoggerGlobals.Logger
 import com.google.firebase.dataconnect.core.LoggerGlobals.debug
+import com.google.firebase.dataconnect.util.ImmutableByteArray
 import com.google.firebase.dataconnect.util.NullableReference
 import com.google.firebase.dataconnect.util.SequencedReference
 import com.google.firebase.dataconnect.util.SequencedReference.Companion.map
@@ -254,7 +255,7 @@ internal class LiveQuery(
           }
       }
 
-  data class Key(val operationName: String, val variablesHash: String)
+  data class Key(val operationName: String, val variablesHash: ImmutableByteArray)
 
   override fun close() {
     logger.debug("close() called")

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/AlphanumericStringUtil.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/AlphanumericStringUtil.kt
@@ -31,7 +31,7 @@ internal object AlphanumericStringUtil {
   private const val ALPHANUMERIC_ALPHABET = "23456789abcdefghjkmnopqrstuvwxyz"
 
   /**
-   * Converts this byte array to a base-36 string, which uses the 26 letters from the English
+   * Converts this byte array to a base-32 string, which uses the 26 letters from the English
    * alphabet and the 10 numeric digits.
    */
   fun ByteArray.toAlphaNumericString(): String = buildString {
@@ -70,4 +70,10 @@ internal object AlphanumericStringUtil {
       append(ALPHANUMERIC_ALPHABET[intValue and 0x1f])
     }
   }
+
+  /**
+   * Converts this [ImmutableByteArray] to a base-32 string, which uses the 26 letters from the
+   * English alphabet and the 10 numeric digits.
+   */
+  fun ImmutableByteArray.toAlphaNumericString(): String = peek().toAlphaNumericString()
 }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/ProtoUtil.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/ProtoUtil.kt
@@ -60,11 +60,11 @@ import kotlinx.serialization.serializer
 internal object ProtoUtil {
 
   /** Calculates a SHA-512 digest of a [Struct]. */
-  fun Struct.calculateSha512(preamble: String = ""): ByteArray =
+  fun Struct.calculateSha512(preamble: String = ""): ImmutableByteArray =
     Value.newBuilder().setStructValue(this).build().calculateSha512(preamble = preamble)
 
   /** Calculates a SHA-512 digest of a [Value]. */
-  fun Value.calculateSha512(preamble: String = ""): ByteArray {
+  fun Value.calculateSha512(preamble: String = ""): ImmutableByteArray {
     val digest = MessageDigest.getInstance("SHA-512")
     val out = DataOutputStream(DigestOutputStream(NullOutputStream, digest))
 
@@ -102,7 +102,7 @@ internal object ProtoUtil {
 
     calculateDigest(this)
 
-    return digest.digest()
+    return ImmutableByteArray.adopt(digest.digest())
   }
 
   fun Boolean.toValueProto(): Value = Value.newBuilder().setBoolValue(this).build()

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/util/AlphanumericStringUtilUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/util/AlphanumericStringUtilUnitTest.kt
@@ -154,6 +154,28 @@ class AlphanumericStringUtilUnitTest {
     val byteArrayArb = Arb.byteArray(length = Arb.int(0, 100), content = Arb.byte())
     checkAll(100_000, byteArrayArb) { byteArray -> byteArray.toAlphaNumericString() }
   }
+
+  @Test
+  fun `toAlphaNumericString() for ImmutableByteArray returns expected value`() = runTest {
+    val byteArrayArb = Arb.byteArray(length = Arb.int(0, 100), content = Arb.byte())
+    checkAll(100_000, byteArrayArb) { byteArray ->
+      val expected = byteArray.toAlphaNumericString()
+      val actual = ImmutableByteArray.adopt(byteArray).toAlphaNumericString()
+      actual shouldBe expected
+    }
+  }
+
+  @Test
+  fun `toAlphaNumericString() for ImmutableByteArray does not affect underlying array`() = runTest {
+    val byteArrayArb = Arb.byteArray(length = Arb.int(0, 100), content = Arb.byte())
+    checkAll(100, byteArrayArb) { byteArray ->
+      val byteArrayCopy = byteArray.copyOf()
+
+      ImmutableByteArray.adopt(byteArray).toAlphaNumericString()
+
+      byteArray shouldBe byteArrayCopy
+    }
+  }
 }
 
 /*


### PR DESCRIPTION
This PR refactors the internal hashing logic within the `firebase-dataconnect` module by migrating from mutable byte arrays to `ImmutableByteArray`. This change reinforces the immutability of internally calculated SHA-512 hashes for Protobuf `Struct` and `Value` types, which are used to represent query IDs and variable hashes.

### Highlights

* **Immutable Hash Representation**: Updated the `calculateSha512` extension functions for `Struct` and `Value` to return `ImmutableByteArray` instead of primitive `ByteArray`.
* **LiveQuery Improvements**: Changed the type of the `variablesHash` field in `LiveQuery.Key` from `String` to `ImmutableByteArray` to leverage the new immutable return type.
* **Alphanumeric Conversion Overload**: Added a new `toAlphaNumericString()` extension for `ImmutableByteArray` in `AlphanumericStringUtil` and fixed a documentation typo (base-32 instead of base-36).
* **Test Coverage**: Expanded `AlphanumericStringUtilUnitTest.kt` with property-based testing to verify that the new `toAlphaNumericString()` extension function correctly formats `ImmutableByteArray`s without mutating the underlying array.

<details>

<summary><b>Changelog</b></summary>

* **CHANGELOG.md**
  * Added an entry detailing the internal refactor to use immutable byte arrays.
* **DataConnectGrpcRPCs.kt**
  * Updated query ID calculation to utilize the modified `calculateSha512` function returning an `ImmutableByteArray`.
* **LiveQueries.kt**
  * Updated the hash generation logic for variables to return `ImmutableByteArray` directly.
* **LiveQuery.kt**
  * Changed the data type of `variablesHash` in `LiveQuery.Key` from `String` to `ImmutableByteArray`.
* **AlphanumericStringUtil.kt**
  * Corrected documentation comment noting base-32 instead of base-36.
  * Added `toAlphaNumericString()` extension function for `ImmutableByteArray`.
* **ProtoUtil.kt**
  * Changed the return type of `calculateSha512` for `Struct` and `Value` to `ImmutableByteArray`.
* **AlphanumericStringUtilUnitTest.kt**
  * Added unit tests verifying `toAlphaNumericString()` behavior and array safety for `ImmutableByteArray`.
</details>