### PR TITLE
[AI] Use Ktor's HttpRequestTimeoutException for timeout handling

### DIFF
--- a/ai-logic/firebase-ai/CHANGELOG.md
+++ b/ai-logic/firebase-ai/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 - [feature] Added support for [Maps Grounding](https://ai.google.dev/gemini-api/docs/maps-grounding) (#7950)
+- [fixed] Fixed an issue causing network timeouts to throw the incorrect exception type, instead of
+  `RequestTimeoutException` (#7966)
 
 # 17.10.1
 
@@ -153,4 +155,3 @@ using [specific Gemini models](/docs/vertex-ai/models).
 
 Note: This feature is in Public Preview, which means that it is not subject to any SLA or
 deprecation policy and could change in backwards-incompatible ways.
-

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/Exceptions.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/Exceptions.kt
@@ -18,8 +18,8 @@ package com.google.firebase.ai.type
 
 import com.google.firebase.ai.FirebaseAI
 import com.google.firebase.ai.ondevice.interop.FirebaseAIOnDeviceException
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.TimeoutCancellationException
 
 /** Parent class for any errors that occur from the [FirebaseAI] SDK. */
 public abstract class FirebaseAIException
@@ -45,7 +45,7 @@ internal constructor(message: String, cause: Throwable? = null) : RuntimeExcepti
               FirebaseAIOnDeviceInvalidRequestException(cause)
             else -> FirebaseAIOnDeviceUnknownException(cause)
           }
-        is TimeoutCancellationException ->
+        is HttpRequestTimeoutException ->
           RequestTimeoutException("The request failed to complete in the allotted time.")
         is CancellationException -> throw cause
         else -> UnknownException("Something unexpected happened.", cause)

--- a/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/common/APIControllerTests.kt
+++ b/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/common/APIControllerTests.kt
@@ -31,13 +31,11 @@ import com.google.firebase.ai.type.FunctionCallingConfig
 import com.google.firebase.ai.type.GoogleSearch
 import com.google.firebase.ai.type.PublicPreviewAPI
 import com.google.firebase.ai.type.RequestOptions
-import com.google.firebase.ai.type.RequestTimeoutException
 import com.google.firebase.ai.type.TextPart
 import com.google.firebase.ai.type.Tool
 import com.google.firebase.ai.type.ToolConfig
 import com.google.firebase.ai.type.UrlContext
 import io.kotest.assertions.json.shouldContainJsonKey
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.ktor.client.engine.mock.MockEngine
@@ -88,15 +86,8 @@ internal class APIControllerTests {
     }
   }
 
-  @Test
-  fun `(generateContent) respects a custom timeout`() =
-    commonTest(requestOptions = RequestOptions(2.seconds.inWholeMilliseconds, 10)) {
-      shouldThrow<RequestTimeoutException> {
-        withTimeout(testTimeout) {
-          apiController.generateContent(textGenerateContentRequest("test"))
-        }
-      }
-    }
+  // TODO(rlazo): Add a timeout tests once it's supported by ktor, see
+  // https://youtrack.jetbrains.com/issue/KTOR-8271
 }
 
 @OptIn(ExperimentalSerializationApi::class)


### PR DESCRIPTION
Updated the exception handling logic to catch`HttpRequestTimeoutException` from the Ktor HTTP client for request timeouts. This replaces the previous reliance on `TimeoutCancellationException`, which comes from the coroutine rather than the network layer.

The timeout test in `APIControllerTests` is temporarily disabled due to missing Ktor timeout testing support.