### PR TITLE
[FCM] Fix ANR in SharedPreferencesQueue by reducing lock contention

### DIFF
--- a/firebase-messaging/CHANGELOG.md
+++ b/firebase-messaging/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [changed] Fix ANR in SharedPreferencesQueue by reducing lock contention
+
 # 25.0.1
 
 - [changed] Bumped internal dependencies.

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/SharedPreferencesQueue.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/SharedPreferencesQueue.java
@@ -157,11 +157,9 @@ final class SharedPreferencesQueue {
 
   @WorkerThread
   private void syncState() {
-    String queueValue;
     synchronized (internalQueue) {
-      queueValue = serialize();
+      sharedPreferences.edit().putString(queueName, serialize()).apply();
     }
-    sharedPreferences.edit().putString(queueName, queueValue).apply();
   }
 
   @GuardedBy("internalQueue")

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/SharedPreferencesQueue.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/SharedPreferencesQueue.java
@@ -157,9 +157,11 @@ final class SharedPreferencesQueue {
 
   @WorkerThread
   private void syncState() {
+    String queueValue;
     synchronized (internalQueue) {
-      sharedPreferences.edit().putString(queueName, serialize()).commit();
+      queueValue = serialize();
     }
+    sharedPreferences.edit().putString(queueName, queueValue).apply();
   }
 
   @GuardedBy("internalQueue")


### PR DESCRIPTION
Change `SharedPreferences.Editor.commit()` to `apply()` in `SharedPreferencesQueue.syncState()`.
  
 Previously, the synchronized block held the lock while performing a synchronous `commit()`, which could block the background thread on disk I/O. If the main thread attempted to access the queue (e.g., in `add()`), it would block waiting for the lock, leading to ANRs.
  
 By switching to `apply()`, the operation updates the in-memory SharedPreferences immediately and schedules the disk write asynchronously. This avoids blocking on disk I/O while holding the lock, significantly reducing lock contention and preventing ANRs. Keeping it inside the synchronized block ensures that updates are applied in the correct order even if called from multiple threads.