### PR TITLE
[AI] Add Java-friendly wrapper for TemplateChat

### DIFF
--- a/ai-logic/firebase-ai/CHANGELOG.md
+++ b/ai-logic/firebase-ai/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [feature] Added a Java-friendly wrapper for TemplateChat interactions (`TemplateChatFutures`).
+
 - [feature] Added support for [Maps Grounding](https://ai.google.dev/gemini-api/docs/maps-grounding) (#7950)
 
 - [feature] Added the `turnComplete` argument to multiple `LiveSession.send()` methods.

--- a/ai-logic/firebase-ai/api.txt
+++ b/ai-logic/firebase-ai/api.txt
@@ -266,6 +266,18 @@ package com.google.firebase.ai.java {
     method public com.google.firebase.ai.java.LiveSessionFutures from(com.google.firebase.ai.type.LiveSession session);
   }
 
+  @com.google.firebase.ai.type.PublicPreviewAPI public abstract class TemplateChatFutures {
+    method public static final com.google.firebase.ai.java.TemplateChatFutures from(com.google.firebase.ai.TemplateChat templateChat);
+    method public abstract com.google.firebase.ai.TemplateChat getTemplateChat();
+    method public abstract com.google.common.util.concurrent.ListenableFuture<com.google.firebase.ai.type.GenerateContentResponse> sendMessage(com.google.firebase.ai.type.Content prompt);
+    method public abstract org.reactivestreams.Publisher<com.google.firebase.ai.type.GenerateContentResponse> sendMessageStream(com.google.firebase.ai.type.Content prompt);
+    field public static final com.google.firebase.ai.java.TemplateChatFutures.Companion Companion;
+  }
+
+  public static final class TemplateChatFutures.Companion {
+    method public com.google.firebase.ai.java.TemplateChatFutures from(com.google.firebase.ai.TemplateChat templateChat);
+  }
+
   public abstract class TemplateGenerativeModelFutures {
     method public static final com.google.firebase.ai.java.TemplateGenerativeModelFutures from(com.google.firebase.ai.TemplateGenerativeModel model);
     method public abstract com.google.common.util.concurrent.ListenableFuture<com.google.firebase.ai.type.GenerateContentResponse> generateContent(String templateId, java.util.Map<java.lang.String,?> inputs);

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/java/TemplateChatFutures.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/java/TemplateChatFutures.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.ai.java
+
+import androidx.concurrent.futures.SuspendToFutureAdapter
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.firebase.ai.TemplateChat
+import com.google.firebase.ai.type.Content
+import com.google.firebase.ai.type.GenerateContentResponse
+import com.google.firebase.ai.type.InvalidStateException
+import com.google.firebase.ai.type.PublicPreviewAPI
+import kotlinx.coroutines.reactive.asPublisher
+import org.reactivestreams.Publisher
+
+/**
+ * Wrapper class providing Java compatible methods for [TemplateChat].
+ *
+ * @see [TemplateChat]
+ */
+@PublicPreviewAPI
+public abstract class TemplateChatFutures internal constructor() {
+
+  /**
+   * Sends a message using the existing history of this chat as context and the provided [Content]
+   * prompt.
+   *
+   * If successful, the message and response will be added to the history. If unsuccessful, history
+   * will remain unchanged.
+   *
+   * @param prompt The input(s) that, together with the history, will be given to the model as the
+   * prompt.
+   * @throws InvalidStateException if [prompt] is not coming from the 'user' role
+   * @throws InvalidStateException if the [TemplateChat] instance has an active request
+   */
+  public abstract fun sendMessage(prompt: Content): ListenableFuture<GenerateContentResponse>
+
+  /**
+   * Sends a message using the existing history of this chat as context and the provided [Content]
+   * prompt.
+   *
+   * The response from the model is returned as a stream.
+   *
+   * If successful, the message and response will be added to the history. If unsuccessful, history
+   * will remain unchanged.
+   *
+   * @param prompt The input(s) that, together with the history, will be given to the model as the
+   * prompt.
+   * @throws InvalidStateException if [prompt] is not coming from the 'user' role
+   * @throws InvalidStateException if the [TemplateChat] instance has an active request
+   */
+  public abstract fun sendMessageStream(prompt: Content): Publisher<GenerateContentResponse>
+
+  /** Returns the [TemplateChat] object wrapped by this object. */
+  public abstract fun getTemplateChat(): TemplateChat
+
+  private class FuturesImpl(private val templateChat: TemplateChat) : TemplateChatFutures() {
+    override fun sendMessage(prompt: Content): ListenableFuture<GenerateContentResponse> =
+      SuspendToFutureAdapter.launchFuture { templateChat.sendMessage(prompt) }
+
+    override fun sendMessageStream(prompt: Content): Publisher<GenerateContentResponse> =
+      templateChat.sendMessageStream(prompt).asPublisher()
+
+    override fun getTemplateChat(): TemplateChat = templateChat
+  }
+
+  public companion object {
+
+    /** @return a [TemplateChatFutures] created around the provided [TemplateChat] */
+    @JvmStatic
+    public fun from(templateChat: TemplateChat): TemplateChatFutures = FuturesImpl(templateChat)
+  }
+}

--- a/ai-logic/firebase-ai/src/testUtil/java/com/google/firebase/ai/JavaCompileTests.java
+++ b/ai-logic/firebase-ai/src/testUtil/java/com/google/firebase/ai/JavaCompileTests.java
@@ -126,7 +126,7 @@ public class JavaCompileTests {
     TemplateGenerativeModelFutures templateFutures =
         TemplateGenerativeModelFutures.from(templateModel);
     TemplateChat templateChat =
-        templateModel.startChat("fake-template", Map.of(), Collections.emptyList());
+        templateModel.startChat("fake-template", Collections.emptyMap(), Collections.emptyList());
     TemplateChatFutures templateChatFutures = TemplateChatFutures.from(templateChat);
     testTemplateChatFutures(templateChatFutures);
   }

--- a/ai-logic/firebase-ai/src/testUtil/java/com/google/firebase/ai/JavaCompileTests.java
+++ b/ai-logic/firebase-ai/src/testUtil/java/com/google/firebase/ai/JavaCompileTests.java
@@ -25,11 +25,15 @@ import com.google.firebase.ai.ImagenModel;
 import com.google.firebase.ai.InferenceMode;
 import com.google.firebase.ai.LiveGenerativeModel;
 import com.google.firebase.ai.OnDeviceConfig;
+import com.google.firebase.ai.TemplateChat;
+import com.google.firebase.ai.TemplateGenerativeModel;
 import com.google.firebase.ai.java.ChatFutures;
 import com.google.firebase.ai.java.GenerativeModelFutures;
 import com.google.firebase.ai.java.ImagenModelFutures;
 import com.google.firebase.ai.java.LiveModelFutures;
 import com.google.firebase.ai.java.LiveSessionFutures;
+import com.google.firebase.ai.java.TemplateChatFutures;
+import com.google.firebase.ai.java.TemplateGenerativeModelFutures;
 import com.google.firebase.ai.type.BlockReason;
 import com.google.firebase.ai.type.Candidate;
 import com.google.firebase.ai.type.Citation;
@@ -117,6 +121,14 @@ public class JavaCompileTests {
     LiveModelFutures liveFutures = LiveModelFutures.from(live);
     testFutures(futures);
     testLiveFutures(liveFutures);
+
+    TemplateGenerativeModel templateModel = vertex.templateGenerativeModel();
+    TemplateGenerativeModelFutures templateFutures =
+        TemplateGenerativeModelFutures.from(templateModel);
+    TemplateChat templateChat =
+        templateModel.startChat("fake-template", Map.of(), Collections.emptyList());
+    TemplateChatFutures templateChatFutures = TemplateChatFutures.from(templateChat);
+    testTemplateChatFutures(templateChatFutures);
   }
 
   private GenerationConfig getGenerationConfig() {
@@ -205,6 +217,43 @@ public class JavaCompileTests {
         },
         executor);
     Publisher<GenerateContentResponse> responsePublisher = futures.generateContentStream(content);
+    responsePublisher.subscribe(
+        new Subscriber<GenerateContentResponse>() {
+          private boolean complete = false;
+
+          @Override
+          public void onSubscribe(Subscription s) {
+            s.request(Long.MAX_VALUE);
+          }
+
+          @Override
+          public void onNext(GenerateContentResponse response) {
+            Assert.assertFalse(complete);
+            validateGenerateContentResponse(response);
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            // Ignore
+          }
+
+          @Override
+          public void onComplete() {
+            complete = true;
+          }
+        });
+  }
+
+  private void testTemplateChatFutures(TemplateChatFutures futures) throws Exception {
+    Content content =
+        new Content.Builder()
+            .setParts(new ArrayList<>())
+            .addText("Fake prompt")
+            .setRole("user")
+            .build();
+    ListenableFuture<GenerateContentResponse> generateResponse = futures.sendMessage(content);
+    validateGenerateContentResponse(generateResponse.get());
+    Publisher<GenerateContentResponse> responsePublisher = futures.sendMessageStream(content);
     responsePublisher.subscribe(
         new Subscriber<GenerateContentResponse>() {
           private boolean complete = false;


### PR DESCRIPTION
Introduced `TemplateChatFutures`, a Java-compatible wrapper for `TemplateChat`. It's the equivalent of `ChatFutures` for the non-template version of `Chat`.