### PR TITLE
[Infra] Document local publishing of debug variant

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -114,6 +114,16 @@ To publish a project locally, you can use the following command:
 ./gradlew -PprojectsToPublish="<firebase-project>" publishReleasingLibrariesToMavenLocal
 ```
 
+By default, the `release` variant is published. To publish the `debug` variant instead, use the
+`publishDebugVariant` property:
+
+```bash
+./gradlew -PprojectsToPublish="<firebase-project>" -PpublishDebugVariant=true publishReleasingLibrariesToMavenLocal
+```
+
+Using the `debug` variant has the advantage of including additional logging information. For example,
+the `ai-logic/firebase-ai` SDK logs the request/response information when the debug variant is used.
+
 ## Development Conventions
 
 ### Code Formatting


### PR DESCRIPTION
Added instructions for locally publishing the debug variant of a project using `publishDebugVariant=true`.