### PR TITLE
[Proposal] Fix breadcrumb race condition

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+- [fixed] Fixed race condition that caused logs from background threads to not be attached to
+  reports in some cases [#8034]
+
+
 # 20.0.5
 
 - [fixed] Fixed a runtime crash that could occur in minified native apps when using the Crashlytics

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -16,6 +16,7 @@ package com.google.firebase.crashlytics.internal.common;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
@@ -456,6 +457,31 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
   @Test
   public void testBreadcrumbSourceIsRegistered() {
     Mockito.verify(mockBreadcrumbSource).registerBreadcrumbHandler(any(BreadcrumbHandler.class));
+  }
+
+  /**
+   * Regression test for https://github.com/firebase/firebase-android-sdk/issues/8034.
+   *
+   * <p>Verifies that a breadcrumb logged immediately before {@code logException} is written to disk
+   * before the non-fatal event snapshots the log. Prior to the fix, {@code log()} used
+   * {@code common.submit()} which completed as soon as the disk-write was enqueued, allowing the
+   * subsequent {@code logException()} task to read an empty log. The fix uses {@code submitTask()}
+   * so the common worker suspends until the disk write finishes.
+   */
+  @Test
+  public void testLog_breadcrumbIsWrittenBeforeLogExceptionReadsIt() throws Exception {
+    final String breadcrumb = "test breadcrumb";
+
+    crashlyticsCore.log(breadcrumb);
+    crashlyticsCore.logException(new RuntimeException("non-fatal"), Map.of());
+
+    // Awaiting common is sufficient: submitTask makes common suspend until diskWrite completes,
+    // so when this returns the log entry is guaranteed to be on disk.
+    crashlyticsWorkers.common.await();
+
+    final String logString = crashlyticsCore.getController().getLogString();
+    assertNotNull("Log should have been written before logException read it", logString);
+    assertTrue("Log should contain the breadcrumb", logString.contains(breadcrumb));
   }
 
   @Test

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -25,6 +25,7 @@ import android.os.StatFs;
 import android.util.Base64;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.tasks.SuccessContinuation;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
@@ -791,6 +792,12 @@ class CrashlyticsController {
 
   UserMetadata getUserMetadata() {
     return userMetadata;
+  }
+
+  @VisibleForTesting
+  @Nullable
+  String getLogString() {
+    return logFileManager.getLogString();
   }
 
   boolean isHandlingException() {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -330,11 +330,10 @@ public class CrashlyticsCore {
    */
   public void log(final String msg) {
     final long timestamp = System.currentTimeMillis() - startTime;
-    // queuing up on common worker to maintain the order
-    crashlyticsWorkers.common.submit(
-        () -> {
-          crashlyticsWorkers.diskWrite.submit(() -> controller.writeToLog(timestamp, msg));
-        });
+    // submitTask ensures the common worker waits for the diskWrite task to complete, ensuring
+    // that subsequent tasks on the common worker (e.g. logException) see this log entry.
+    crashlyticsWorkers.common.submitTask(
+        () -> crashlyticsWorkers.diskWrite.submit(() -> controller.writeToLog(timestamp, msg)));
   }
 
   public void setUserId(String identifier) {


### PR DESCRIPTION
## PR: Fix breadcrumb race condition — log() entry dropped before logException() reads it

## Summary

**Fixes:** https://github.com/firebase/firebase-android-sdk/issues/8034

- `Firebase.crashlytics.log()` breadcrumbs were silently dropped when called from a background thread immediately before `recordException()`.
- Root cause: a race condition between the `common` and `diskWrite` Crashlytics workers caused the non-fatal event to snapshot the log before the breadcrumb was written to disk.
- Fix: one-line change from `common.submit()` to `common.submitTask()` in `CrashlyticsCore.log()`, which suspends the common worker until the disk write completes.

## Root Cause

`CrashlyticsCore.log()` used a double-dispatch pattern:

```java
// BEFORE (buggy)
crashlyticsWorkers.common.submit(
    () -> {
        crashlyticsWorkers.diskWrite.submit(() -> controller.writeToLog(timestamp, msg));
    });
```

`CrashlyticsWorker.submit(Runnable)` chains the runnable onto the common queue and marks the task complete **as soon as the runnable returns** — not when the inner `diskWrite` task finishes. So the sequence was:

1. `log("breadcrumb")` → adds task **C1** to `common`: "enqueue writeToLog on diskWrite"
2. `logException(ex)` → adds task **C2** to `common`: "call writeNonFatalException"
3. `common` runs **C1**: calls `diskWrite.submit(writeToLog)` → C1 **completes immediately**
4. `common` runs **C2**: calls `writeNonFatalException` → calls `logFileManager.getLogString()`
   — the diskWrite task **D1** has been queued but not yet run → **log is empty → breadcrumb missing**
5. `diskWrite` eventually runs **D1**: `writeToLog` — but the event was already captured without it

The main-thread workaround happened to work because `Handler.post {}` batched both calls into a single posted block, accidentally serializing them in a way that masked the race.


## Fix

```java
// AFTER (fixed)
crashlyticsWorkers.common.submitTask(
    () -> crashlyticsWorkers.diskWrite.submit(() -> controller.writeToLog(timestamp, msg)));
```

`submitTask(Callable<Task<T>>)` sets the common worker's internal tail to the `Task` returned by `diskWrite.submit(...)`. Subsequent common tasks (like `logException`) are chained after that Task, so they cannot start until the disk write has completed.

## Test Plan

**New test:** `CrashlyticsCoreTest#testLog_breadcrumbIsWrittenBeforeLogExceptionReadsIt`

- Calls `log("test breadcrumb")` immediately followed by `logException(exception)` — reproducing the exact pattern reported in the issue.
- Awaits only `crashlyticsWorkers.common` (not diskWrite separately). With `submitTask`, awaiting `common` guarantees the `diskWrite` has also completed, so the log MUST be on disk.
- Asserts `logFileManager.getLogString()` is non-null and contains the breadcrumb.

Without the fix, awaiting `common` would NOT guarantee that `diskWrite` finished, making this assertion unreliable (the log might be empty at assertion time).

**Existing tests:** All existing tests in `:firebase-crashlytics` compile and run clean.

## Risks / Trade-offs

- **Slightly more serialized hot path:** `common` now suspends until each `writeToLog` disk write completes before processing the next task. In practice, `writeToLog` is fast (a small QueueFile append), and the previous behavior (fire-and-forget) was already incorrect per the documented contract ("queuing up on common worker to maintain the order").
- **No deadlock risk:** `diskWrite` never submits back to `common`, so no cycle.
