### PR TITLE
[AI] Gracefully handle unknown LiveServerMessage types

### DIFF
--- a/ai-logic/firebase-ai/CHANGELOG.md
+++ b/ai-logic/firebase-ai/CHANGELOG.md
@@ -3,6 +3,8 @@
 - [feature] Added support for [Maps Grounding](https://ai.google.dev/gemini-api/docs/maps-grounding) (#7950)
 - [fixed] Fixed an issue causing network timeouts to throw the incorrect exception type, instead of
   `RequestTimeoutException` (#7966)
+- [fixed] Fixed an issue causing the SDK to throw an exception if an unknown message was received
+  from the LiveAPI model, instead of ignoring it (#7975)
 
 # 17.10.1
 

--- a/ai-logic/firebase-ai/api.txt
+++ b/ai-logic/firebase-ai/api.txt
@@ -1301,6 +1301,10 @@ package com.google.firebase.ai.type {
     property public final java.util.List<java.lang.String> functionIds;
   }
 
+  @com.google.firebase.ai.type.PublicPreviewAPI public final class LiveServerUnknownMessage implements com.google.firebase.ai.type.LiveServerMessage {
+    ctor public LiveServerUnknownMessage();
+  }
+
   @com.google.firebase.ai.type.PublicPreviewAPI public final class LiveSession {
     method public suspend Object? close(kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public boolean isAudioConversationActive();

--- a/ai-logic/firebase-ai/api.txt
+++ b/ai-logic/firebase-ai/api.txt
@@ -1302,7 +1302,6 @@ package com.google.firebase.ai.type {
   }
 
   @com.google.firebase.ai.type.PublicPreviewAPI public final class LiveServerUnknownMessage implements com.google.firebase.ai.type.LiveServerMessage {
-    ctor public LiveServerUnknownMessage();
   }
 
   @com.google.firebase.ai.type.PublicPreviewAPI public final class LiveSession {

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveServerMessage.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveServerMessage.kt
@@ -138,7 +138,7 @@ public class LiveServerSetupComplete : LiveServerMessage {
 }
 
 @PublicPreviewAPI
-public class LiveServerUnknownMessage : LiveServerMessage {
+public class LiveServerUnknownMessage private constructor() : LiveServerMessage {
   @Serializable
   internal data class InternalWrapper(@Transient val unused: Unit? = null) :
     InternalLiveServerMessage {

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveServerMessage.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveServerMessage.kt
@@ -16,6 +16,7 @@
 
 package com.google.firebase.ai.type
 
+import android.util.Log
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.serialization.DeserializationStrategy
@@ -136,6 +137,15 @@ public class LiveServerSetupComplete : LiveServerMessage {
   }
 }
 
+@PublicPreviewAPI
+public class LiveServerUnknownMessage : LiveServerMessage {
+  @Serializable
+  internal data class InternalWrapper(@Transient val unused: Unit? = null) :
+    InternalLiveServerMessage {
+    override fun toPublic() = LiveServerUnknownMessage()
+  }
+}
+
 /**
  * Request for the client to execute the provided [functionCalls].
  *
@@ -233,10 +243,13 @@ internal object LiveServerMessageSerializer :
       "toolCallCancellation" in jsonObject ->
         LiveServerToolCallCancellation.InternalWrapper.serializer()
       "goAway" in jsonObject -> LiveServerGoAway.InternalWrapper.serializer()
-      else ->
-        throw SerializationException(
-          "Unknown LiveServerMessage response type. Keys found: ${jsonObject.keys}"
+      else -> {
+        Log.w(
+          LiveServerMessageSerializer::class.simpleName,
+          "Ignoring unknown LiveServerMessage response type. Keys found: ${jsonObject.keys}"
         )
+        LiveServerUnknownMessage.InternalWrapper.serializer()
+      }
     }
   }
 }

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveServerMessage.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveServerMessage.kt
@@ -245,7 +245,7 @@ internal object LiveServerMessageSerializer :
       "goAway" in jsonObject -> LiveServerGoAway.InternalWrapper.serializer()
       else -> {
         Log.w(
-          LiveServerMessageSerializer::class.simpleName,
+          "LiveServerMsgSerializer",
           "Ignoring unknown LiveServerMessage response type. Keys found: ${jsonObject.keys}"
         )
         LiveServerUnknownMessage.InternalWrapper.serializer()

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveSession.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveSession.kt
@@ -578,6 +578,7 @@ internal constructor(
             // Notify the application
             goAwayHandler?.invoke(it)
           }
+          is LiveServerUnknownMessage -> {} // Ignore. Logging happens at de-serialization time
         }
       }
       .launchIn(networkScope)

--- a/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/type/LiveServerMessageTests.kt
+++ b/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/type/LiveServerMessageTests.kt
@@ -17,7 +17,6 @@
 package com.google.firebase.ai.type
 
 import com.google.firebase.ai.common.JSON
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -109,10 +108,11 @@ internal class LiveServerMessageTests {
   }
 
   @Test
-  fun `LiveServerMessageSerializer throws on unknown message type`() {
+  fun `LiveServerMessageSerializer returns LiveServeUnknownMessage for unrecognized message`() {
     val json = """{"unknownType": {"data": "value"}}"""
 
-    shouldThrow<SerializationException> { JSON.decodeFromString<InternalLiveServerMessage>(json) }
+    val message = JSON.decodeFromString<InternalLiveServerMessage>(json)
+    message.toPublic().shouldBeInstanceOf<LiveServerUnknownMessage>()
   }
 
   @Test

--- a/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/type/LiveServerMessageTests.kt
+++ b/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/type/LiveServerMessageTests.kt
@@ -108,7 +108,7 @@ internal class LiveServerMessageTests {
   }
 
   @Test
-  fun `LiveServerMessageSerializer returns LiveServeUnknownMessage for unrecognized message`() {
+  fun `LiveServerMessageSerializer returns LiveServerUnknownMessage for unrecognized message`() {
     val json = """{"unknownType": {"data": "value"}}"""
 
     val message = JSON.decodeFromString<InternalLiveServerMessage>(json)


### PR DESCRIPTION
Introduce `LiveServerUnknownMessage` to represent unrecognized messages received from the server.
Previously, the `LiveServerMessageSerializer` would throw a `SerializationException` when encountering an unknown message type. This change modifies the serializer to instead log a warning and return a `LiveServerUnknownMessage` for any unhandled types. The `LiveSession`'s message handler is updated to explicitly ignore these unknown messages.

This prevents crashes due to unexpected server messages and allows for forward compatibility with new message types.