### PR TITLE
[Infra] Enable dynamic variant selection for publishing

### DIFF
--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/BaseFirebaseLibraryPlugin.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/BaseFirebaseLibraryPlugin.kt
@@ -218,7 +218,7 @@ abstract class BaseFirebaseLibraryPlugin : Plugin<Project> {
 
             pom(firebaseLibrary.customizePomAction)
             firebaseLibrary.applyPomTransformations(pom)
-            from(components.findByName(firebaseLibrary.type.componentName))
+            from(components.findByName(firebaseLibrary.componentName))
           }
         }
       }

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/FirebaseAndroidLibraryPlugin.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/FirebaseAndroidLibraryPlugin.kt
@@ -151,10 +151,8 @@ class FirebaseAndroidLibraryPlugin : BaseFirebaseLibraryPlugin() {
     firebaseLibrary: FirebaseLibraryExtension,
     android: LibraryExtension,
   ) {
-    android.publishing.singleVariant("release") { withSourcesJar() }
-
+    android.publishing.singleVariant(firebaseLibrary.componentName) { withSourcesJar() }
     project.tasks.withType<GenerateModuleMetadata> { isEnabled = false }
-
     configurePublishing(project, firebaseLibrary)
   }
 }

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/FirebaseLibraryExtension.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/FirebaseLibraryExtension.kt
@@ -265,6 +265,16 @@ constructor(val project: Project, val type: LibraryType) {
   val runtimeClasspath: String =
     if (type == LibraryType.ANDROID) "releaseRuntimeClasspath" else "runtimeClasspath"
 
+  val componentName: String
+    get() {
+      val publishDebugVariant =
+        project.hasProperty("publishDebugVariant") && project.property("publishDebugVariant") == "true"
+      if (type == LibraryType.ANDROID && publishDebugVariant) {
+        return "debug"
+      }
+      return type.componentName
+    }
+
   override fun toString(): String {
     return """FirebaseLibraryExtension{name="$mavenName", project="$path", type="$type"}"""
   }

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/FirebaseLibraryExtension.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/FirebaseLibraryExtension.kt
@@ -268,7 +268,8 @@ constructor(val project: Project, val type: LibraryType) {
   val componentName: String
     get() {
       val publishDebugVariant =
-        project.hasProperty("publishDebugVariant") && project.property("publishDebugVariant") == "true"
+        project.hasProperty("publishDebugVariant") &&
+          project.property("publishDebugVariant") == "true"
       if (type == LibraryType.ANDROID && publishDebugVariant) {
         return "debug"
       }


### PR DESCRIPTION
This change introduces the `publishDebugVariant` Gradle property to allow publishing the "debug" variant instead of the default "release" variant. This is useful for testing and distributing debuggable AARs.

- Modified `FirebaseLibraryExtension` to provide a dynamic `componentName` based on the `publishDebugVariant` property.
- Updated `BaseFirebaseLibraryPlugin` and `FirebaseAndroidLibraryPlugin` to use the dynamic `componentName` during Maven publication setup.