### PR TITLE
Deprecate Template Imagen class and the methods in it

### DIFF
--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/ImagenModel.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/ImagenModel.kt
@@ -49,7 +49,7 @@ import com.google.firebase.auth.internal.InternalAuthProvider
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 public class ImagenModel
 internal constructor(
   private val modelName: String,
@@ -96,7 +96,7 @@ internal constructor(
    * early as June 2026. As a replacement, you can
    * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
    */
-  @Deprecated("All Imagen models are deprecated.")
+  @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
   public suspend fun generateImages(prompt: String): ImagenGenerationResponse<ImagenInlineImage> =
     try {
       controller
@@ -119,7 +119,7 @@ internal constructor(
    * early as June 2026. As a replacement, you can
    * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
    */
-  @Deprecated("All Imagen models are deprecated.")
+  @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
   @PublicPreviewAPI
   public suspend fun editImage(
     referenceImages: List<ImagenReferenceImage>,
@@ -149,7 +149,7 @@ internal constructor(
    * early as June 2026. As a replacement, you can
    * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
    */
-  @Deprecated("All Imagen models are deprecated.")
+  @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
   @PublicPreviewAPI
   public suspend fun inpaintImage(
     image: ImagenInlineImage,
@@ -179,7 +179,7 @@ internal constructor(
    * early as June 2026. As a replacement, you can
    * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
    */
-  @Deprecated("All Imagen models are deprecated.")
+  @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
   @PublicPreviewAPI
   public suspend fun outpaintImage(
     image: ImagenInlineImage,

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/TemplateImagenModel.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/TemplateImagenModel.kt
@@ -41,7 +41,7 @@ import org.json.JSONObject
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 @PublicPreviewAPI
 public class TemplateImagenModel
 internal constructor(
@@ -85,7 +85,7 @@ internal constructor(
    * early as June 2026. As a replacement, you can
    * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
    */
-  @Deprecated("All Imagen models are deprecated.")
+  @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
   public suspend fun generateImages(
     templateId: String,
     inputs: Map<String, Any>

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/TemplateImagenModel.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/TemplateImagenModel.kt
@@ -36,7 +36,12 @@ import org.json.JSONObject
  *
  * See the documentation for a list of
  * [supported models](https://firebase.google.com/docs/ai-logic/models).
+ *
+ * @deprecated **Deprecation Notice:** All Imagen models are deprecated and will shut down as early
+ * as June 2026. As a replacement, you can
+ * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
+@Deprecated("All Imagen models are deprecated.")
 @PublicPreviewAPI
 public class TemplateImagenModel
 internal constructor(
@@ -75,7 +80,12 @@ internal constructor(
    *
    * @param templateId The ID of server prompt template.
    * @param inputs the inputs needed to fill in the prompt
+   *
+   * @deprecated **Deprecation Notice:** All Imagen models are deprecated and will shut down as
+   * early as June 2026. As a replacement, you can
+   * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
    */
+  @Deprecated("All Imagen models are deprecated.")
   public suspend fun generateImages(
     templateId: String,
     inputs: Map<String, Any>

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/java/ImagenModelFutures.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/java/ImagenModelFutures.kt
@@ -38,7 +38,7 @@ import com.google.firebase.ai.type.PublicPreviewAPI
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 @PublicPreviewAPI
 public abstract class ImagenModelFutures internal constructor() {
   /**
@@ -50,7 +50,7 @@ public abstract class ImagenModelFutures internal constructor() {
    * early as June 2026. As a replacement, you can
    * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
    */
-  @Deprecated("All Imagen models are deprecated.")
+  @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
   public abstract fun generateImages(
     prompt: String,
   ): ListenableFuture<ImagenGenerationResponse<ImagenInlineImage>>
@@ -67,7 +67,7 @@ public abstract class ImagenModelFutures internal constructor() {
    * early as June 2026. As a replacement, you can
    * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
    */
-  @Deprecated("All Imagen models are deprecated.")
+  @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
   public abstract fun editImage(
     referenceImages: List<ImagenReferenceImage>,
     prompt: String,
@@ -85,7 +85,7 @@ public abstract class ImagenModelFutures internal constructor() {
    * early as June 2026. As a replacement, you can
    * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
    */
-  @Deprecated("All Imagen models are deprecated.")
+  @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
   public abstract fun editImage(
     referenceImages: List<ImagenReferenceImage>,
     prompt: String,
@@ -103,7 +103,7 @@ public abstract class ImagenModelFutures internal constructor() {
    * early as June 2026. As a replacement, you can
    * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
    */
-  @Deprecated("All Imagen models are deprecated.")
+  @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
   public abstract fun inpaintImage(
     image: ImagenInlineImage,
     prompt: String,
@@ -129,7 +129,7 @@ public abstract class ImagenModelFutures internal constructor() {
    * early as June 2026. As a replacement, you can
    * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
    */
-  @Deprecated("All Imagen models are deprecated.")
+  @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
   public abstract fun outpaintImage(
     image: ImagenInlineImage,
     newDimensions: Dimensions,
@@ -145,7 +145,8 @@ public abstract class ImagenModelFutures internal constructor() {
    * early as June 2026. As a replacement, you can
    * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
    */
-  @Deprecated("All Imagen models are deprecated.") public abstract fun getImageModel(): ImagenModel
+  @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
+  public abstract fun getImageModel(): ImagenModel
 
   private class FuturesImpl(private val model: ImagenModel) : ImagenModelFutures() {
     override fun generateImages(
@@ -197,7 +198,7 @@ public abstract class ImagenModelFutures internal constructor() {
      * early as June 2026. As a replacement, you can
      * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
      */
-    @Deprecated("All Imagen models are deprecated.")
+    @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
     @JvmStatic
     public fun from(model: ImagenModel): ImagenModelFutures = FuturesImpl(model)
   }

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenAspectRatio.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenAspectRatio.kt
@@ -23,7 +23,7 @@ package com.google.firebase.ai.type
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 public class ImagenAspectRatio private constructor(internal val internalVal: String) {
   public companion object {
     /** A square image, useful for icons, profile pictures, etc. */

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenControlType.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenControlType.kt
@@ -22,7 +22,7 @@ package com.google.firebase.ai.type
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 public class ImagenControlType internal constructor(internal val value: String) {
   public companion object {
 

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenEditMode.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenEditMode.kt
@@ -22,7 +22,7 @@ package com.google.firebase.ai.type
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 public class ImagenEditMode private constructor(internal val value: String) {
 
   public companion object {

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenEditingConfig.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenEditingConfig.kt
@@ -26,7 +26,7 @@ import kotlinx.serialization.Serializable
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 @PublicPreviewAPI
 public class ImagenEditingConfig(
   internal val editMode: ImagenEditMode? = null,

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenGenerationConfig.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenGenerationConfig.kt
@@ -32,7 +32,7 @@ package com.google.firebase.ai.type
  */
 import kotlin.jvm.JvmField
 
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 public class ImagenGenerationConfig(
   public val negativePrompt: String? = null,
   public val numberOfImages: Int? = 1,
@@ -50,7 +50,7 @@ public class ImagenGenerationConfig(
    * early as June 2026. As a replacement, you can
    * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
    */
-  @Deprecated("All Imagen models are deprecated.")
+  @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
   public class Builder {
     @JvmField public var negativePrompt: String? = null
     @JvmField public var numberOfImages: Int? = 1
@@ -65,7 +65,7 @@ public class ImagenGenerationConfig(
      * early as June 2026. As a replacement, you can
      * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
      */
-    @Deprecated("All Imagen models are deprecated.")
+    @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
     public fun setNegativePrompt(negativePrompt: String): Builder = apply {
       this.negativePrompt = negativePrompt
     }
@@ -77,7 +77,7 @@ public class ImagenGenerationConfig(
      * early as June 2026. As a replacement, you can
      * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
      */
-    @Deprecated("All Imagen models are deprecated.")
+    @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
     public fun setNumberOfImages(numberOfImages: Int): Builder = apply {
       this.numberOfImages = numberOfImages
     }
@@ -89,7 +89,7 @@ public class ImagenGenerationConfig(
      * early as June 2026. As a replacement, you can
      * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
      */
-    @Deprecated("All Imagen models are deprecated.")
+    @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
     public fun setAspectRatio(aspectRatio: ImagenAspectRatio): Builder = apply {
       this.aspectRatio = aspectRatio
     }
@@ -101,7 +101,7 @@ public class ImagenGenerationConfig(
      * early as June 2026. As a replacement, you can
      * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
      */
-    @Deprecated("All Imagen models are deprecated.")
+    @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
     public fun setImageFormat(imageFormat: ImagenImageFormat): Builder = apply {
       this.imageFormat = imageFormat
     }
@@ -113,7 +113,7 @@ public class ImagenGenerationConfig(
      * early as June 2026. As a replacement, you can
      * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
      */
-    @Deprecated("All Imagen models are deprecated.")
+    @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
     public fun setAddWatermark(addWatermark: Boolean): Builder = apply {
       this.addWatermark = addWatermark
     }
@@ -128,7 +128,7 @@ public class ImagenGenerationConfig(
      * early as June 2026. As a replacement, you can
      * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
      */
-    @Deprecated("All Imagen models are deprecated.")
+    @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
     public fun build(): ImagenGenerationConfig =
       ImagenGenerationConfig(
         negativePrompt = negativePrompt,
@@ -162,7 +162,7 @@ public class ImagenGenerationConfig(
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 public fun imagenGenerationConfig(
   init: ImagenGenerationConfig.Builder.() -> Unit
 ): ImagenGenerationConfig {

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenGenerationResponse.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenGenerationResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.Serializable
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 public class ImagenGenerationResponse<T>
 internal constructor(public val images: List<T>, public val filteredReason: String?) {
 

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenImageFormat.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenImageFormat.kt
@@ -30,7 +30,7 @@ import kotlinx.serialization.Serializable
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 public class ImagenImageFormat
 private constructor(public val mimeType: String, public val compressionQuality: Int?) {
 
@@ -49,7 +49,7 @@ private constructor(public val mimeType: String, public val compressionQuality: 
      * early as June 2026. As a replacement, you can
      * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
      */
-    @Deprecated("All Imagen models are deprecated.")
+    @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
     @JvmStatic
     public fun jpeg(compressionQuality: Int? = null): ImagenImageFormat {
       return ImagenImageFormat("image/jpeg", compressionQuality)
@@ -62,7 +62,7 @@ private constructor(public val mimeType: String, public val compressionQuality: 
      * early as June 2026. As a replacement, you can
      * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
      */
-    @Deprecated("All Imagen models are deprecated.")
+    @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
     @JvmStatic
     public fun png(): ImagenImageFormat {
       return ImagenImageFormat("image/png", null)

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenImagePlacement.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenImagePlacement.kt
@@ -23,7 +23,7 @@ package com.google.firebase.ai.type
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 public class ImagenImagePlacement
 private constructor(public val x: Int? = null, public val y: Int? = null) {
 
@@ -82,7 +82,7 @@ private constructor(public val x: Int? = null, public val y: Int? = null) {
      * early as June 2026. As a replacement, you can
      * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
      */
-    @Deprecated("All Imagen models are deprecated.")
+    @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
     @JvmStatic
     public fun fromCoordinate(x: Int, y: Int): ImagenImagePlacement {
       return ImagenImagePlacement(x, y)

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenInlineImage.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenInlineImage.kt
@@ -33,7 +33,7 @@ import kotlinx.serialization.Serializable
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 public class ImagenInlineImage
 internal constructor(
   public val data: ByteArray,
@@ -47,7 +47,7 @@ internal constructor(
    * early as June 2026. As a replacement, you can
    * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
    */
-  @Deprecated("All Imagen models are deprecated.")
+  @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
   public fun asBitmap(): Bitmap {
     return BitmapFactory.decodeByteArray(data, 0, data.size)
   }
@@ -67,7 +67,7 @@ internal constructor(
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 @PublicPreviewAPI
 public fun Bitmap.toImagenInlineImage(): ImagenInlineImage {
   val byteArrayOutputStream = ByteArrayOutputStream()

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenPersonFilterLevel.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenPersonFilterLevel.kt
@@ -23,7 +23,7 @@ package com.google.firebase.ai.type
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 public class ImagenPersonFilterLevel private constructor(internal val internalVal: String) {
   public companion object {
     /**

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenReferenceImage.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenReferenceImage.kt
@@ -30,7 +30,7 @@ import kotlinx.serialization.Serializable
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 @PublicPreviewAPI
 public abstract class ImagenReferenceImage
 internal constructor(
@@ -97,7 +97,7 @@ internal constructor(
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 @PublicPreviewAPI
 public class ImagenControlReference(
   type: ImagenControlType,
@@ -122,7 +122,7 @@ public class ImagenControlReference(
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 @PublicPreviewAPI
 public abstract class ImagenMaskReference
 internal constructor(maskConfig: ImagenMaskConfig, image: ImagenInlineImage? = null) :
@@ -146,7 +146,7 @@ internal constructor(maskConfig: ImagenMaskConfig, image: ImagenInlineImage? = n
      * early as June 2026. As a replacement, you can
      * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
      */
-    @Deprecated("All Imagen models are deprecated.")
+    @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
     @JvmOverloads
     @JvmStatic
     public fun generateMaskAndPadForOutpainting(
@@ -174,7 +174,7 @@ internal constructor(maskConfig: ImagenMaskConfig, image: ImagenInlineImage? = n
      * early as June 2026. As a replacement, you can
      * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
      */
-    @Deprecated("All Imagen models are deprecated.")
+    @Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
     @JvmStatic
     public fun generateMaskAndPadForOutpainting(
       image: ImagenInlineImage,
@@ -246,7 +246,7 @@ internal constructor(maskConfig: ImagenMaskConfig, image: ImagenInlineImage? = n
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 @PublicPreviewAPI
 public class ImagenBackgroundMask(dilation: Double? = null) :
   ImagenMaskReference(maskConfig = ImagenMaskConfig(ImagenMaskMode.BACKGROUND, dilation)) {}
@@ -261,7 +261,7 @@ public class ImagenBackgroundMask(dilation: Double? = null) :
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 @PublicPreviewAPI
 public class ImagenForegroundMask(dilation: Double? = null) :
   ImagenMaskReference(maskConfig = ImagenMaskConfig(ImagenMaskMode.FOREGROUND, dilation)) {}
@@ -278,7 +278,7 @@ public class ImagenForegroundMask(dilation: Double? = null) :
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 @PublicPreviewAPI
 public class ImagenRawMask(mask: ImagenInlineImage, dilation: Double? = null) :
   ImagenMaskReference(
@@ -299,7 +299,7 @@ public class ImagenRawMask(mask: ImagenInlineImage, dilation: Double? = null) :
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 @PublicPreviewAPI
 public class ImagenSemanticMask(classes: List<Int>, dilation: Double? = null) :
   ImagenMaskReference(maskConfig = ImagenMaskConfig(ImagenMaskMode.SEMANTIC, dilation, classes)) {}
@@ -312,7 +312,7 @@ public class ImagenSemanticMask(classes: List<Int>, dilation: Double? = null) :
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 @PublicPreviewAPI
 public class ImagenRawImage(image: ImagenInlineImage) : ImagenReferenceImage(image = image) {}
 
@@ -326,7 +326,7 @@ public class ImagenRawImage(image: ImagenInlineImage) : ImagenReferenceImage(ima
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 @PublicPreviewAPI
 public class ImagenStyleReference(
   image: ImagenInlineImage,
@@ -350,7 +350,7 @@ public class ImagenStyleReference(
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 @PublicPreviewAPI
 public class ImagenSubjectReference(
   image: ImagenInlineImage,

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenSafetyFilterLevel.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenSafetyFilterLevel.kt
@@ -23,7 +23,7 @@ package com.google.firebase.ai.type
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 public class ImagenSafetyFilterLevel private constructor(internal val internalVal: String) {
   public companion object {
     /** Strongest filtering level, most strict blocking. */

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenSubjectReferenceType.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/ImagenSubjectReferenceType.kt
@@ -22,7 +22,7 @@ package com.google.firebase.ai.type
  * as June 2026. As a replacement, you can
  * [migrate your apps to use Gemini Image models (the 'Nano Banana' models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
  */
-@Deprecated("All Imagen models are deprecated.")
+@Deprecated("All Imagen models are deprecated. Migrate your apps to use Gemini Image Models")
 public class ImagenSubjectReferenceType private constructor(internal val value: String) {
 
   public companion object {


### PR DESCRIPTION
TemplateImagen class was missed while deprecating imagen. This PR adds the deprecation message to that class and its underlying methods. Also update the deprecation message to include details about migrating to use the new gemini image model.