### PR TITLE
Gradle task injectCrashlyticsBuildIds fails when processing unparseable ELFs

### DIFF
--- a/firebase-crashlytics-buildtools/src/main/java/com/google/firebase/crashlytics/buildtools/buildids/BuildIdInfoCollector.java
+++ b/firebase-crashlytics-buildtools/src/main/java/com/google/firebase/crashlytics/buildtools/buildids/BuildIdInfoCollector.java
@@ -27,7 +27,6 @@ import com.google.firebase.crashlytics.buildtools.ndk.internal.elf.ElfSectionHea
 import com.google.firebase.crashlytics.buildtools.ndk.internal.elf.ElfSymbol;
 import com.google.firebase.crashlytics.buildtools.utils.FileUtils;
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -47,10 +46,7 @@ public class BuildIdInfoCollector {
     BuildIdInfoContentHandler contentHandler = new BuildIdInfoContentHandler(file.getName());
     try {
       ElfDataParser.parse(file, contentHandler, false);
-    } catch (IOException
-        | NegativeArraySizeException
-        | ArithmeticException
-        | IllegalArgumentException ex) {
+    } catch (Exception ex) {
       // TODO(b/289053263): Make build tools support Go binaries smoother.
       // Ignore any file that doesn't parse, or has unexpected opcodeBase, to avoid breaking builds.
       getLogger().logD("Unable to parse binary: " + file.getPath() + " - " + ex.getMessage());

--- a/firebase-crashlytics-buildtools/src/main/java/com/google/firebase/crashlytics/buildtools/buildids/BuildIdInfoCollector.java
+++ b/firebase-crashlytics-buildtools/src/main/java/com/google/firebase/crashlytics/buildtools/buildids/BuildIdInfoCollector.java
@@ -47,7 +47,10 @@ public class BuildIdInfoCollector {
     BuildIdInfoContentHandler contentHandler = new BuildIdInfoContentHandler(file.getName());
     try {
       ElfDataParser.parse(file, contentHandler, false);
-    } catch (IOException | NegativeArraySizeException | ArithmeticException ex) {
+    } catch (IOException
+        | NegativeArraySizeException
+        | ArithmeticException
+        | IllegalArgumentException ex) {
       // TODO(b/289053263): Make build tools support Go binaries smoother.
       // Ignore any file that doesn't parse, or has unexpected opcodeBase, to avoid breaking builds.
       getLogger().logD("Unable to parse binary: " + file.getPath() + " - " + ex.getMessage());

--- a/firebase-crashlytics-gradle/CHANGELOG.md
+++ b/firebase-crashlytics-gradle/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 - [changed] Improved efficiency when extracting breakpad binary files.
+- [fixed] Avoid build breaks when handling unsupported native libraries for injectCrashlyticsBuildIds task [#7780]
 
 ### Crashlytics Gradle plugin version 3.0.6
 


### PR DESCRIPTION
NIT: Extending catch clause to prevent build breaking.

Related issue: https://github.com/firebase/firebase-android-sdk/issues/7780