### PR TITLE
Expand FcmLifecycleCallbacks try/catch to cover analytics dispatch

### DIFF
--- a/firebase-messaging/CHANGELOG.md
+++ b/firebase-messaging/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- [fixed] Prevented app crashes in `FcmLifecycleCallbacks` when an exported activity is
+  invoked with malformed Intent extras. [#8049]
+
 # 25.0.1
 
 - [changed] Bumped internal dependencies.

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/FcmLifecycleCallbacks.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/FcmLifecycleCallbacks.java
@@ -90,13 +90,13 @@ class FcmLifecycleCallbacks implements Application.ActivityLifecycleCallbacks {
         }
         analyticsData = extras.getBundle(Constants.MessageNotificationKeys.ANALYTICS_DATA);
       }
+      if (MessagingAnalytics.shouldUploadScionMetrics(analyticsData)) {
+        MessagingAnalytics.logNotificationOpen(analyticsData);
+      }
     } catch (RuntimeException e) {
       // Don't crash if there was a problem trying to get the analytics data Bundle since the
       // Intent could be coming from anywhere and could be incorrectly formatted.
       Log.w(TAG, "Failed trying to get analytics data from Intent extras.", e);
-    }
-    if (MessagingAnalytics.shouldUploadScionMetrics(analyticsData)) {
-      MessagingAnalytics.logNotificationOpen(analyticsData);
     }
   }
 }


### PR DESCRIPTION
Move MessagingAnalytics.shouldUploadScionMetrics + logNotificationOpen calls inside the existing try block so that any RuntimeException from the extras Bundle (including malformed Serializable extras delivered to an exported activity) cannot propagate out of Application.dispatchActivityCreated.

```diff
 private void logNotificationOpen(Intent startingIntent) {
   Bundle analyticsData = null;
   try {
     Bundle extras = startingIntent.getExtras();
     if (extras != null) { … }
+    if (MessagingAnalytics.shouldUploadScionMetrics(analyticsData)) {
+      MessagingAnalytics.logNotificationOpen(analyticsData);
+    }
   } catch (RuntimeException e) {
     Log.w(TAG, "Failed trying to get analytics data from Intent extras.", e);
   }
-  if (MessagingAnalytics.shouldUploadScionMetrics(analyticsData)) {
-    MessagingAnalytics.logNotificationOpen(analyticsData);
-  }
 }
```

Fixes #8049.