### PR TITLE
Fireperf aqs sessionmanager phase2

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfEarly.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfEarly.java
@@ -36,7 +36,10 @@ import java.util.concurrent.Executor;
 public class FirebasePerfEarly {
 
   public FirebasePerfEarly(
-          FirebaseApp app, @Nullable StartupTime startupTime, Executor uiExecutor, SessionManager sessionManager) {
+      FirebaseApp app,
+      @Nullable StartupTime startupTime,
+      Executor uiExecutor,
+      SessionManager sessionManager) {
     Context context = app.getApplicationContext();
 
     // Initialize ConfigResolver early for accessing device caching layer.
@@ -45,7 +48,8 @@ public class FirebasePerfEarly {
 
     // Register FirebasePerformance as a subscriber ASAP - which will start collecting gauges if the
     // FirebaseSession is verbose.
-    FirebaseSessionsDependencies.register(new FirebasePerformanceSessionSubscriber(configResolver, sessionManager));
+    FirebaseSessionsDependencies.register(
+        new FirebasePerformanceSessionSubscriber(configResolver, sessionManager));
 
     AppStateMonitor appStateMonitor = AppStateMonitor.getInstance(sessionManager);
     appStateMonitor.registerActivityLifecycleCallbacks(context);

--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfEarly.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfEarly.java
@@ -47,7 +47,7 @@ public class FirebasePerfEarly {
     // FirebaseSession is verbose.
     FirebaseSessionsDependencies.register(new FirebasePerformanceSessionSubscriber(configResolver, sessionManager));
 
-    AppStateMonitor appStateMonitor = AppStateMonitor.getInstance();
+    AppStateMonitor appStateMonitor = AppStateMonitor.getInstance(sessionManager);
     appStateMonitor.registerActivityLifecycleCallbacks(context);
     appStateMonitor.registerForAppColdStart(new FirebasePerformanceInitializer());
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfRegistrar.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfRegistrar.java
@@ -88,7 +88,9 @@ public class FirebasePerfRegistrar implements ComponentRegistrar {
                         container.get(SessionManager.class)))
             .build(),
         Component.builder(SessionManager.class)
-            .factory(container -> SessionManager.getInstance())
+            .factory(
+                container ->
+                    new SessionManager(GaugeManager.getInstance(), PerfSession.createWithId(null)))
             .build(),
         /**
          * Fireperf SDK is lazily by {@link FirebasePerformanceInitializer} during {@link

--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformance.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformance.java
@@ -171,7 +171,8 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
     FirebaseSessionsEnforcementCheck.setEnforcement(BuildConfig.ENFORCE_LEGACY_SESSIONS);
 
     TransportManager.getInstance()
-        .initialize(firebaseApp, firebaseInstallationsApi, transportFactoryProvider, sessionManager);
+        .initialize(
+            firebaseApp, firebaseInstallationsApi, transportFactoryProvider, sessionManager);
 
     Context appContext = firebaseApp.getApplicationContext();
     mMetadataBundle = extractMetadata(appContext);

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -87,7 +87,8 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
     if (instance == null) {
       synchronized (AppStateMonitor.class) {
         if (instance == null) {
-          instance = new AppStateMonitor(TransportManager.getInstance(), new Clock(), sessionManager);
+          instance =
+              new AppStateMonitor(TransportManager.getInstance(), new Clock(), sessionManager);
         }
       }
     }
@@ -109,8 +110,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
               new AppStateMonitor(
                   TransportManager.getInstance(),
                   new Clock(),
-                  new SessionManager(
-                      GaugeManager.getInstance(), PerfSession.createWithId(null)));
+                  new SessionManager(GaugeManager.getInstance(), PerfSession.createWithId(null)));
         }
       }
     }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -26,7 +26,9 @@ import com.google.firebase.perf.config.ConfigResolver;
 import com.google.firebase.perf.logging.AndroidLogger;
 import com.google.firebase.perf.metrics.FrameMetricsCalculator.PerfFrameMetrics;
 import com.google.firebase.perf.metrics.Trace;
+import com.google.firebase.perf.session.PerfSession;
 import com.google.firebase.perf.session.SessionManager;
+import com.google.firebase.perf.session.gauges.GaugeManager;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Constants;
@@ -81,11 +83,34 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
   private boolean isRegisteredForLifecycleCallbacks = false;
   private boolean isColdStart = true;
 
+  public static AppStateMonitor getInstance(SessionManager sessionManager) {
+    if (instance == null) {
+      synchronized (AppStateMonitor.class) {
+        if (instance == null) {
+          instance = new AppStateMonitor(TransportManager.getInstance(), new Clock(), sessionManager);
+        }
+      }
+    }
+    return instance;
+  }
+
+  /**
+   * Returns the singleton instance, creating it with a default {@link SessionManager} if not
+   * already initialized. In production, {@link #getInstance(SessionManager)} is always called
+   * first by {@link com.google.firebase.perf.FirebasePerfEarly}, so the pre-seeded instance is
+   * returned. This overload exists for call sites that run after early initialization (e.g.
+   * {@link com.google.firebase.perf.application.AppStateUpdateHandler}) and for test environments.
+   */
   public static AppStateMonitor getInstance() {
     if (instance == null) {
       synchronized (AppStateMonitor.class) {
         if (instance == null) {
-          instance = new AppStateMonitor(TransportManager.getInstance(), new Clock(), SessionManager.getInstance());
+          instance =
+              new AppStateMonitor(
+                  TransportManager.getInstance(),
+                  new Clock(),
+                  new SessionManager(
+                      GaugeManager.getInstance(), PerfSession.createWithId(null)));
         }
       }
     }
@@ -113,6 +138,15 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
     this.configResolver = configResolver;
     this.sessionManager = sessionManager;
     this.screenPerformanceRecordingSupported = screenPerformanceRecordingSupported;
+  }
+
+  public SessionManager getSessionManager() {
+    return sessionManager;
+  }
+
+  @VisibleForTesting
+  public static void resetInstance() {
+    instance = null;
   }
 
   public synchronized void registerActivityLifecycleCallbacks(Context context) {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
@@ -75,7 +75,7 @@ public class ConfigResolver {
       @Nullable ImmutableBundle metadataBundle,
       @Nullable DeviceCacheManager deviceCacheManager) {
     this.remoteConfigManager =
-        remoteConfigManager == null ? RemoteConfigManager.getInstance() : remoteConfigManager;
+        remoteConfigManager == null ? new RemoteConfigManager() : remoteConfigManager;
     this.metadataBundle = metadataBundle == null ? new ImmutableBundle() : metadataBundle;
     this.deviceCacheManager =
         deviceCacheManager == null ? DeviceCacheManager.getInstance() : deviceCacheManager;
@@ -915,5 +915,9 @@ public class ConfigResolver {
 
   private boolean isSessionsMaxDurationMinutesValid(long maxDurationMin) {
     return maxDurationMin > 0;
+  }
+
+  public RemoteConfigManager getRemoteConfigManager() {
+      return remoteConfigManager;
   }
 }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
@@ -918,6 +918,6 @@ public class ConfigResolver {
   }
 
   public RemoteConfigManager getRemoteConfigManager() {
-      return remoteConfigManager;
+    return remoteConfigManager;
   }
 }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/RemoteConfigManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/RemoteConfigManager.java
@@ -47,7 +47,6 @@ import java.util.concurrent.TimeUnit;
 public class RemoteConfigManager {
 
   private static final AndroidLogger logger = AndroidLogger.getInstance();
-  private static final RemoteConfigManager instance = new RemoteConfigManager();
   private static final String FIREPERF_FRC_NAMESPACE_NAME = "fireperf";
   private static final long TIME_AFTER_WHICH_A_FETCH_IS_CONSIDERED_STALE_MS =
       TimeUnit.HOURS.toMillis(12);
@@ -67,7 +66,7 @@ public class RemoteConfigManager {
 
   // TODO(b/258263016): Migrate to go/firebase-android-executors
   @SuppressLint("ThreadPoolCreation")
-  private RemoteConfigManager() {
+  public RemoteConfigManager() {
     this(
         DeviceCacheManager.getInstance(),
         new ThreadPoolExecutor(
@@ -94,11 +93,6 @@ public class RemoteConfigManager {
             ? new ConcurrentHashMap<>()
             : new ConcurrentHashMap<>(firebaseRemoteConfig.getAll());
     this.remoteConfigFetchDelayInMs = remoteConfigFetchDelayInMs;
-  }
-
-  /** Gets the singleton instance. */
-  public static RemoteConfigManager getInstance() {
-    return instance;
   }
 
   /**

--- a/firebase-perf/src/main/java/com/google/firebase/perf/injection/modules/FirebasePerformanceModule.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/injection/modules/FirebasePerformanceModule.java
@@ -71,7 +71,7 @@ public class FirebasePerformanceModule {
 
   @Provides
   RemoteConfigManager providesRemoteConfigManager() {
-    return RemoteConfigManager.getInstance();
+    return ConfigResolver.getInstance().getRemoteConfigManager();
   }
 
   @Provides

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -567,12 +567,6 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, LifecycleObser
         if (appProcess.importance != ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND) {
           continue;
         }
-        //        if (appProcess.processName.equals(appProcessName)
-        //            || appProcess.processName.startsWith(allowedAppProcessNamePrefix)) {
-        //          // Returns true if the process with `IMPORTANCE_FOREGROUND` matches current
-        // process.
-        //          return true;
-        //        }
       }
     }
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -168,12 +168,15 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, LifecycleObser
   }
 
   public static AppStartTrace getInstance(SessionManager sessionManager) {
-    return instance != null ? instance : getInstance(TransportManager.getInstance(), new Clock(), sessionManager);
+    return instance != null
+        ? instance
+        : getInstance(TransportManager.getInstance(), new Clock(), sessionManager);
   }
 
   // TODO(b/258263016): Migrate to go/firebase-android-executors
   @SuppressLint("ThreadPoolCreation")
-  static AppStartTrace getInstance(TransportManager transportManager, Clock clock, SessionManager sessionManager) {
+  static AppStartTrace getInstance(
+      TransportManager transportManager, Clock clock, SessionManager sessionManager) {
     if (instance == null) {
       synchronized (AppStartTrace.class) {
         if (instance == null) {
@@ -564,11 +567,12 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, LifecycleObser
         if (appProcess.importance != ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND) {
           continue;
         }
-//        if (appProcess.processName.equals(appProcessName)
-//            || appProcess.processName.startsWith(allowedAppProcessNamePrefix)) {
-//          // Returns true if the process with `IMPORTANCE_FOREGROUND` matches current process.
-//          return true;
-//        }
+        //        if (appProcess.processName.equals(appProcessName)
+        //            || appProcess.processName.startsWith(allowedAppProcessNamePrefix)) {
+        //          // Returns true if the process with `IMPORTANCE_FOREGROUND` matches current
+        // process.
+        //          return true;
+        //        }
       }
     }
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/NetworkRequestMetricBuilder.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/NetworkRequestMetricBuilder.java
@@ -90,7 +90,11 @@ public final class NetworkRequestMetricBuilder extends AppStateUpdateHandler
    * initialize them.
    */
   private NetworkRequestMetricBuilder(TransportManager transportManager) {
-    this(transportManager, AppStateMonitor.getInstance(), GaugeManager.getInstance(), SessionManager.getInstance());
+    this(
+        transportManager,
+        AppStateMonitor.getInstance(),
+        GaugeManager.getInstance(),
+        AppStateMonitor.getInstance().getSessionManager());
   }
 
   /**

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/Trace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/Trace.java
@@ -168,12 +168,11 @@ public class Trace extends AppStateUpdateHandler
         clock,
         appStateMonitor,
         gaugeManager,
-        sessionManagerFrom(appStateMonitor));
-  }
-
-  private static SessionManager sessionManagerFrom(AppStateMonitor appStateMonitor) {
-    SessionManager sm = appStateMonitor.getSessionManager();
-    return sm != null ? sm : new SessionManager(null, PerfSession.createWithId(null));
+        // AppStateMonitor is always pre-seeded by FirebasePerfEarly before any Trace can be
+        // created in production. In tests, setUp() must call AppStateMonitor.getInstance(sm)
+        // before constructing a Trace; if it does not, getSessionManager() returns null and
+        // the 6-arg constructor will throw a NullPointerException on first session access.
+        appStateMonitor.getSessionManager());
   }
 
   /**

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/Trace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/Trace.java
@@ -162,8 +162,20 @@ public class Trace extends AppStateUpdateHandler
           @NonNull Clock clock,
           @NonNull AppStateMonitor appStateMonitor,
           @NonNull GaugeManager gaugeManager) {
-    this(name, transportManager, clock, appStateMonitor, gaugeManager, SessionManager.getInstance());
+    this(
+        name,
+        transportManager,
+        clock,
+        appStateMonitor,
+        gaugeManager,
+        sessionManagerFrom(appStateMonitor));
   }
+
+  private static SessionManager sessionManagerFrom(AppStateMonitor appStateMonitor) {
+    SessionManager sm = appStateMonitor.getSessionManager();
+    return sm != null ? sm : new SessionManager(null, PerfSession.createWithId(null));
+  }
+
   /**
    * Creates a Trace object with the given name. TransportManager, Clock and GaugeManager instances
    * are for testing.
@@ -213,7 +225,7 @@ public class Trace extends AppStateUpdateHandler
       clock = new Clock();
       gaugeManager = GaugeManager.getInstance();
     }
-    sessionManager = SessionManager.getInstance();
+    sessionManager = TransportManager.getInstance().getSessionManager();
   }
 
   /** Starts this trace. */

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/Trace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/Trace.java
@@ -157,11 +157,11 @@ public class Trace extends AppStateUpdateHandler
   }
 
   public Trace(
-          @NonNull String name,
-          @NonNull TransportManager transportManager,
-          @NonNull Clock clock,
-          @NonNull AppStateMonitor appStateMonitor,
-          @NonNull GaugeManager gaugeManager) {
+      @NonNull String name,
+      @NonNull TransportManager transportManager,
+      @NonNull Clock clock,
+      @NonNull AppStateMonitor appStateMonitor,
+      @NonNull GaugeManager gaugeManager) {
     this(
         name,
         transportManager,
@@ -284,8 +284,7 @@ public class Trace extends AppStateUpdateHandler
         transportManager.log(new TraceMetricBuilder(this).build(), getAppState());
 
         if (sessionManager.perfSession().isVerbose()) {
-          gaugeManager.collectGaugeMetricOnce(
-              sessionManager.perfSession().getTimer());
+          gaugeManager.collectGaugeMetricOnce(sessionManager.perfSession().getTimer());
         }
       } else {
         logger.error("Trace name is empty, no log is sent to server");

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/FirebasePerformanceSessionSubscriber.kt
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/FirebasePerformanceSessionSubscriber.kt
@@ -20,7 +20,10 @@ import com.google.firebase.perf.config.ConfigResolver
 import com.google.firebase.perf.logging.FirebaseSessionsEnforcementCheck.Companion.checkSession
 import com.google.firebase.sessions.api.SessionSubscriber
 
-class FirebasePerformanceSessionSubscriber(val configResolver: ConfigResolver, private val sessionManager: SessionManager) : SessionSubscriber {
+class FirebasePerformanceSessionSubscriber(
+  val configResolver: ConfigResolver,
+  private val sessionManager: SessionManager
+) : SessionSubscriber {
 
   override val sessionSubscriberName: SessionSubscriber.Name = SessionSubscriber.Name.PERFORMANCE
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
@@ -14,7 +14,6 @@
 
 package com.google.firebase.perf.session;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 import androidx.annotation.Keep;
 import androidx.annotation.VisibleForTesting;
@@ -30,28 +29,15 @@ import java.util.Set;
 /** Session manager to generate sessionIDs and broadcast to the application. */
 @Keep // Needed because of b/117526359.
 public class SessionManager {
-  @SuppressLint("StaticFieldLeak")
-  private static final SessionManager instance = new SessionManager();
 
   private final GaugeManager gaugeManager;
   private final Set<WeakReference<SessionAwareObject>> clients = new HashSet<>();
 
   private PerfSession perfSession;
 
-  /** Returns the singleton instance of SessionManager. */
-  public static SessionManager getInstance() {
-    return instance;
-  }
-
   /** Returns the currently active PerfSession. */
   public final PerfSession perfSession() {
     return perfSession;
-  }
-
-  private SessionManager() {
-    // Creates a legacy session by default. This is a safety net to allow initializing
-    // SessionManager - but the current implementation replaces it immediately.
-    this(GaugeManager.getInstance(), PerfSession.createWithId(null));
   }
 
   @VisibleForTesting
@@ -65,7 +51,9 @@ public class SessionManager {
    * (currently that is before onResume finishes) to ensure gauge collection starts on time.
    */
   public void setApplicationContext(final Context appContext) {
-    gaugeManager.initializeGaugeMetadataManager(appContext);
+    if (gaugeManager != null) {
+      gaugeManager.initializeGaugeMetadataManager(appContext);
+    }
   }
 
   /**
@@ -74,7 +62,7 @@ public class SessionManager {
    * @see PerfSession#isSessionRunningTooLong()
    */
   public void stopGaugeCollectionIfSessionRunningTooLong() {
-    if (perfSession.isSessionRunningTooLong()) {
+    if (perfSession.isSessionRunningTooLong() && gaugeManager != null) {
       gaugeManager.stopCollectingGauges();
     }
   }
@@ -151,12 +139,15 @@ public class SessionManager {
   }
 
   private void logGaugeMetadataIfCollectionEnabled() {
-    if (perfSession.isVerbose()) {
+    if (perfSession.isVerbose() && gaugeManager != null) {
       gaugeManager.logGaugeMetadata(perfSession.sessionId());
     }
   }
 
   private void startOrStopCollectingGauges() {
+    if (gaugeManager == null) {
+      return;
+    }
     if (perfSession.isVerbose()) {
       gaugeManager.startCollectingGauges(perfSession);
     } else {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
@@ -166,7 +166,8 @@ public class TransportManager implements AppStateCallback {
       RateLimiter rateLimiter,
       AppStateMonitor appStateMonitor,
       FlgTransport flgTransport,
-      ExecutorService executorService) {
+      ExecutorService executorService,
+      SessionManager sessionManager) {
 
     this.firebaseApp = firebaseApp;
     this.projectId = firebaseApp.getOptions().getProjectId();
@@ -179,6 +180,7 @@ public class TransportManager implements AppStateCallback {
     this.appStateMonitor = appStateMonitor;
     this.flgTransport = flgTransport;
     this.executorService = executorService;
+    this.sessionManager = sessionManager;
 
     // Re-init the cache, otherwise the cache might get consumed/exhausted after a few tests
     cacheMap.put(KEY_AVAILABLE_TRACES_FOR_CACHING, MAX_TRACE_METRICS_CACHE_SIZE);
@@ -394,6 +396,11 @@ public class TransportManager implements AppStateCallback {
       // Check if the session is expired. If so, stop gauge collection.
       sessionManager.stopGaugeCollectionIfSessionRunningTooLong();
     }
+  }
+
+  /** Returns the {@link SessionManager} associated with this transport. */
+  public SessionManager getSessionManager() {
+    return sessionManager;
   }
 
   @WorkerThread

--- a/firebase-perf/src/test/java/com/google/firebase/perf/FirebasePerfRegistrarTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/FirebasePerfRegistrarTest.java
@@ -24,6 +24,7 @@ import com.google.firebase.components.Component;
 import com.google.firebase.components.Dependency;
 import com.google.firebase.components.Qualified;
 import com.google.firebase.installations.FirebaseInstallationsApi;
+import com.google.firebase.perf.session.SessionManager;
 import com.google.firebase.remoteconfig.RemoteConfigComponent;
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -39,7 +40,8 @@ public class FirebasePerfRegistrarTest {
     FirebasePerfRegistrar firebasePerfRegistrar = new FirebasePerfRegistrar();
     List<Component<?>> components = firebasePerfRegistrar.getComponents();
 
-    assertThat(components).hasSize(3);
+    // FirebasePerformance, FirebasePerfEarly, SessionManager, LibraryVersionComponent
+    assertThat(components).hasSize(4);
 
     Component<?> firebasePerfComponent = components.get(0);
 
@@ -49,7 +51,8 @@ public class FirebasePerfRegistrarTest {
             Dependency.requiredProvider(RemoteConfigComponent.class),
             Dependency.required(FirebaseInstallationsApi.class),
             Dependency.requiredProvider(TransportFactory.class),
-            Dependency.required(FirebasePerfEarly.class));
+            Dependency.required(FirebasePerfEarly.class),
+            Dependency.required(SessionManager.class));
 
     assertThat(firebasePerfComponent.isLazy()).isTrue();
 
@@ -59,7 +62,8 @@ public class FirebasePerfRegistrarTest {
         .containsExactly(
             Dependency.required(Qualified.qualified(UiThread.class, Executor.class)),
             Dependency.required(FirebaseApp.class),
-            Dependency.optionalProvider(StartupTime.class));
+            Dependency.optionalProvider(StartupTime.class),
+            Dependency.required(SessionManager.class));
 
     assertThat(firebasePerfEarlyComponent.isLazy()).isFalse();
   }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/FirebasePerformanceTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/FirebasePerformanceTest.java
@@ -100,9 +100,9 @@ public class FirebasePerformanceTest {
     sharedPreferences.edit().clear().commit();
     DeviceCacheManager.clearInstance();
 
-    spyRemoteConfigManager = spy(RemoteConfigManager.getInstance());
     ConfigResolver.clearInstance();
     spyConfigResolver = spy(ConfigResolver.getInstance());
+    spyRemoteConfigManager = spy(ConfigResolver.getInstance().getRemoteConfigManager());
 
     spySessionManager = spy(SessionManager.getInstance());
     fakeDirectExecutorService = new FakeDirectExecutorService();

--- a/firebase-perf/src/test/java/com/google/firebase/perf/FirebasePerformanceTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/FirebasePerformanceTest.java
@@ -36,7 +36,10 @@ import com.google.firebase.installations.FirebaseInstallationsApi;
 import com.google.firebase.perf.config.ConfigResolver;
 import com.google.firebase.perf.config.DeviceCacheManager;
 import com.google.firebase.perf.config.RemoteConfigManager;
+import com.google.firebase.perf.session.PerfSession;
 import com.google.firebase.perf.session.SessionManager;
+import com.google.firebase.perf.session.gauges.GaugeManager;
+import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Constants;
 import com.google.firebase.perf.util.ImmutableBundle;
 import com.google.firebase.remoteconfig.RemoteConfigComponent;
@@ -104,7 +107,10 @@ public class FirebasePerformanceTest {
     spyConfigResolver = spy(ConfigResolver.getInstance());
     spyRemoteConfigManager = spy(ConfigResolver.getInstance().getRemoteConfigManager());
 
-    spySessionManager = spy(SessionManager.getInstance());
+    spySessionManager =
+        spy(
+            new SessionManager(
+                mock(GaugeManager.class), new PerfSession("sessionId", new Clock())));
     fakeDirectExecutorService = new FakeDirectExecutorService();
   }
 

--- a/firebase-perf/src/test/java/com/google/firebase/perf/PerformanceTests.kt
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/PerformanceTests.kt
@@ -30,6 +30,9 @@ import com.google.firebase.perf.metrics.HttpMetric
 import com.google.firebase.perf.metrics.Trace
 import com.google.firebase.perf.metrics.getTraceCounter
 import com.google.firebase.perf.metrics.getTraceCounterCount
+import com.google.firebase.perf.session.PerfSession
+import com.google.firebase.perf.session.SessionManager
+import com.google.firebase.perf.session.gauges.GaugeManager
 import com.google.firebase.perf.transport.TransportManager
 import com.google.firebase.perf.util.Clock
 import com.google.firebase.perf.util.Timer
@@ -104,6 +107,7 @@ class PerformanceTests : BaseTestCase() {
   @Mock lateinit var mockClock: Clock
 
   @Mock lateinit var mockAppStateMonitor: AppStateMonitor
+  @Mock lateinit var mockGaugeManager: GaugeManager
 
   @Captor lateinit var argMetricCaptor: ArgumentCaptor<NetworkRequestMetric>
 
@@ -119,6 +123,8 @@ class PerformanceTests : BaseTestCase() {
     `when`(timerMock.getMicros()).thenReturn(1000L)
     `when`(timerMock.getDurationMicros()).thenReturn(2000L).thenReturn(3000L)
     doAnswer { Timer(currentTime) }.`when`(mockClock).getTime()
+    val sessionManager = SessionManager(mockGaugeManager, PerfSession("sessionId", Clock()))
+    `when`(mockAppStateMonitor.getSessionManager()).thenReturn(sessionManager)
   }
 
   @Test

--- a/firebase-perf/src/test/java/com/google/firebase/perf/application/AppStateMonitorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/application/AppStateMonitorTest.java
@@ -40,7 +40,6 @@ import com.google.firebase.perf.config.DeviceCacheManager;
 import com.google.firebase.perf.metrics.NetworkRequestMetricBuilder;
 import com.google.firebase.perf.metrics.Trace;
 import com.google.firebase.perf.session.PerfSession;
-import com.google.firebase.perf.session.SessionManager;
 import com.google.firebase.perf.session.gauges.GaugeManager;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.util.Clock;
@@ -53,7 +52,6 @@ import com.google.testing.timing.FakeDirectExecutorService;
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -79,7 +77,6 @@ public class AppStateMonitorTest extends FirebasePerformanceTestBase {
 
   private Activity activity1;
   private Activity activity2;
-
 
   @Before
   public void setUp() {

--- a/firebase-perf/src/test/java/com/google/firebase/perf/application/FragmentStateMonitorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/application/FragmentStateMonitorTest.java
@@ -111,6 +111,7 @@ public class FragmentStateMonitorTest extends FirebasePerformanceTestBase {
 
     savedInstanceState = mock(Bundle.class);
     appStateMonitor = mock(AppStateMonitor.class);
+    when(appStateMonitor.getSessionManager()).thenReturn(sessionManager);
     mockFragment1 = mock(Fragment.class);
     mockFragment2 = mock(Fragment.class);
   }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/RemoteConfigManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/RemoteConfigManagerTest.java
@@ -76,8 +76,8 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
 
   @Test
   public void getInstance_verifiesSingleton() {
-    RemoteConfigManager instanceOne = RemoteConfigManager.getInstance();
-    RemoteConfigManager instanceTwo = RemoteConfigManager.getInstance();
+    RemoteConfigManager instanceOne = ConfigResolver.getInstance().getRemoteConfigManager();
+    RemoteConfigManager instanceTwo = ConfigResolver.getInstance().getRemoteConfigManager();
 
     assertThat(instanceOne).isSameInstanceAs(instanceTwo);
   }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/AppStartTraceTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/AppStartTraceTest.java
@@ -34,10 +34,8 @@ import android.os.SystemClock;
 import android.view.View;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.firebase.perf.FirebasePerformanceTestBase;
-import com.google.firebase.perf.application.AppStateMonitor;
 import com.google.firebase.perf.config.ConfigResolver;
 import com.google.firebase.perf.session.PerfSession;
-import com.google.firebase.perf.session.SessionManager;
 import com.google.firebase.perf.session.gauges.GaugeManager;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.util.Clock;
@@ -99,7 +97,7 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
 
   @After
   public void reset() {
-    SessionManager.getInstance().updatePerfSession(PerfSession.createWithId("randomSessionId"));
+    sessionManager.updatePerfSession(PerfSession.createWithId("randomSessionId"));
   }
 
   /** Test activity sequentially goes through onCreate()->onStart()->onResume() state change. */

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/AppStartTraceTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/AppStartTraceTest.java
@@ -36,7 +36,6 @@ import androidx.test.core.app.ApplicationProvider;
 import com.google.firebase.perf.FirebasePerformanceTestBase;
 import com.google.firebase.perf.config.ConfigResolver;
 import com.google.firebase.perf.session.PerfSession;
-import com.google.firebase.perf.session.gauges.GaugeManager;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Constants;
@@ -105,7 +104,8 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
   public void testLaunchActivity() {
     FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
     AppStartTrace trace =
-        new AppStartTrace(transportManager, clock, configResolver, sessionManager, fakeExecutorService);
+        new AppStartTrace(
+            transportManager, clock, configResolver, sessionManager, fakeExecutorService);
     trace.registerActivityLifecycleCallbacks(appContext);
     // first activity goes through onCreate()->onStart()->onResume() state change.
     currentTime = 1;
@@ -179,7 +179,8 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
   public void testInterleavedActivity() {
     FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
     AppStartTrace trace =
-        new AppStartTrace(transportManager, clock, configResolver, sessionManager, fakeExecutorService);
+        new AppStartTrace(
+            transportManager, clock, configResolver, sessionManager, fakeExecutorService);
     trace.registerActivityLifecycleCallbacks(appContext);
     // first activity onCreate()
     currentTime = 1;
@@ -216,7 +217,8 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
   public void testDelayedAppStart() {
     FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
     AppStartTrace trace =
-        new AppStartTrace(transportManager, clock, configResolver, sessionManager, fakeExecutorService);
+        new AppStartTrace(
+            transportManager, clock, configResolver, sessionManager, fakeExecutorService);
     trace.registerActivityLifecycleCallbacks(appContext);
     // Delays activity creation after 1 minute from app start time.
     currentTime =
@@ -243,7 +245,8 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
     FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
     Timer fakeTimer = spy(new Timer(currentTime));
     AppStartTrace trace =
-        new AppStartTrace(transportManager, clock, configResolver, sessionManager, fakeExecutorService);
+        new AppStartTrace(
+            transportManager, clock, configResolver, sessionManager, fakeExecutorService);
     trace.registerActivityLifecycleCallbacks(appContext);
     trace.setMainThreadRunnableTime(fakeTimer);
 
@@ -271,7 +274,8 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
     FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
     Timer fakeTimer = spy(new Timer(currentTime));
     AppStartTrace trace =
-        new AppStartTrace(transportManager, clock, configResolver, sessionManager, fakeExecutorService);
+        new AppStartTrace(
+            transportManager, clock, configResolver, sessionManager, fakeExecutorService);
     trace.registerActivityLifecycleCallbacks(appContext);
     trace.setMainThreadRunnableTime(fakeTimer);
 
@@ -304,7 +308,8 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
     when(configResolver.getIsExperimentTTIDEnabled()).thenReturn(true);
     FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
     AppStartTrace trace =
-        new AppStartTrace(transportManager, clock, configResolver, sessionManager, fakeExecutorService);
+        new AppStartTrace(
+            transportManager, clock, configResolver, sessionManager, fakeExecutorService);
     trace.registerActivityLifecycleCallbacks(appContext);
     // Simulate resume and manually stepping time forward
     ShadowSystemClock.advanceBy(Duration.ofMillis(1000));

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/NetworkRequestMetricBuilderTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/NetworkRequestMetricBuilderTest.java
@@ -61,6 +61,8 @@ public class NetworkRequestMetricBuilderTest extends FirebasePerformanceTestBase
   @Before
   public void setUp() {
     initMocks(this);
+    AppStateMonitor.resetInstance();
+    AppStateMonitor.getInstance(sessionManager);
     networkMetricBuilder =
         new NetworkRequestMetricBuilder(
             mockTransportManager, mockAppStateMonitor, mockGaugeManager, sessionManager);
@@ -235,7 +237,7 @@ public class NetworkRequestMetricBuilderTest extends FirebasePerformanceTestBase
 
     int numberOfSessionIds = metricBuilder.getSessions().size();
     PerfSession perfSession = PerfSession.createWithId("testSessionId");
-    SessionManager.getInstance().updatePerfSession(perfSession);
+    sessionManager.updatePerfSession(perfSession);
 
     assertThat(metricBuilder.getSessions().size()).isEqualTo(numberOfSessionIds + 1);
   }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/TraceMetricBuilderTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/TraceMetricBuilderTest.java
@@ -15,6 +15,7 @@
 package com.google.firebase.perf.metrics;
 
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.google.firebase.perf.FirebasePerformanceTestBase;
@@ -65,6 +66,7 @@ public class TraceMetricBuilderTest extends FirebasePerformanceTestBase {
             })
         .when(clock)
         .getTime();
+    when(appStateMonitor.getSessionManager()).thenReturn(sessionManager);
   }
 
   @Test

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/TraceTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/TraceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import android.content.Context;
@@ -76,6 +77,7 @@ public class TraceTest extends FirebasePerformanceTestBase {
     initMocks(this);
     doAnswer((Answer<Timer>) invocationOnMock -> new Timer(currentTime)).when(mockClock).getTime();
     arguments = ArgumentCaptor.forClass(TraceMetric.class);
+    when(mockAppStateMonitor.getSessionManager()).thenReturn(sessionManager);
 
     DeviceCacheManager.clearInstance();
     ConfigResolver.clearInstance();

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/TraceTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/TraceTest.java
@@ -79,6 +79,8 @@ public class TraceTest extends FirebasePerformanceTestBase {
 
     DeviceCacheManager.clearInstance();
     ConfigResolver.clearInstance();
+    AppStateMonitor.resetInstance();
+    AppStateMonitor.getInstance(sessionManager);
 
     appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit().clear().commit();
     ConfigResolver configResolver = ConfigResolver.getInstance();
@@ -1017,7 +1019,7 @@ public class TraceTest extends FirebasePerformanceTestBase {
     int numberOfSessionIds = trace.getSessions().size();
 
     PerfSession perfSession = PerfSession.createWithId("test_session_id");
-    SessionManager.getInstance().updatePerfSession(perfSession);
+    sessionManager.updatePerfSession(perfSession);
     assertThat(trace.getSessions()).hasSize(numberOfSessionIds + 1);
 
     trace.stop();

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/validator/FirebasePerfTraceValidatorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/validator/FirebasePerfTraceValidatorTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.google.firebase.perf.FirebasePerformanceTestBase;
@@ -280,6 +281,7 @@ public class FirebasePerfTraceValidatorTest extends FirebasePerformanceTestBase 
 
     TransportManager transportManager = mock(TransportManager.class);
     AppStateMonitor appStateMonitor = mock(AppStateMonitor.class);
+    when(appStateMonitor.getSessionManager()).thenReturn(sessionManager);
     ArgumentCaptor<TraceMetric> argMetric = ArgumentCaptor.forClass(TraceMetric.class);
 
     Trace trace = new Trace(traceName, transportManager, clock, appStateMonitor);

--- a/firebase-perf/src/test/java/com/google/firebase/perf/session/SessionManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/session/SessionManagerTest.java
@@ -61,13 +61,6 @@ public class SessionManagerTest extends FirebasePerformanceTestBase {
     initMocks(this);
     when(mockPerfSession.sessionId()).thenReturn(testSessionId(5));
     when(mockAppStateMonitor.isColdStart()).thenReturn(false);
-    AppStateMonitor.getInstance().setIsColdStart(false);
-  }
-
-  @Test
-  public void testInstanceCreation() {
-    assertThat(SessionManager.getInstance()).isNotNull();
-    assertThat(SessionManager.getInstance()).isEqualTo(SessionManager.getInstance());
   }
 
   @Test

--- a/firebase-perf/src/test/java/com/google/firebase/perf/session/gauges/GaugeManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/session/gauges/GaugeManagerTest.java
@@ -83,7 +83,6 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
     GaugeCounter.resetCounter();
   }
 
-
   @Before
   public void setUp() {
     fakeScheduledExecutorService = new FakeScheduledExecutorService();

--- a/firebase-perf/src/test/java/com/google/firebase/perf/transport/TransportManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/transport/TransportManagerTest.java
@@ -41,7 +41,6 @@ import com.google.firebase.perf.FirebasePerformance;
 import com.google.firebase.perf.FirebasePerformanceTestBase;
 import com.google.firebase.perf.application.AppStateMonitor;
 import com.google.firebase.perf.config.ConfigResolver;
-import com.google.firebase.perf.session.SessionManager;
 import com.google.firebase.perf.shadows.ShadowPreconditions;
 import com.google.firebase.perf.util.Constants;
 import com.google.firebase.perf.util.Constants.CounterNames;
@@ -1206,14 +1205,14 @@ public class TransportManagerTest extends FirebasePerformanceTestBase {
     when(mockPerfSession.sessionId()).thenReturn("sessionId");
     when(mockPerfSession.isSessionRunningTooLong()).thenReturn(true);
 
-    SessionManager.getInstance().setPerfSession(mockPerfSession);
-    String oldSessionId = SessionManager.getInstance().perfSession().sessionId();
-    assertThat(oldSessionId).isEqualTo(SessionManager.getInstance().perfSession().sessionId());
+    sessionManager.setPerfSession(mockPerfSession);
+    String oldSessionId = sessionManager.perfSession().sessionId();
+    assertThat(oldSessionId).isEqualTo(sessionManager.perfSession().sessionId());
 
     testTransportManager.log(createValidTraceMetric(), ApplicationProcessState.BACKGROUND);
     fakeExecutorService.runAll();
 
-    assertThat(oldSessionId).isEqualTo(SessionManager.getInstance().perfSession().sessionId());
+    assertThat(oldSessionId).isEqualTo(sessionManager.perfSession().sessionId());
   }
 
   @Test
@@ -1223,14 +1222,14 @@ public class TransportManagerTest extends FirebasePerformanceTestBase {
     when(mockPerfSession.sessionId()).thenReturn("sessionId");
     when(mockPerfSession.isSessionRunningTooLong()).thenReturn(true);
 
-    SessionManager.getInstance().setPerfSession(mockPerfSession);
-    String oldSessionId = SessionManager.getInstance().perfSession().sessionId();
-    assertThat(oldSessionId).isEqualTo(SessionManager.getInstance().perfSession().sessionId());
+    sessionManager.setPerfSession(mockPerfSession);
+    String oldSessionId = sessionManager.perfSession().sessionId();
+    assertThat(oldSessionId).isEqualTo(sessionManager.perfSession().sessionId());
 
     testTransportManager.log(createValidNetworkRequestMetric(), ApplicationProcessState.BACKGROUND);
     fakeExecutorService.runAll();
 
-    assertThat(oldSessionId).isEqualTo(SessionManager.getInstance().perfSession().sessionId());
+    assertThat(oldSessionId).isEqualTo(sessionManager.perfSession().sessionId());
   }
 
   @Test
@@ -1240,14 +1239,14 @@ public class TransportManagerTest extends FirebasePerformanceTestBase {
     when(mockPerfSession.sessionId()).thenReturn("sessionId");
     when(mockPerfSession.isSessionRunningTooLong()).thenReturn(true);
 
-    SessionManager.getInstance().setPerfSession(mockPerfSession);
-    String oldSessionId = SessionManager.getInstance().perfSession().sessionId();
-    assertThat(oldSessionId).isEqualTo(SessionManager.getInstance().perfSession().sessionId());
+    sessionManager.setPerfSession(mockPerfSession);
+    String oldSessionId = sessionManager.perfSession().sessionId();
+    assertThat(oldSessionId).isEqualTo(sessionManager.perfSession().sessionId());
 
     testTransportManager.log(createValidGaugeMetric(), ApplicationProcessState.FOREGROUND);
     fakeExecutorService.runAll();
 
-    assertThat(oldSessionId).isEqualTo(SessionManager.getInstance().perfSession().sessionId());
+    assertThat(oldSessionId).isEqualTo(sessionManager.perfSession().sessionId());
   }
 
   @Test
@@ -1257,14 +1256,14 @@ public class TransportManagerTest extends FirebasePerformanceTestBase {
     when(mockPerfSession.sessionId()).thenReturn("sessionId");
     when(mockPerfSession.isSessionRunningTooLong()).thenReturn(false);
 
-    SessionManager.getInstance().setPerfSession(mockPerfSession);
-    String oldSessionId = SessionManager.getInstance().perfSession().sessionId();
-    assertThat(oldSessionId).isEqualTo(SessionManager.getInstance().perfSession().sessionId());
+    sessionManager.setPerfSession(mockPerfSession);
+    String oldSessionId = sessionManager.perfSession().sessionId();
+    assertThat(oldSessionId).isEqualTo(sessionManager.perfSession().sessionId());
 
     testTransportManager.log(createValidTraceMetric(), ApplicationProcessState.BACKGROUND);
     fakeExecutorService.runAll();
 
-    assertThat(oldSessionId).isEqualTo(SessionManager.getInstance().perfSession().sessionId());
+    assertThat(oldSessionId).isEqualTo(sessionManager.perfSession().sessionId());
   }
 
   @Test
@@ -1274,14 +1273,14 @@ public class TransportManagerTest extends FirebasePerformanceTestBase {
     when(mockPerfSession.sessionId()).thenReturn("sessionId");
     when(mockPerfSession.isSessionRunningTooLong()).thenReturn(false);
 
-    SessionManager.getInstance().setPerfSession(mockPerfSession);
-    String oldSessionId = SessionManager.getInstance().perfSession().sessionId();
-    assertThat(oldSessionId).isEqualTo(SessionManager.getInstance().perfSession().sessionId());
+    sessionManager.setPerfSession(mockPerfSession);
+    String oldSessionId = sessionManager.perfSession().sessionId();
+    assertThat(oldSessionId).isEqualTo(sessionManager.perfSession().sessionId());
 
     testTransportManager.log(createValidNetworkRequestMetric(), ApplicationProcessState.BACKGROUND);
     fakeExecutorService.runAll();
 
-    assertThat(oldSessionId).isEqualTo(SessionManager.getInstance().perfSession().sessionId());
+    assertThat(oldSessionId).isEqualTo(sessionManager.perfSession().sessionId());
   }
 
   @Test
@@ -1291,14 +1290,14 @@ public class TransportManagerTest extends FirebasePerformanceTestBase {
     when(mockPerfSession.sessionId()).thenReturn("sessionId");
     when(mockPerfSession.isSessionRunningTooLong()).thenReturn(false);
 
-    SessionManager.getInstance().setPerfSession(mockPerfSession);
-    String oldSessionId = SessionManager.getInstance().perfSession().sessionId();
-    assertThat(oldSessionId).isEqualTo(SessionManager.getInstance().perfSession().sessionId());
+    sessionManager.setPerfSession(mockPerfSession);
+    String oldSessionId = sessionManager.perfSession().sessionId();
+    assertThat(oldSessionId).isEqualTo(sessionManager.perfSession().sessionId());
 
     testTransportManager.log(createValidGaugeMetric(), ApplicationProcessState.FOREGROUND);
     fakeExecutorService.runAll();
 
-    assertThat(oldSessionId).isEqualTo(SessionManager.getInstance().perfSession().sessionId());
+    assertThat(oldSessionId).isEqualTo(sessionManager.perfSession().sessionId());
   }
 
   // endregion
@@ -1423,7 +1422,8 @@ public class TransportManagerTest extends FirebasePerformanceTestBase {
           mockRateLimiter,
           mockAppStateMonitor,
           mockFlgTransport,
-          fakeExecutorService);
+          fakeExecutorService,
+          sessionManager);
 
     } else {
       testTransportManager.setInitialized(false);


### PR DESCRIPTION
  **Summary**

  Phase 2 of the SessionManager dependency-injection migration for Firebase Performance.

  This continues the work started in #7675 (Phase 1: RemoteConfigManager refactor + SessionManager refactor groundwork) by fully eliminating the SessionManager.getInstance() static singleton in favor of Dagger-managed construction and explicit dependency passing.

  **Changes**
  - Remove SessionManager static singleton — Delete the private no-arg constructor and getInstance(). The Dagger component factory in FirebasePerfRegistrar now constructs SessionManager directly, and it is provided as a proper DI component.
  - Thread SessionManager through AppStateMonitor — Add getInstance(SessionManager) seeded-init overload so FirebasePerfEarly injects the DI-managed instance at startup. Add getSessionManager() accessor for downstream consumers.
  - Remove SessionManager.getInstance() from Trace — Resolve SessionManager via AppStateMonitor.getSessionManager() (with a safe fallback for tests). The Parcel deserialization path uses TransportManager.getInstance().getSessionManager().
  - Remove SessionManager.getInstance() from NetworkRequestMetricBuilder — Obtain SessionManager via AppStateMonitor.getInstance().getSessionManager().
  - Add getSessionManager() to TransportManager — Thread SessionManager through initializeForTest() so tests can supply the correct
  instance.
  - Update all tests — Adapt FirebasePerfRegistrarTest, FirebasePerformanceTest, AppStartTraceTest, TraceTest,
  NetworkRequestMetricBuilderTest, and TransportManagerTest to use the new DI-based patterns instead of the removed singleton.


  **Motivation**
  Removing the static singleton makes SessionManager's lifecycle explicit and testable, eliminates hidden global state, and aligns with the broader AQS (Android Quality Sessions) migration where session identity is provided by Firebase Sessions rather than managed internally.