### PR TITLE
dataconnect(test): fix test flakiness in AuthIntegrationTest.kt

### DIFF
--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/AuthIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/AuthIntegrationTest.kt
@@ -17,7 +17,6 @@
 package com.google.firebase.dataconnect
 
 import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.dataconnect.core.FirebaseDataConnectInternal
 import com.google.firebase.dataconnect.testutil.DataConnectBackend
 import com.google.firebase.dataconnect.testutil.DataConnectIntegrationTestBase
 import com.google.firebase.dataconnect.testutil.InProcessDataConnectGrpcServer
@@ -44,6 +43,7 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.next
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.random.Random
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toCollection
 import kotlinx.coroutines.launch
@@ -70,10 +70,10 @@ class AuthIntegrationTest : DataConnectIntegrationTestBase() {
 
   @Test
   fun authenticatedRequestsAreSuccessful() = runTest {
-    signIn()
     val person1Id = Arb.alphanumericString(prefix = "person1Id").next()
     val person2Id = Arb.alphanumericString(prefix = "person2Id").next()
     val person3Id = Arb.alphanumericString(prefix = "person3Id").next()
+    signIn(personSchema.dataConnect)
 
     personSchema.createPersonAuth(id = person1Id, name = "TestName1", age = 42).execute()
     personSchema.createPersonAuth(id = person2Id, name = "TestName2", age = 43).execute()
@@ -85,7 +85,7 @@ class AuthIntegrationTest : DataConnectIntegrationTestBase() {
 
   @Test
   fun queryFailsAfterUserSignsOut() = runTest {
-    signIn()
+    signIn(personSchema.dataConnect)
     // Verify that we are signed in by executing a query, which should succeed.
     personSchema.getPersonAuth(id = "foo").execute()
     signOut()
@@ -98,7 +98,7 @@ class AuthIntegrationTest : DataConnectIntegrationTestBase() {
 
   @Test
   fun mutationFailsAfterUserSignsOut() = runTest {
-    signIn()
+    signIn(personSchema.dataConnect)
     // Verify that we are signed in by executing a mutation, which should succeed.
     personSchema.createPersonAuth(id = Random.nextAlphanumericString(20), name = "foo").execute()
     signOut()
@@ -115,20 +115,20 @@ class AuthIntegrationTest : DataConnectIntegrationTestBase() {
 
   @Test
   fun queryShouldRetryOnUnauthenticated() = runTest {
-    signIn()
     val responseData = buildStructProto { put("foo", key) }
     val executeQueryResponse = executeQueryResponse { data = responseData }
     val grpcServer =
       inProcessDataConnectGrpcServer.newInstance(
         errors = listOf(Status.UNAUTHENTICATED),
-        executeQueryResponse = executeQueryResponse
+        executeQueryResponse = executeQueryResponse,
+        responseDelay = 1.seconds, // avoid getting the same access token from auth emulator
       )
     val authTokens = CopyOnWriteArrayList<String?>()
     backgroundScope.launch {
       grpcServer.metadatas.map { it.get(firebaseAuthTokenHeader) }.toCollection(authTokens)
     }
     val dataConnect = dataConnectFactory.newInstance(auth.app, grpcServer)
-    (dataConnect as FirebaseDataConnectInternal).awaitAuthReady()
+    signIn(dataConnect)
     val operationName = Arb.dataConnect.operationName().next(rs)
     val queryRef =
       dataConnect.query(operationName, Unit, serializer<TestData>(), serializer<Unit>())
@@ -144,20 +144,20 @@ class AuthIntegrationTest : DataConnectIntegrationTestBase() {
 
   @Test
   fun mutationShouldRetryOnUnauthenticated() = runTest {
-    signIn()
     val responseData = buildStructProto { put("foo", key) }
     val executeMutationResponse = executeMutationResponse { data = responseData }
     val grpcServer =
       inProcessDataConnectGrpcServer.newInstance(
         errors = listOf(Status.UNAUTHENTICATED),
-        executeMutationResponse = executeMutationResponse
+        executeMutationResponse = executeMutationResponse,
+        responseDelay = 1.seconds, // avoid getting the same access token from auth emulator
       )
     val authTokens = CopyOnWriteArrayList<String?>()
     backgroundScope.launch {
       grpcServer.metadatas.map { it.get(firebaseAuthTokenHeader) }.toCollection(authTokens)
     }
     val dataConnect = dataConnectFactory.newInstance(auth.app, grpcServer)
-    (dataConnect as FirebaseDataConnectInternal).awaitAuthReady()
+    signIn(dataConnect)
     val operationName = Arb.dataConnect.operationName().next(rs)
     val mutationRef =
       dataConnect.mutation(operationName, Unit, serializer<TestData>(), serializer<Unit>())
@@ -173,12 +173,12 @@ class AuthIntegrationTest : DataConnectIntegrationTestBase() {
 
   @Test
   fun queryShouldOnlyRetryOnUnauthenticatedOnce() = runTest {
-    signIn()
     val grpcServer =
       inProcessDataConnectGrpcServer.newInstance(
         errors = listOf(Status.UNAUTHENTICATED, Status.UNAUTHENTICATED),
       )
     val dataConnect = dataConnectFactory.newInstance(auth.app, grpcServer)
+    signIn(dataConnect)
     val operationName = Arb.dataConnect.operationName().next(rs)
     val queryRef = dataConnect.query(operationName, Unit, serializer<Unit>(), serializer<Unit>())
 
@@ -189,12 +189,13 @@ class AuthIntegrationTest : DataConnectIntegrationTestBase() {
 
   @Test
   fun mutationShouldOnlyRetryOnUnauthenticatedOnce() = runTest {
-    signIn()
     val grpcServer =
       inProcessDataConnectGrpcServer.newInstance(
         errors = listOf(Status.UNAUTHENTICATED, Status.UNAUTHENTICATED),
+        responseDelay = 1.seconds, // avoid getting the same access token from auth emulator
       )
     val dataConnect = dataConnectFactory.newInstance(auth.app, grpcServer)
+    signIn(dataConnect)
     val operationName = Arb.dataConnect.operationName().next(rs)
     val mutationRef =
       dataConnect.mutation(operationName, Unit, serializer<Unit>(), serializer<Unit>())
@@ -204,8 +205,8 @@ class AuthIntegrationTest : DataConnectIntegrationTestBase() {
     thrownException.asClue { it.status shouldBe Status.UNAUTHENTICATED }
   }
 
-  private suspend fun signIn() {
-    personSchema.dataConnect.awaitAuthReady()
+  private suspend fun signIn(dataConnect: FirebaseDataConnect) {
+    dataConnect.awaitAuthReady()
     val authResult = auth.run { signInAnonymously().await() }
     withClue("authResult.user returned from signInAnonymously()") {
       authResult.user.shouldNotBeNull()

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/AuthIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/AuthIntegrationTest.kt
@@ -176,6 +176,7 @@ class AuthIntegrationTest : DataConnectIntegrationTestBase() {
     val grpcServer =
       inProcessDataConnectGrpcServer.newInstance(
         errors = listOf(Status.UNAUTHENTICATED, Status.UNAUTHENTICATED),
+        responseDelay = 1.seconds, // avoid getting the same access token from auth emulator
       )
     val dataConnect = dataConnectFactory.newInstance(auth.app, grpcServer)
     signIn(dataConnect)

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/testutil/InProcessDataConnectGrpcServer.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/testutil/InProcessDataConnectGrpcServer.kt
@@ -36,6 +36,7 @@ import io.grpc.Status
 import io.grpc.StatusException
 import io.grpc.okhttp.OkHttpServerBuilder
 import io.grpc.stub.StreamObserver
+import kotlin.time.Duration
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -53,32 +54,40 @@ class InProcessDataConnectGrpcServer :
   fun newInstance(
     errors: List<Status>? = null,
     executeQueryResponse: ExecuteQueryResponse? = null,
-    executeMutationResponse: ExecuteMutationResponse? = null
+    executeMutationResponse: ExecuteMutationResponse? = null,
+    responseDelay: Duration? = null,
   ): ServerInfo =
     createInstance(
       errors = errors,
       executeQueryResponse = executeQueryResponse,
-      executeMutationResponse = executeMutationResponse
+      executeMutationResponse = executeMutationResponse,
+      responseDelay = responseDelay,
     )
 
   override fun createInstance(params: Params?): ServerInfo {
     return createInstance(
       params?.errors,
       params?.executeQueryResponse,
-      params?.executeMutationResponse
+      params?.executeMutationResponse,
+      params?.responseDelay,
     )
   }
 
   private fun createInstance(
-    errors: List<Status>? = null,
-    executeQueryResponse: ExecuteQueryResponse? = null,
-    executeMutationResponse: ExecuteMutationResponse? = null
+    errors: List<Status>?,
+    executeQueryResponse: ExecuteQueryResponse?,
+    executeMutationResponse: ExecuteMutationResponse?,
+    responseDelay: Duration?,
   ): ServerInfo {
-    val serverInterceptor = ServerInterceptorImpl(errors ?: Params.defaults.errors)
+    val serverInterceptor =
+      ServerInterceptorImpl(
+        errors ?: Params.defaults.errors,
+        responseDelay ?: Params.defaults.responseDelay,
+      )
     val connectorService =
       ConnectorServiceImpl(
         executeQueryResponse ?: Params.defaults.executeQueryResponse,
-        executeMutationResponse ?: Params.defaults.executeMutationResponse
+        executeMutationResponse ?: Params.defaults.executeMutationResponse,
       )
     val grpcServer =
       OkHttpServerBuilder.forPort(0, InsecureServerCredentials.create())
@@ -92,7 +101,8 @@ class InProcessDataConnectGrpcServer :
   data class Params(
     val errors: List<Status> = emptyList(),
     val executeQueryResponse: ExecuteQueryResponse? = null,
-    val executeMutationResponse: ExecuteMutationResponse? = null
+    val executeMutationResponse: ExecuteMutationResponse? = null,
+    val responseDelay: Duration? = null,
   ) {
     companion object {
       val defaults = Params()
@@ -105,7 +115,8 @@ class InProcessDataConnectGrpcServer :
 
   data class ServerInfo(val server: Server, val metadatas: Flow<Metadata>)
 
-  private class ServerInterceptorImpl(errors: List<Status> = emptyList()) : ServerInterceptor {
+  private class ServerInterceptorImpl(errors: List<Status>, private val responseDelay: Duration?) :
+    ServerInterceptor {
 
     private val errors = errors.toList().iterator()
 
@@ -121,6 +132,8 @@ class InProcessDataConnectGrpcServer :
     ): ServerCall.Listener<ReqT> {
       check(_metadatas.tryEmit(headers)) { "_metadatas.tryEmit(headers) failed" }
 
+      responseDelay?.let { Thread.sleep(it.inWholeMilliseconds) }
+
       synchronized(errors) {
         if (errors.hasNext()) {
           throw StatusException(errors.next())
@@ -132,8 +145,8 @@ class InProcessDataConnectGrpcServer :
   }
 
   private class ConnectorServiceImpl(
-    val executeQueryResponse: ExecuteQueryResponse? = null,
-    val executeMutationResponse: ExecuteMutationResponse? = null
+    val executeQueryResponse: ExecuteQueryResponse?,
+    val executeMutationResponse: ExecuteMutationResponse?,
   ) : ConnectorServiceGrpc.ConnectorServiceImplBase() {
     override fun executeQuery(
       request: ExecuteQueryRequest,


### PR DESCRIPTION
Fixes test flakiness in `AuthIntegrationTest.kt` by ensuring that `signIn()` waits for auth to be ready on the correct `FirebaseDataConnect` instance and by introducing a response delay in the mock gRPC server to prevent the reuse of stale auth tokens from the emulator.

The delay works around behaviour of the Firebase Auth emulator that it will produce identical tokens if called in rapid succession because it uses the current time as a basis for the tokens that it returns.

### Highlights
- Updated `AuthIntegrationTest` to pass the `FirebaseDataConnect` instance to `signIn()`, ensuring the object is ready for auth operations.
- Added a `responseDelay` parameter to `InProcessDataConnectGrpcServer` to simulate network latency and allow time for token updates.
- Modified several tests in `AuthIntegrationTest` to use the new `responseDelay`, specifically to avoid receiving the same access token twice from the auth emulator during retries.

### Changelog
<details>
<summary>View file-level changes</summary>

- `AuthIntegrationTest.kt`: Refactored `signIn` to accept a `dataConnect` instance, updated test cases to use this instance, and added delays to tests that retry on unauthenticated errors.
- `InProcessDataConnectGrpcServer.kt`: Added support for a configurable `responseDelay` in the mock gRPC server using a `ServerInterceptor`.
</details>