### PR TITLE
[AI] Attach X-Firebase-AppCheck header on Live API WebSocket handshake

### DIFF
--- a/ai-logic/firebase-ai/CHANGELOG.md
+++ b/ai-logic/firebase-ai/CHANGELOG.md
@@ -19,6 +19,9 @@
 - [fixed] Fixed an issue causing the SDK to throw an exception if an unknown message was received
   from the LiveAPI model, instead of ignoring it (#7975)
 
+- [fixed] Fixed `LiveGenerativeModel.connect()` not attaching the `X-Firebase-AppCheck`
+  header, causing Live API requests to be rejected when App Check is enforced on AI Logic. (#8060)
+
 # 17.10.1
 
 - [fixed] Fixed an issue causing Live API to fail when using the `GoogleAI` backend (#7880)

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/common/APIController.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/common/APIController.kt
@@ -257,13 +257,15 @@ internal constructor(
 
   suspend fun getWebSocketSession(location: String): DefaultClientWebSocketSession {
     // applyHeaderProvider() is suspend; Ktor's webSocketSession { } config lambda is not.
-    // Pre-fetch headers (including X-Firebase-AppCheck) in the outer suspend context, then
-    // set them synchronously inside the lambda. Other methods route through HTTP builders
-    // whose pipelines allow calling applyHeaderProvider() directly inside the config block.
-    val extraHeaders = headerProvider?.generateHeaders().orEmpty()
+    // Pre-fetch headers (including X-Firebase-AppCheck) in the outer suspend context using
+    // the same timeout-protected path as HTTP methods, then set them synchronously inside the
+    // lambda.
+    val extraHeaders = extractHeaders(headerProvider)
     return client.webSocketSession(getBidiEndpoint(location)) {
       applyCommonHeaders()
-      extraHeaders.forEach { (name, value) -> header(name, value) }
+      for ((tag, value) in extraHeaders) {
+        header(tag, value)
+      }
     }
   }
 
@@ -315,16 +317,18 @@ internal constructor(
   }
 
   private suspend fun HttpRequestBuilder.applyHeaderProvider() {
-    if (headerProvider != null) {
-      try {
-        withTimeout(headerProvider.timeout) {
-          for ((tag, value) in headerProvider.generateHeaders()) {
-            header(tag, value)
-          }
-        }
-      } catch (e: TimeoutCancellationException) {
-        Log.w(TAG, "HeaderProvided timed out without generating headers, ignoring")
-      }
+    for ((tag, value) in extractHeaders(headerProvider)) {
+      header(tag, value)
+    }
+  }
+
+  private suspend fun extractHeaders(headerProvider: HeaderProvider?): Map<String, String> {
+    if (headerProvider == null) return emptyMap()
+    return try {
+      withTimeout(headerProvider.timeout) { headerProvider.generateHeaders() }
+    } catch (e: TimeoutCancellationException) {
+      Log.w(TAG, "HeaderProvided timed out without generating headers, ignoring", e)
+      emptyMap()
     }
   }
 

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/common/APIController.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/common/APIController.kt
@@ -255,8 +255,17 @@ internal constructor(
         "wss://firebasevertexai.googleapis.com/ws/google.firebase.vertexai.v1beta.GenerativeService/BidiGenerateContent?key=$key"
     }
 
-  suspend fun getWebSocketSession(location: String): DefaultClientWebSocketSession =
-    client.webSocketSession(getBidiEndpoint(location)) { applyCommonHeaders() }
+  suspend fun getWebSocketSession(location: String): DefaultClientWebSocketSession {
+    // applyHeaderProvider() is suspend; Ktor's webSocketSession { } config lambda is not.
+    // Pre-fetch headers (including X-Firebase-AppCheck) in the outer suspend context, then
+    // set them synchronously inside the lambda. Other methods route through HTTP builders
+    // whose pipelines allow calling applyHeaderProvider() directly inside the config block.
+    val extraHeaders = headerProvider?.generateHeaders().orEmpty()
+    return client.webSocketSession(getBidiEndpoint(location)) {
+      applyCommonHeaders()
+      extraHeaders.forEach { (name, value) -> header(name, value) }
+    }
+  }
 
   fun generateContentStream(
     request: GenerateContentRequest

--- a/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/common/APIControllerTests.kt
+++ b/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/common/APIControllerTests.kt
@@ -418,6 +418,42 @@ internal class RequestFormatTests {
   }
 
   @Test
+  fun `headers from HeaderProvider are added to the WebSocket handshake`() = doBlocking {
+    val mockEngine = MockEngine {
+      // MockEngine isn't designed to complete a WebSocket upgrade handshake, but the
+      // outgoing request is recorded in requestHistory before the handshake attempt,
+      // so we can still assert on its headers.
+      respond("", HttpStatusCode.OK)
+    }
+
+    val testHeaderProvider =
+      object : HeaderProvider {
+        override val timeout: Duration
+          get() = 5.seconds
+
+        override suspend fun generateHeaders(): Map<String, String> =
+          mapOf("X-Firebase-AppCheck" to "test-token")
+      }
+
+    val controller =
+      APIController(
+        "super_cool_test_key",
+        "gemini-pro-2.5",
+        RequestOptions(),
+        mockEngine,
+        TEST_CLIENT_ID,
+        mockFirebaseApp,
+        TEST_VERSION,
+        TEST_APP_ID,
+        testHeaderProvider,
+      )
+
+    runCatching { withTimeout(5.seconds) { controller.getWebSocketSession("us-central1") } }
+
+    mockEngine.requestHistory.first().headers["X-Firebase-AppCheck"] shouldBe "test-token"
+  }
+
+  @Test
   fun `code execution tool serialization contains correct keys`() = doBlocking {
     val channel = ByteChannel(autoFlush = true)
     val mockEngine = MockEngine {


### PR DESCRIPTION
Fixes #8060

## Summary

`APIController.getWebSocketSession()` did not call `applyHeaderProvider()`, so the `X-Firebase-AppCheck` header was missing from the WebSocket upgrade request. This broke Gemini Live whenever App Check was enforced on AI Logic, while HTTPS methods on the same class continued to work because they route through either `applyHeaderProvider()` directly or `postStream` (which calls it internally).

## Fix

`applyHeaderProvider()` is `suspend` and Ktor's `webSocketSession { }` config lambda is non-suspend, so the fix pre-fetches headers in the outer suspend context and applies them synchronously inside the lambda.

## Test plan

- [x] Added unit test `headers from HeaderProvider are added to the WebSocket handshake` mirroring the existing HTTP-path test — passes.
- [x] Existing `RequestFormatTests` suite still passes (`./gradlew :ai-logic:firebase-ai:test`).
- [x] Code formatted with `./gradlew :ai-logic:firebase-ai:spotlessApply`.
- [x] Manual E2E reproduction: built the SDK locally, consumed via `mavenLocal()` in a real app, confirmed `liveModel().connect()` succeeds with App Check enforced on AI Logic.
