### PR TITLE
Add daily test reporting

### DIFF
--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
   implementation("org.ow2.asm:asm-tree:9.8")
   implementation("org.eclipse.jgit:org.eclipse.jgit:7.1.0.202411261347-r")
   implementation(libs.kotlinx.serialization.json)
+  implementation(libs.kotlinx.datetime)
   implementation("com.google.code.gson:gson:2.13.2")
   implementation(libs.android.gradlePlugin.gradle)
   implementation(libs.android.gradlePlugin.builder.test.api)

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/report/TestReport.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/report/TestReport.kt
@@ -15,16 +15,20 @@
  */
 package com.google.firebase.gradle.plugins.report
 
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
 /**
  * Represents a single run of a test in CI. One unit/instrumentation test workflow run creates many
  * `TestReport`s, one for each tested SDK.
  *
  * @param name SDK name of the associated test run.
- * @param type What type of test result this is, either unit or instrumentation test.
+ * @param type What type of test result this is, either unit, instrumentation or daily test.
  * @param status Conclusion status of the test run, `SUCCESS`/`FAILURE` for typical results, `OTHER`
  *   for ongoing runs and unexpected data.
  * @param commit Commit SHA this test was run on.
  * @param url Link to the GHA test run info, including logs.
+ * @param date The ISO date of the run, only if the test is a daily test
  */
 data class TestReport(
   val name: String,
@@ -32,15 +36,31 @@ data class TestReport(
   val status: Status,
   val commit: String,
   val url: String,
+  val date: String? = null,
 ) {
   enum class Type {
     UNIT_TEST,
     INSTRUMENTATION_TEST,
+    DAILY_TEST,
   }
 
   enum class Status {
     SUCCESS,
     FAILURE,
-    OTHER,
+    OTHER;
+
+    companion object {
+      fun of(json: JsonObject): Status {
+        if (json["status"]?.jsonPrimitive?.content == "completed") {
+          if (json["conclusion"]?.jsonPrimitive?.content == "success") {
+            return SUCCESS
+          } else {
+            return FAILURE
+          }
+        } else {
+          return OTHER
+        }
+      }
+    }
   }
 }

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/report/TestReport.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/report/TestReport.kt
@@ -51,14 +51,13 @@ data class TestReport(
 
     companion object {
       fun of(json: JsonObject): Status {
-        if (json["status"]?.jsonPrimitive?.content == "completed") {
-          if (json["conclusion"]?.jsonPrimitive?.content == "success") {
-            return SUCCESS
-          } else {
-            return FAILURE
-          }
-        } else {
-          return OTHER
+        return when {
+          json["status"]?.jsonPrimitive?.content == "completed" ->
+            when {
+              json["conclusion"]?.jsonPrimitive?.content == "success" -> SUCCESS
+              else -> FAILURE
+            }
+          else -> OTHER
         }
       }
     }

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/report/TestReport.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/report/TestReport.kt
@@ -51,13 +51,14 @@ data class TestReport(
 
     companion object {
       fun of(json: JsonObject): Status {
-        return when {
-          json["status"]?.jsonPrimitive?.content == "completed" ->
-            when {
-              json["conclusion"]?.jsonPrimitive?.content == "success" -> SUCCESS
-              else -> FAILURE
-            }
-          else -> OTHER
+        if (json["status"]?.jsonPrimitive?.content == "completed") {
+          if (json["conclusion"]?.jsonPrimitive?.content == "success") {
+            return SUCCESS
+          } else {
+            return FAILURE
+          }
+        } else {
+          return OTHER
         }
       }
     }

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/report/TestReportGenerator.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/report/TestReportGenerator.kt
@@ -22,6 +22,9 @@ import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
+import java.time.LocalDate
+import java.time.Month
+import java.util.Calendar
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -220,9 +223,12 @@ class TestReportGenerator(private val apiToken: String) {
 
   private fun generateDailyTable(reports: List<TestReport>): String {
     val output = StringBuilder("| |")
-    var offset = 0
-    for (report in reports) {
-      output.append(" -${offset++}")
+    val now = LocalDate.now()
+    for ((offset, report) in reports.withIndex().reversed()) {
+      val time = now.minusDays(offset.toLong())
+      val month = shortMonths.getOrDefault(time.month, "???")
+      val day = time.dayOfMonth
+      output.append(" $month $day")
       output.append(" |")
     }
     output.append(" Success Rate |\n|")
@@ -424,5 +430,19 @@ class TestReportGenerator(private val apiToken: String) {
       )
     private val CLIENT: HttpClient =
       HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build()
+    private val shortMonths: Map<Month, String> = mapOf(
+      Month.JANUARY to "Jan",
+      Month.FEBRUARY to "Feb",
+      Month.MARCH to "Mar",
+      Month.APRIL to "Apr",
+      Month.MAY to "May",
+      Month.JUNE to "Jun",
+      Month.JULY to "Jul",
+      Month.AUGUST to "Aug",
+      Month.SEPTEMBER to "Sep",
+      Month.OCTOBER to "Oct",
+      Month.NOVEMBER to "Nov",
+      Month.DECEMBER to "Dec",
+    )
   }
 }

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/report/TestReportGenerator.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/report/TestReportGenerator.kt
@@ -22,9 +22,9 @@ import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
-import java.time.LocalDate
-import java.time.Month
-import java.util.Calendar
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.format.MonthNames
+import kotlinx.datetime.format.char
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -94,6 +94,7 @@ class TestReportGenerator(private val apiToken: String) {
           obj["head_commit"]?.jsonObject?.get("id")?.jsonPrimitive?.content
             ?: throw RuntimeException("Missing head_commit"),
           obj["html_url"]?.jsonPrimitive?.content ?: throw RuntimeException("Missing url"),
+          obj["created_at"]?.jsonPrimitive?.content?.substringBefore("T"),
         )
       )
     }
@@ -123,9 +124,11 @@ class TestReportGenerator(private val apiToken: String) {
       )
     )
     output.append("\n")
-    output.append("### Daily Tests\n\n")
-    output.append(generateDailyTable(dailyTests))
-    output.append("\n")
+    if (dailyTests.isNotEmpty()) {
+      output.append("### Daily Tests\n\n")
+      output.append(generateDailyTable(dailyTests.reversed()))
+      output.append("\n")
+    }
 
     try {
       outputFile.writeText(output.toString())
@@ -198,7 +201,7 @@ class TestReportGenerator(private val apiToken: String) {
               TestReport.Status.FAILURE -> "⛔"
               TestReport.Status.OTHER -> "➖"
             }
-          val link: String = " [%s](%s)".format(icon, report.url)
+          val link: String = " [$icon](${report.url})"
           output.append(link)
         }
         output.append(" |")
@@ -223,13 +226,9 @@ class TestReportGenerator(private val apiToken: String) {
 
   private fun generateDailyTable(reports: List<TestReport>): String {
     val output = StringBuilder("| |")
-    val now = LocalDate.now()
-    for ((offset, report) in reports.withIndex().reversed()) {
-      val time = now.minusDays(offset.toLong())
-      val month = shortMonths.getOrDefault(time.month, "???")
-      val day = time.dayOfMonth
-      output.append(" $month $day")
-      output.append(" |")
+    for (report in reports) {
+      val time = LocalDate.parse(report.date!!)
+      output.append(" ${DATE_FORMAT.format(time)} |")
     }
     output.append(" Success Rate |\n|")
     output.append(" :--- |")
@@ -243,13 +242,13 @@ class TestReportGenerator(private val apiToken: String) {
           TestReport.Status.FAILURE -> "⛔"
           TestReport.Status.OTHER -> "➖"
         }
-      val link: String = " [%s](%s)".format(icon, report.url)
+      val link: String = " [$icon](${report.url})"
       output.append(link)
       output.append(" |")
     }
     output.append(" ")
     val successChance: Int =
-      reports.filter { r -> r.status == TestReport.Status.SUCCESS }.size * 100 / reports.size
+      reports.count { r -> r.status == TestReport.Status.SUCCESS } * 100 / reports.size
     if (successChance == 100) {
       output.append("✅ 100%")
     } else {
@@ -430,19 +429,11 @@ class TestReportGenerator(private val apiToken: String) {
       )
     private val CLIENT: HttpClient =
       HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build()
-    private val shortMonths: Map<Month, String> = mapOf(
-      Month.JANUARY to "Jan",
-      Month.FEBRUARY to "Feb",
-      Month.MARCH to "Mar",
-      Month.APRIL to "Apr",
-      Month.MAY to "May",
-      Month.JUNE to "Jun",
-      Month.JULY to "Jul",
-      Month.AUGUST to "Aug",
-      Month.SEPTEMBER to "Sep",
-      Month.OCTOBER to "Oct",
-      Month.NOVEMBER to "Nov",
-      Month.DECEMBER to "Dec",
-    )
+    private val DATE_FORMAT =
+      LocalDate.Format {
+        monthName(MonthNames.ENGLISH_ABBREVIATED)
+        char(' ')
+        dayOfMonth()
+      }
   }
 }

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/report/TestReportGenerator.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/report/TestReportGenerator.kt
@@ -75,10 +75,33 @@ class TestReportGenerator(private val apiToken: String) {
               ?.int ?: throw RuntimeException("Couldn't find PR number for commit $obj"),
           )
         }
-    outputReport(outputFile, commits)
+    val dailyTests = arrayListOf<TestReport>()
+    // GraphQL does not expose actions in an easy to index way, and the REST API does
+    val dailyTestResponse = request("actions/workflows/ai-daily-tests.yml/runs?per_page=7")
+    val arr =
+      dailyTestResponse["workflow_runs"]?.jsonArray
+        ?: throw RuntimeException("Workflow request failed")
+    for (test in arr) {
+      val obj = test.jsonObject
+      dailyTests.add(
+        TestReport(
+          "ai-daily-test",
+          TestReport.Type.DAILY_TEST,
+          TestReport.Status.of(obj),
+          obj["head_commit"]?.jsonObject?.get("id")?.jsonPrimitive?.content
+            ?: throw RuntimeException("Missing head_commit"),
+          obj["html_url"]?.jsonPrimitive?.content ?: throw RuntimeException("Missing url"),
+        )
+      )
+    }
+    outputReport(outputFile, commits, dailyTests)
   }
 
-  private fun outputReport(outputFile: File, commits: List<ReportCommit>) {
+  private fun outputReport(
+    outputFile: File,
+    commits: List<ReportCommit>,
+    dailyTests: List<TestReport>,
+  ) {
     val reports = commits.flatMap { commit -> parseTestReports(commit.sha) }
     val output = StringBuilder()
     output.append("### Unit Tests\n\n")
@@ -96,6 +119,9 @@ class TestReportGenerator(private val apiToken: String) {
         reports.filter { r: TestReport -> r.type == TestReport.Type.INSTRUMENTATION_TEST },
       )
     )
+    output.append("\n")
+    output.append("### Daily Tests\n\n")
+    output.append(generateDailyTable(dailyTests))
     output.append("\n")
 
     try {
@@ -192,6 +218,42 @@ class TestReportGenerator(private val apiToken: String) {
     return output.toString()
   }
 
+  private fun generateDailyTable(reports: List<TestReport>): String {
+    val output = StringBuilder("| |")
+    var offset = 0
+    for (report in reports) {
+      output.append(" -${offset++}")
+      output.append(" |")
+    }
+    output.append(" Success Rate |\n|")
+    output.append(" :--- |")
+    output.append(" :---: |".repeat(reports.size))
+    output.append(" :--- |")
+    output.append("\n| AI Daily Tests |")
+    for (report in reports) {
+      val icon =
+        when (report.status) {
+          TestReport.Status.SUCCESS -> "✅"
+          TestReport.Status.FAILURE -> "⛔"
+          TestReport.Status.OTHER -> "➖"
+        }
+      val link: String = " [%s](%s)".format(icon, report.url)
+      output.append(link)
+      output.append(" |")
+    }
+    output.append(" ")
+    val successChance: Int =
+      reports.filter { r -> r.status == TestReport.Status.SUCCESS }.size * 100 / reports.size
+    if (successChance == 100) {
+      output.append("✅ 100%")
+    } else {
+      output.append("⛔ $successChance%")
+    }
+    output.append(" |")
+    output.append("\n")
+    return output.toString()
+  }
+
   private fun parseTestReports(commit: String): List<TestReport> {
     val runs = request("actions/runs?head_sha=$commit")
     for (el in runs["workflow_runs"] as JsonArray) {
@@ -234,16 +296,7 @@ class TestReportGenerator(private val apiToken: String) {
         .dropLastWhile { it.isEmpty() }
         .toTypedArray()[1]
     name = name.substring(0, name.length - 1) // Remove trailing ")"
-    val status =
-      if (job["status"]?.jsonPrimitive?.content == "completed") {
-        if (job["conclusion"]?.jsonPrimitive?.content == "success") {
-          TestReport.Status.SUCCESS
-        } else {
-          TestReport.Status.FAILURE
-        }
-      } else {
-        TestReport.Status.OTHER
-      }
+    val status = TestReport.Status.of(job)
     val url = job["html_url"]?.jsonPrimitive?.content ?: throw RuntimeException("PR missing URL")
     return TestReport(name, type, status, commit, url)
   }


### PR DESCRIPTION
Adds daily test status to the Test Reporting bug. Unlike unit and instrumentation tests, all runs are always shown, since we currently only have 1 type of daily test.

Example output below.

----- 

### Unit Tests

| | [#8009](https://github.com/firebase/firebase-android-sdk/pull/8009) | [#7983](https://github.com/firebase/firebase-android-sdk/pull/7983) | [#8002](https://github.com/firebase/firebase-android-sdk/pull/8002) | [#8027](https://github.com/firebase/firebase-android-sdk/pull/8027) | [#8028](https://github.com/firebase/firebase-android-sdk/pull/8028) | [#8025](https://github.com/firebase/firebase-android-sdk/pull/8025) | Success Rate |
| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :--- |
| firebase-dataconnect | | | | [✅](https://github.com/firebase/firebase-android-sdk/actions/runs/24202345424/job/70649528040) | | [⛔](https://github.com/firebase/firebase-android-sdk/actions/runs/24162429246/job/70516856982) | ⛔ 50% |

*+8 passing SDKs
### Instrumentation Tests

*All tests passing*

### Daily Tests

| | Apr 15 | Apr 16 | Apr 17 | Apr 18 | Apr 19 | Apr 20 | Apr 21 | Success Rate |
| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :--- |
| AI Daily Tests | [✅](https://github.com/firebase/firebase-android-sdk/actions/runs/24442505713) | [✅](https://github.com/firebase/firebase-android-sdk/actions/runs/24498252859) | [✅](https://github.com/firebase/firebase-android-sdk/actions/runs/24553833385) | [✅](https://github.com/firebase/firebase-android-sdk/actions/runs/24599892175) | [✅](https://github.com/firebase/firebase-android-sdk/actions/runs/24623963356) | [✅](https://github.com/firebase/firebase-android-sdk/actions/runs/24654541730) | [✅](https://github.com/firebase/firebase-android-sdk/actions/runs/24710324995) | ✅ 100% |
