### PR TITLE
dataconnect(change): refactor toCompactString() for future code reuse

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -8,7 +8,7 @@
 - [changed] Internal refactor to use immutable byte arrays.
   ([#7957](https://github.com/firebase/firebase-android-sdk/pull/7957))
 - [changed] Internal refactor for calculating debug logging strings.
-  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
+  ([#8024](https://github.com/firebase/firebase-android-sdk/pull/8024))
 
 # 17.2.0
 

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -7,6 +7,8 @@
   ([#7910](https://github.com/firebase/firebase-android-sdk/pull/7910))
 - [changed] Internal refactor to use immutable byte arrays.
   ([#7957](https://github.com/firebase/firebase-android-sdk/pull/7957))
+- [changed] Internal refactor for calculating debug logging strings.
+  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
 
 # 17.2.0
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/DeserializeUtils.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/DeserializeUtils.kt
@@ -36,14 +36,9 @@ internal object DeserializeUtils {
       when (it.kindCase) {
         Value.KindCase.STRING_VALUE -> DataConnectPathSegment.Field(it.stringValue)
         Value.KindCase.NUMBER_VALUE -> DataConnectPathSegment.ListIndex(it.numberValue.toInt())
-        // The cases below are expected to never occur; however, implement some logic for them
+        // The other cases are expected to never occur; however, implement some logic for them
         // to avoid things like throwing exceptions in those cases.
-        Value.KindCase.NULL_VALUE -> DataConnectPathSegment.Field("null")
-        Value.KindCase.BOOL_VALUE -> DataConnectPathSegment.Field(it.boolValue.toString())
-        Value.KindCase.LIST_VALUE -> DataConnectPathSegment.Field(it.listValue.toCompactString())
-        Value.KindCase.STRUCT_VALUE ->
-          DataConnectPathSegment.Field(it.structValue.toCompactString())
-        else -> DataConnectPathSegment.Field(it.toString())
+        else -> DataConnectPathSegment.Field(it.toCompactString())
       }
     }
 }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/DeserializeUtils.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/DeserializeUtils.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.dataconnect.util
+
+import com.google.firebase.dataconnect.DataConnectPathSegment
+import com.google.firebase.dataconnect.core.DataConnectOperationFailureResponseImpl
+import com.google.firebase.dataconnect.util.ProtoUtil.toCompactString
+import com.google.protobuf.ListValue
+import com.google.protobuf.Value
+import google.firebase.dataconnect.proto.GraphqlError
+
+internal object DeserializeUtils {
+
+  fun GraphqlError.toErrorInfoImpl() =
+    DataConnectOperationFailureResponseImpl.ErrorInfoImpl(
+      message = message,
+      path = path.toPathSegment(),
+    )
+
+  private fun ListValue.toPathSegment() =
+    valuesList.map {
+      when (it.kindCase) {
+        Value.KindCase.STRING_VALUE -> DataConnectPathSegment.Field(it.stringValue)
+        Value.KindCase.NUMBER_VALUE -> DataConnectPathSegment.ListIndex(it.numberValue.toInt())
+        // The cases below are expected to never occur; however, implement some logic for them
+        // to avoid things like throwing exceptions in those cases.
+        Value.KindCase.NULL_VALUE -> DataConnectPathSegment.Field("null")
+        Value.KindCase.BOOL_VALUE -> DataConnectPathSegment.Field(it.boolValue.toString())
+        Value.KindCase.LIST_VALUE -> DataConnectPathSegment.Field(it.listValue.toCompactString())
+        Value.KindCase.STRUCT_VALUE ->
+          DataConnectPathSegment.Field(it.structValue.toCompactString())
+        else -> DataConnectPathSegment.Field(it.toString())
+      }
+    }
+}

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/ProtoUtil.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/ProtoUtil.kt
@@ -18,8 +18,8 @@ package com.google.firebase.dataconnect.util
 
 import com.google.firebase.dataconnect.DataConnectPath
 import com.google.firebase.dataconnect.DataConnectPathSegment
-import com.google.firebase.dataconnect.core.DataConnectGrpcClientGlobals.toErrorInfoImpl
 import com.google.firebase.dataconnect.toPathString
+import com.google.firebase.dataconnect.util.DeserializeUtils.toErrorInfoImpl
 import com.google.firebase.dataconnect.util.ProtoUtil.nullProtoValue
 import com.google.firebase.dataconnect.util.ProtoUtil.toValueProto
 import com.google.protobuf.Duration
@@ -37,6 +37,8 @@ import google.firebase.dataconnect.proto.ExecuteMutationRequest
 import google.firebase.dataconnect.proto.ExecuteMutationResponse
 import google.firebase.dataconnect.proto.ExecuteQueryRequest
 import google.firebase.dataconnect.proto.ExecuteQueryResponse
+import google.firebase.dataconnect.proto.GraphqlError
+import google.firebase.dataconnect.proto.GraphqlResponseExtensions
 import google.firebase.dataconnect.proto.ServiceInfo
 import java.io.BufferedWriter
 import java.io.CharArrayWriter
@@ -223,30 +225,37 @@ internal object ProtoUtil {
 
   fun ExecuteQueryResponse.toStructProto(): Struct = buildStructProto {
     if (hasData()) put("data", data)
-    putList("errors") { errorsList.forEach { add(it.toErrorInfoImpl().toString()) } }
-
+    if (errorsCount > 0) {
+      put("errors", errorsList)
+    }
     if (hasExtensions()) {
-      putStruct("extensions") {
-        putList("data_connect") {
-          extensions.dataConnectList.forEach { dataConnectProperties ->
-            addStruct {
-              if (dataConnectProperties.hasPath()) {
-                put("path", dataConnectProperties.path.toDataConnectPath().toPathString())
-              }
-              dataConnectProperties.entityId
-                .takeIf { it.isNotEmpty() }
-                ?.let { put("entity_id", it) }
-              dataConnectProperties.entityIdsList
-                .takeIf { it.isNotEmpty() }
-                ?.let { putList("entity_ids") { it.forEach(::add) } }
-              if (dataConnectProperties.hasMaxAge()) {
-                put("max_age", dataConnectProperties.maxAge.toHumanFriendlyString())
-              }
+      put("extensions", extensions)
+    }
+  }
+
+  fun StructProtoBuilder.put(key: String, extensions: GraphqlResponseExtensions) {
+    putStruct(key) {
+      putList("data_connect") {
+        extensions.dataConnectList.forEach { dataConnectProperties ->
+          addStruct {
+            if (dataConnectProperties.hasPath()) {
+              put("path", dataConnectProperties.path.toDataConnectPath().toPathString())
+            }
+            dataConnectProperties.entityId.takeIf { it.isNotEmpty() }?.let { put("entity_id", it) }
+            dataConnectProperties.entityIdsList
+              .takeIf { it.isNotEmpty() }
+              ?.let { putList("entity_ids") { it.forEach(::add) } }
+            if (dataConnectProperties.hasMaxAge()) {
+              put("max_age", dataConnectProperties.maxAge.toHumanFriendlyString())
             }
           }
         }
       }
     }
+  }
+
+  fun StructProtoBuilder.put(key: String, errors: Collection<GraphqlError>) {
+    putList(key) { errors.forEach { add(it.toErrorInfoImpl().toString()) } }
   }
 
   fun Duration.toHumanFriendlyString(): String = humanFriendlyStringForDuration(seconds, nanos)
@@ -508,6 +517,10 @@ internal class StructProtoBuilder(struct: Struct? = null) {
 
   fun put(key: String, value: ListValue?) {
     builder.putFields(key, value?.toValueProto() ?: nullProtoValue)
+  }
+
+  fun putValue(key: String, value: Value?) {
+    builder.putFields(key, value ?: nullProtoValue)
   }
 
   fun putList(key: String, block: ListValueProtoBuilder.() -> Unit) {

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/ProtoUtil.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/ProtoUtil.kt
@@ -519,10 +519,6 @@ internal class StructProtoBuilder(struct: Struct? = null) {
     builder.putFields(key, value?.toValueProto() ?: nullProtoValue)
   }
 
-  fun putValue(key: String, value: Value?) {
-    builder.putFields(key, value ?: nullProtoValue)
-  }
-
   fun putList(key: String, block: ListValueProtoBuilder.() -> Unit) {
     val initialValue = builder.getFieldsOrDefault(key, Value.getDefaultInstance()).listValueOrNull
     builder.putFields(key, ListValueProtoBuilder(initialValue).apply(block).build().toValueProto())


### PR DESCRIPTION
This PR refactors data connect's internal logic for calculating debug logging strings, specifically focusing on the conversion of protobuf messages to compact string representations.

### Highlights
* Created a new `DeserializeUtils` utility class to centralize the conversion of protobuf `GraphqlError` and `ListValue` objects into internal data structures.
* Refactored `ProtoUtil.toStructProto()` to leverage `DeserializeUtils`.
* Enhanced `StructProtoBuilder` with new helper methods for handling `GraphqlResponseExtensions` and `GraphqlError` collections.

### Changelog
<details>
<summary>3 files changed</summary>

* **CHANGELOG.md**: Added a entry for the internal refactor of debug logging strings.
* **DeserializeUtils.kt**: Introduced this new utility class with methods to convert protobuf messages to internal types.
* **ProtoUtil.kt**: Refactored `toStructProto` and updated `StructProtoBuilder` with more efficient data handling methods.
</details>
