### PR TITLE
[AI] Implement toString/equals/hashCode for InferenceSource

### DIFF
--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/OnDeviceConfig.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/OnDeviceConfig.kt
@@ -82,11 +82,18 @@ public class InferenceMode private constructor(private val value: String) {
 /** Indicates the source of the model inference. */
 @PublicPreviewAPI
 public class InferenceSource private constructor(private val value: String) {
+
+  override fun toString(): String = value
+
+  override fun equals(other: Any?): Boolean = other is InferenceSource && value == other.value
+
+  override fun hashCode(): Int = value.hashCode()
+
   public companion object {
     /** Inference was performed on the device. */
-    @JvmField public val ON_DEVICE: InferenceSource = InferenceSource("source on device")
+    @JvmField public val ON_DEVICE: InferenceSource = InferenceSource("On Device")
 
     /** Inference was performed in the cloud. */
-    @JvmField public val IN_CLOUD: InferenceSource = InferenceSource("source in cloud")
+    @JvmField public val IN_CLOUD: InferenceSource = InferenceSource("In Cloud")
   }
 }


### PR DESCRIPTION
Overrode `toString()`, `equals()`, and `hashCode()` for the `InferenceSource` class to provide standard object behavior and improved string representation.