### PR TITLE
dataconnect(chore): add connector_stream_service.proto to the build

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -6,6 +6,8 @@
   ([#8025](https://github.com/firebase/firebase-android-sdk/pull/8025))
 - [changed] Internal refactor to use token objects instead of strings.
   ([#8027](https://github.com/firebase/firebase-android-sdk/pull/8027))
+- [changed] Internal change to add protos for realtime query updates.
+  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
 
 # 17.2.1
 

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -7,7 +7,7 @@
 - [changed] Internal refactor to use token objects instead of strings.
   ([#8027](https://github.com/firebase/firebase-android-sdk/pull/8027))
 - [changed] Internal change to add protos for realtime query updates.
-  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
+  ([#8081](https://github.com/firebase/firebase-android-sdk/pull/8081))
 
 # 17.2.1
 

--- a/firebase-dataconnect/src/main/proto/google/firebase/dataconnect/proto/connector_stream_service.proto
+++ b/firebase-dataconnect/src/main/proto/google/firebase/dataconnect/proto/connector_stream_service.proto
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from http://google3/google/firebase/dataconnect/v1main/connector_stream_service.proto;rcl=890513448
+
+syntax = "proto3";
+
+package google.firebase.dataconnect.v1;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/struct.proto";
+import "google/firebase/dataconnect/proto/graphql_error.proto";
+import "google/firebase/dataconnect/proto/graphql_response_extensions.proto";
+
+option java_package = "google.firebase.dataconnect.proto";
+option java_multiple_files = true;
+
+service ConnectorStreamService {
+  rpc Connect(stream StreamRequest) returns (stream StreamResponse);
+}
+
+message StreamRequest {
+  string name = 1;
+  map<string, string> headers = 10;
+  string request_id = 2;
+
+  oneof request_kind {
+    ExecuteRequest subscribe = 3;
+    ExecuteRequest execute = 4;
+    ResumeRequest resume = 5;
+    google.protobuf.Empty cancel = 6;
+  }
+
+  string data_etag = 8;
+}
+
+message ExecuteRequest {
+  string operation_name = 2;
+  google.protobuf.Struct variables = 3;
+}
+
+message ResumeRequest {}
+
+message StreamResponse {
+  string request_id = 1;
+  google.protobuf.Struct data = 2;
+  string data_etag = 4;
+  repeated GraphqlError errors = 3;
+  bool cancelled = 5;
+  GraphqlResponseExtensions extensions = 6;
+}


### PR DESCRIPTION
Adds `connector_stream_service.proto` to the Data Connect SDK to support future real-time query updates via bi-directional streaming.

### Highlights
- Added `connector_stream_service.proto` which defines the `ConnectorStreamService` and associated request/response messages for streaming operations.
