### PR TITLE
[Infra] Add comment to ensure  Gradle Setup Action version pin

### DIFF
--- a/.github/workflows/ai-daily-tests.yml
+++ b/.github/workflows/ai-daily-tests.yml
@@ -30,6 +30,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/api-information.yml
+++ b/.github/workflows/api-information.yml
@@ -18,6 +18,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -20,6 +20,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/check-head-dependencies.yml
+++ b/.github/workflows/check-head-dependencies.yml
@@ -18,6 +18,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -24,6 +24,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -27,6 +27,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
@@ -58,6 +59,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
@@ -144,6 +146,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/config-e2e.yml
+++ b/.github/workflows/config-e2e.yml
@@ -26,6 +26,7 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/create-releases-buildtools.yml
+++ b/.github/workflows/create-releases-buildtools.yml
@@ -31,6 +31,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
@@ -57,6 +58,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
@@ -92,6 +94,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/create_releases.yml
+++ b/.github/workflows/create_releases.yml
@@ -41,6 +41,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/dataconnect.yml
+++ b/.github/workflows/dataconnect.yml
@@ -59,6 +59,7 @@ jobs:
           java-version: ${{ env.FDC_JAVA_VERSION }}
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/dataconnect_demo_app.yml
+++ b/.github/workflows/dataconnect_demo_app.yml
@@ -86,6 +86,7 @@ jobs:
             firebase-dataconnect/demo/gradle/wrapper/gradle-wrapper.properties
             github_actions_demo_test_cache_key.txt
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
@@ -170,6 +171,7 @@ jobs:
             firebase-dataconnect/demo/gradle/wrapper/gradle-wrapper.properties
             github_actions_demo_spotless_cache_key.txt
 
+     # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/diff-javadoc.yml
+++ b/.github/workflows/diff-javadoc.yml
@@ -24,6 +24,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/fireperf-e2e.yml
+++ b/.github/workflows/fireperf-e2e.yml
@@ -27,6 +27,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/firestore_ci_tests.yml
+++ b/.github/workflows/firestore_ci_tests.yml
@@ -27,6 +27,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
@@ -63,6 +64,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
@@ -128,6 +130,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
@@ -221,6 +224,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
@@ -292,6 +296,7 @@ jobs:
           java-version: 21
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/health-metrics.yml
+++ b/.github/workflows/health-metrics.yml
@@ -34,6 +34,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
@@ -73,6 +74,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
@@ -113,6 +115,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/make-bom.yml
+++ b/.github/workflows/make-bom.yml
@@ -20,6 +20,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/metalava-semver-check.yml
+++ b/.github/workflows/metalava-semver-check.yml
@@ -22,6 +22,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/perf-gradle-compatibility-tests.yml
+++ b/.github/workflows/perf-gradle-compatibility-tests.yml
@@ -20,6 +20,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/plugins-check.yml
+++ b/.github/workflows/plugins-check.yml
@@ -24,6 +24,7 @@ jobs:
           distribution: temurin
           cache: gradle
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/post_release_cleanup.yml
+++ b/.github/workflows/post_release_cleanup.yml
@@ -21,6 +21,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/release-note-changes.yml
+++ b/.github/workflows/release-note-changes.yml
@@ -35,6 +35,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/sessions-e2e.yml
+++ b/.github/workflows/sessions-e2e.yml
@@ -26,6 +26,7 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -17,6 +17,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -25,6 +25,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/validate-dependencies.yml
+++ b/.github/workflows/validate-dependencies.yml
@@ -17,6 +17,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -17,6 +17,7 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # Do not update to version 6, context: https://blog.gradle.org/github-actions-for-gradle-v6
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 


### PR DESCRIPTION
Added a comment to all GitHub Actions workflows that use `gradle/actions/setup-gradle` to explain why the action is pinned to version `v5.0.2` and should not be updated to version 6.

For further context see https://blog.gradle.org/github-actions-for-gradle-v6