### PR TITLE
dataconnect(change): internal refactor of connectorResourceName variable names

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -7,6 +7,8 @@
   ([#7910](https://github.com/firebase/firebase-android-sdk/pull/7910))
 - [changed] Internal refactor to use immutable byte arrays.
   ([#7957](https://github.com/firebase/firebase-android-sdk/pull/7957))
+- [changed] Internal refactor to use more descriptive variable names.
+  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
 
 # 17.2.0
 

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -7,13 +7,10 @@
   ([#7910](https://github.com/firebase/firebase-android-sdk/pull/7910))
 - [changed] Internal refactor to use immutable byte arrays.
   ([#7957](https://github.com/firebase/firebase-android-sdk/pull/7957))
-<<<<<<< dconeybe/dataconnect/ConnectorResourceName
-- [changed] Internal refactor to use more descriptive variable names.
-  ([#8025](https://github.com/firebase/firebase-android-sdk/pull/8025))
-=======
 - [changed] Internal refactor for calculating debug logging strings.
   ([#8024](https://github.com/firebase/firebase-android-sdk/pull/8024))
->>>>>>> main
+- [changed] Internal refactor to use more descriptive variable names.
+  ([#8025](https://github.com/firebase/firebase-android-sdk/pull/8025))
 
 # 17.2.0
 

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -8,7 +8,7 @@
 - [changed] Internal refactor to use immutable byte arrays.
   ([#7957](https://github.com/firebase/firebase-android-sdk/pull/7957))
 - [changed] Internal refactor to use more descriptive variable names.
-  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
+  ([#8025](https://github.com/firebase/firebase-android-sdk/pull/8025))
 
 # 17.2.0
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClient.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClient.kt
@@ -47,7 +47,7 @@ internal class DataConnectGrpcClient(
   val instanceId: String
     get() = logger.nameWithId
 
-  private val requestName =
+  private val connectorResourceName =
     "projects/$projectId/" +
       "locations/${connector.location}" +
       "/services/${connector.serviceId}" +
@@ -67,7 +67,7 @@ internal class DataConnectGrpcClient(
     fetchPolicy: FetchPolicy,
   ): OperationResult {
     val request = executeQueryRequest {
-      this.name = requestName
+      this.name = connectorResourceName
       this.operationName = operationName
       this.variables = variables
     }
@@ -87,7 +87,7 @@ internal class DataConnectGrpcClient(
     callerSdkType: FirebaseDataConnect.CallerSdkType,
   ): OperationResult {
     val request = executeMutationRequest {
-      this.name = requestName
+      this.name = connectorResourceName
       this.operationName = operationName
       this.variables = variables
     }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClientUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClientUnitTest.kt
@@ -170,14 +170,14 @@ class DataConnectGrpcClientUnitTest {
         fetchPolicy
       )
 
-      val expectedName =
+      val expectedConnectorResourceName =
         "projects/${projectId}" +
           "/locations/${connectorConfig.location}" +
           "/services/${connectorConfig.serviceId}" +
           "/connectors/${connectorConfig.connector}"
       val expectedRequest =
         ExecuteQueryRequest.newBuilder()
-          .setName(expectedName)
+          .setName(expectedConnectorResourceName)
           .setOperationName(operationName)
           .setVariables(variables)
           .build()
@@ -200,14 +200,14 @@ class DataConnectGrpcClientUnitTest {
   fun `executeMutation() should send the right ExecuteMutationRequest`() = runTest {
     dataConnectGrpcClient.executeMutation(requestId, operationName, variables, callerSdkType)
 
-    val expectedName =
+    val expectedConnectorResourceName =
       "projects/${projectId}" +
         "/locations/${connectorConfig.location}" +
         "/services/${connectorConfig.serviceId}" +
         "/connectors/${connectorConfig.connector}"
     val expectedRequest =
       ExecuteMutationRequest.newBuilder()
-        .setName(expectedName)
+        .setName(expectedConnectorResourceName)
         .setOperationName(operationName)
         .setVariables(variables)
         .build()


### PR DESCRIPTION
Internal refactor in the Data Connect SDK to improve code clarity by renaming variables related to the connector resource name.

### Highlights
- Renamed `requestName` to `connectorResourceName` in `DataConnectGrpcClient` to more accurately reflect its contents.
- Updated unit tests to use the new variable naming convention.
- Added an entry to `CHANGELOG.md` documenting the change.

### Changelog

<details>

- **CHANGELOG.md**: Added an entry for the internal refactor and assigned the pull request number.
- **DataConnectGrpcClient.kt**: Renamed the private `requestName` property and its usages to `connectorResourceName`.
- **DataConnectGrpcClientUnitTest.kt**: Updated unit tests to reflect the variable name change from `expectedName` to `expectedConnectorResourceName`.

</details>
