### PR TITLE
[AI] Improve SessionResumptionConfig constructors

### DIFF
--- a/ai-logic/firebase-ai/api.txt
+++ b/ai-logic/firebase-ai/api.txt
@@ -1654,7 +1654,8 @@ package com.google.firebase.ai.type {
   }
 
   @com.google.firebase.ai.type.PublicPreviewAPI public final class SessionResumptionConfig {
-    ctor public SessionResumptionConfig(String? handle = null);
+    ctor public SessionResumptionConfig();
+    ctor public SessionResumptionConfig(String handle);
   }
 
   @com.google.firebase.ai.type.PublicPreviewAPI public final class SlidingWindow {

--- a/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/LiveSessionTests.kt
+++ b/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/LiveSessionTests.kt
@@ -56,6 +56,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import org.junit.Ignore
 import org.junit.Test
+import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(PublicPreviewAPI::class)
 class LiveSessionTests {
@@ -285,10 +286,12 @@ class LiveSessionTests {
         .takeWhile {
           if (it is LiveSessionResumptionUpdate) {
             lastResumptionUpdate = it
-          } else if (it is LiveServerContent) {
-            !it.turnComplete
           }
-          true
+          if (it is LiveServerContent && it.turnComplete) {
+            false
+          } else {
+            true
+          }
         }
         .collect {}
     }

--- a/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/LiveSessionTests.kt
+++ b/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/LiveSessionTests.kt
@@ -283,7 +283,7 @@ class LiveSessionTests {
     val session = liveModel.connect(SessionResumptionConfig())
     session.send("My favorite color is blue. Remember that.", true)
     var lastResumptionUpdate: LiveSessionResumptionUpdate? = null
-    withTimeout(30_000) {
+    withTimeout(30.seconds) {
       session
         .receive()
         .takeWhile {

--- a/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/LiveSessionTests.kt
+++ b/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/LiveSessionTests.kt
@@ -275,11 +275,7 @@ class LiveSessionTests {
 
   @Test
   fun testResumption(): Unit = runBlocking {
-    val liveModel =
-      getLiveModel(
-        modelName = modelName,
-        config = generationConfig
-      )
+    val liveModel = getLiveModel(modelName = modelName, config = generationConfig)
     val session = liveModel.connect(SessionResumptionConfig())
     session.send("My favorite color is blue. Remember that.", true)
     var lastResumptionUpdate: LiveSessionResumptionUpdate? = null

--- a/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/LiveSessionTests.kt
+++ b/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/LiveSessionTests.kt
@@ -278,12 +278,10 @@ class LiveSessionTests {
     val liveModel =
       getLiveModel(
         modelName = modelName,
-        config = generationConfig,
-        systemInstruction = SystemInstructions.yesOrNo
+        config = generationConfig
       )
     val session = liveModel.connect(SessionResumptionConfig())
-    session.send("Hello, please respond", true)
-    var piecesOfContent = 0
+    session.send("My favorite color is blue. Remember that.", true)
     var lastResumptionUpdate: LiveSessionResumptionUpdate? = null
     withTimeout(30_000) {
       session
@@ -292,30 +290,19 @@ class LiveSessionTests {
           if (it is LiveSessionResumptionUpdate) {
             lastResumptionUpdate = it
           } else if (it is LiveServerContent) {
-            piecesOfContent++
             !it.turnComplete
           }
           true
         }
         .collect {}
     }
-    val firstContentSize = piecesOfContent
     lastResumptionUpdate shouldNotBe null
-    session.resumeSession(SessionResumptionConfig(handle = lastResumptionUpdate!!.newHandle))
-    session.send("Hello, please respond")
-    withTimeout(30_000) {
-      session
-        .receive()
-        .takeWhile {
-          if (it is LiveServerContent) {
-            piecesOfContent++
-            !it.turnComplete
-          }
-          true
-        }
-        .collect {}
+    lastResumptionUpdate?.newHandle?.let { handle ->
+      session.resumeSession(SessionResumptionConfig(handle))
     }
-    piecesOfContent shouldBeGreaterThan firstContentSize
+    session.send("What is my favorite color?")
+    val text = withTimeoutOrNull(30.seconds) { session.collectNextAudioOutputTranscript() } ?: ""
+    text.toLowerCasePreservingASCIIRules() shouldContain "blue"
   }
 
   private suspend fun LiveSession.collectNextAudioOutputTranscript(): String {

--- a/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/LiveSessionTests.kt
+++ b/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/LiveSessionTests.kt
@@ -297,9 +297,9 @@ class LiveSessionTests {
         .collect {}
     }
     lastResumptionUpdate shouldNotBe null
-    lastResumptionUpdate?.newHandle?.let { handle ->
-      session.resumeSession(SessionResumptionConfig(handle))
-    }
+    val handle = lastResumptionUpdate?.newHandle
+    handle.shouldNotBeNull()
+    session.resumeSession(SessionResumptionConfig(handle))
     session.send("What is my favorite color?")
     val text = withTimeoutOrNull(30.seconds) { session.collectNextAudioOutputTranscript() } ?: ""
     text.toLowerCasePreservingASCIIRules() shouldContain "blue"

--- a/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/LiveSessionTests.kt
+++ b/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/LiveSessionTests.kt
@@ -56,7 +56,6 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import org.junit.Ignore
 import org.junit.Test
-import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(PublicPreviewAPI::class)
 class LiveSessionTests {

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/SessionResumptionConfig.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/SessionResumptionConfig.kt
@@ -26,7 +26,17 @@ import kotlinx.serialization.Serializable
  * @property handle The session resumption handle of the previous session to restore.
  */
 @PublicPreviewAPI
-public class SessionResumptionConfig(internal val handle: String? = null) {
+public class SessionResumptionConfig {
+  internal val handle: String?
+
+  public constructor() {
+    this.handle = null
+  }
+
+  public constructor(handle: String) {
+    this.handle = handle
+  }
+
   internal fun toInternal() = Internal(handle)
 
   @Serializable internal data class Internal(val handle: String? = null)


### PR DESCRIPTION
Refactored the `SessionResumptionConfig` class to provide two distinct constructors: a no-argument constructor for starting a new session and a constructor that explicitly takes a non-nullable `handle` for resuming a session. This enhances API clarity by separating these two use cases.

The `resumption_with_dialogue` integration test was updated to use the new constructor signatures. Additionally, the test now includes a more robust verification of session resumption by ensuring that previously remembered information is recalled after the session is resumed.