### PR TITLE
[AppDistro] Add Release Candidate (RC) to unstable version keywords

### DIFF
--- a/firebase-appdistribution-gradle/src/integrationTest/java/com/google/firebase/appdistribution/gradle/VersionUtils.kt
+++ b/firebase-appdistribution-gradle/src/integrationTest/java/com/google/firebase/appdistribution/gradle/VersionUtils.kt
@@ -101,7 +101,7 @@ object VersionUtils {
   }
 
   private fun isUnstable(version: String): Boolean {
-    val unstableKeywords = listOf("alpha", "beta", "milestone", "canary", "m")
+    val unstableKeywords = listOf("alpha", "beta", "milestone", "canary", "m", "rc")
     return unstableKeywords.any { version.contains(it, ignoreCase = true) }
   }
 }


### PR DESCRIPTION
The `isUnstable` function in `VersionUtils` now includes "rc" (release candidate) in its list of unstable version keywords.

This is a temporary change. Tests are failing due to issues on how to handle RC's, and will be investigated further in the future. For now, not taking them into account gets us to a stable state.