### PR TITLE
Add turnComplete to API

### DIFF
--- a/ai-logic/firebase-ai/CHANGELOG.md
+++ b/ai-logic/firebase-ai/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [feature] Added the `turnComplete` argument to multiple `LiveSession.send()` methods.
 - [deprecated] All Imagen models are deprecated and will shut down as early as June 2026.
   As a replacement, you can [migrate your apps to use Gemini Image models (the "Nano Banana" models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration).
 - [feature] Added support for Chat interactions using server prompt templates (#7986)

--- a/ai-logic/firebase-ai/api.txt
+++ b/ai-logic/firebase-ai/api.txt
@@ -1292,8 +1292,10 @@ package com.google.firebase.ai.type {
     method public boolean isAudioConversationActive();
     method public boolean isClosed();
     method public kotlinx.coroutines.flow.Flow<com.google.firebase.ai.type.LiveServerMessage> receive();
-    method public suspend Object? send(com.google.firebase.ai.type.Content content, kotlin.coroutines.Continuation<? super kotlin.Unit>);
-    method public suspend Object? send(String text, kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    method public suspend Object? send(com.google.firebase.ai.type.Content content, boolean turnComplete = true, kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    method public suspend Object? send(com.google.firebase.ai.type.Content content, kotlin.coroutines.Continuation<? super kotlin.Unit> = true);
+    method public suspend Object? send(String text, boolean turnComplete = true, kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    method public suspend Object? send(String text, kotlin.coroutines.Continuation<? super kotlin.Unit> = true);
     method public suspend Object? sendAudioRealtime(com.google.firebase.ai.type.InlineData audio, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? sendFunctionResponse(java.util.List<com.google.firebase.ai.type.FunctionResponsePart> functionList, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method @Deprecated public suspend Object? sendMediaStream(java.util.List<com.google.firebase.ai.type.MediaData> mediaChunks, kotlin.coroutines.Continuation<? super kotlin.Unit>);

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveSession.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/LiveSession.kt
@@ -441,10 +441,12 @@ internal constructor(
    * Calling this after [startAudioConversation] will play the response audio immediately.
    *
    * @param content Client [Content] to be sent to the model.
+   * @param turnComplete Whether the user's input turn has finished.
    */
-  public suspend fun send(content: Content) {
+  @JvmOverloads
+  public suspend fun send(content: Content, turnComplete: Boolean = true) {
     sendFrame(
-      BidiGenerateContentClientContentSetup(listOf(content.toInternal()), true).toInternal()
+      BidiGenerateContentClientContentSetup(listOf(content.toInternal()), turnComplete).toInternal()
     )
   }
 
@@ -468,9 +470,11 @@ internal constructor(
    * Calling this after [startAudioConversation] will play the response audio immediately.
    *
    * @param text Text to be sent to the model.
+   * @param turnComplete Whether the user's input turn has finished.
    */
-  public suspend fun send(text: String) {
-    FirebaseAIException.catchAsync { send(Content.Builder().text(text).build()) }
+  @JvmOverloads
+  public suspend fun send(text: String, turnComplete: Boolean = true) {
+    FirebaseAIException.catchAsync { send(Content.Builder().text(text).build(), turnComplete) }
   }
 
   /**


### PR DESCRIPTION
`turnComplete` was missing from the LiveAPI implementation on Android, but was present on other platform. This PR introduces it as an optional parameter with the previous method signature present as an overload, to maintain compatibility.
Having `turnComplete` available will let developers send content without ending the user's conversation turn and have more control over the functionality of the model.