### PR TITLE
[AI] Introduce OnDeviceExtension for GenerativeModel

### DIFF
--- a/ai-logic/firebase-ai-ondevice-interop/api.txt
+++ b/ai-logic/firebase-ai-ondevice-interop/api.txt
@@ -15,6 +15,32 @@ package com.google.firebase.ai.ondevice.interop {
     property public final int totalTokens;
   }
 
+  public final class DownloadStatusInterop {
+    ctor public DownloadStatusInterop();
+  }
+
+  public static final class DownloadStatusInterop.DownloadCompleted extends com.google.firebase.ai.ondevice.interop.DownloadStatusInterop {
+    ctor public DownloadStatusInterop.DownloadCompleted();
+  }
+
+  public static final class DownloadStatusInterop.DownloadFailed extends com.google.firebase.ai.ondevice.interop.DownloadStatusInterop {
+    ctor public DownloadStatusInterop.DownloadFailed(com.google.firebase.ai.ondevice.interop.FirebaseAIOnDeviceException exception);
+    method public com.google.firebase.ai.ondevice.interop.FirebaseAIOnDeviceException getException();
+    property public final com.google.firebase.ai.ondevice.interop.FirebaseAIOnDeviceException exception;
+  }
+
+  public static final class DownloadStatusInterop.DownloadInProgress extends com.google.firebase.ai.ondevice.interop.DownloadStatusInterop {
+    ctor public DownloadStatusInterop.DownloadInProgress(long totalBytesDownloaded);
+    method public long getTotalBytesDownloaded();
+    property public final long totalBytesDownloaded;
+  }
+
+  public static final class DownloadStatusInterop.DownloadStarted extends com.google.firebase.ai.ondevice.interop.DownloadStatusInterop {
+    ctor public DownloadStatusInterop.DownloadStarted(long bytesToDownload);
+    method public long getBytesToDownload();
+    property public final long bytesToDownload;
+  }
+
   public final class FinishReason {
     method public String getName();
     property public final String name;
@@ -83,7 +109,9 @@ package com.google.firebase.ai.ondevice.interop {
   }
 
   public interface GenerativeModel {
+    method public suspend Object? checkStatus(kotlin.coroutines.Continuation<? super com.google.firebase.ai.ondevice.interop.OnDeviceModelStatusInterop>);
     method public suspend Object? countTokens(com.google.firebase.ai.ondevice.interop.GenerateContentRequest request, kotlin.coroutines.Continuation<? super com.google.firebase.ai.ondevice.interop.CountTokensResponse>);
+    method public kotlinx.coroutines.flow.Flow<com.google.firebase.ai.ondevice.interop.DownloadStatusInterop> download();
     method public suspend Object? generateContent(com.google.firebase.ai.ondevice.interop.GenerateContentRequest request, kotlin.coroutines.Continuation<? super com.google.firebase.ai.ondevice.interop.GenerateContentResponse>);
     method public kotlinx.coroutines.flow.Flow<com.google.firebase.ai.ondevice.interop.GenerateContentResponse> generateContentStream(com.google.firebase.ai.ondevice.interop.GenerateContentRequest request);
     method public suspend Object? getBaseModelName(kotlin.coroutines.Continuation<? super java.lang.String>);
@@ -114,6 +142,17 @@ package com.google.firebase.ai.ondevice.interop {
   public enum ModelReleaseStage {
     enum_constant public static final com.google.firebase.ai.ondevice.interop.ModelReleaseStage PREVIEW;
     enum_constant public static final com.google.firebase.ai.ondevice.interop.ModelReleaseStage STABLE;
+  }
+
+  public final class OnDeviceModelStatusInterop {
+    field public static final com.google.firebase.ai.ondevice.interop.OnDeviceModelStatusInterop AVAILABLE;
+    field public static final com.google.firebase.ai.ondevice.interop.OnDeviceModelStatusInterop.Companion Companion;
+    field public static final com.google.firebase.ai.ondevice.interop.OnDeviceModelStatusInterop DOWNLOADABLE;
+    field public static final com.google.firebase.ai.ondevice.interop.OnDeviceModelStatusInterop DOWNLOADING;
+    field public static final com.google.firebase.ai.ondevice.interop.OnDeviceModelStatusInterop UNAVAILABLE;
+  }
+
+  public static final class OnDeviceModelStatusInterop.Companion {
   }
 
   public interface Part {

--- a/ai-logic/firebase-ai-ondevice-interop/api.txt
+++ b/ai-logic/firebase-ai-ondevice-interop/api.txt
@@ -15,7 +15,7 @@ package com.google.firebase.ai.ondevice.interop {
     property public final int totalTokens;
   }
 
-  public final class DownloadStatusInterop {
+  public class DownloadStatusInterop {
     ctor public DownloadStatusInterop();
   }
 

--- a/ai-logic/firebase-ai-ondevice-interop/src/main/kotlin/com/google/firebase/ai/ondevice/interop/DownloadStatusInterop.kt
+++ b/ai-logic/firebase-ai-ondevice-interop/src/main/kotlin/com/google/firebase/ai/ondevice/interop/DownloadStatusInterop.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.ai.ondevice.interop
+
+/** Represents the status of a model download operation. */
+public open class DownloadStatusInterop {
+  /**
+   * Indicates that the download has started.
+   *
+   * @property bytesToDownload The total number of bytes that need to be downloaded.
+   */
+  public class DownloadStarted(public val bytesToDownload: Long) : DownloadStatusInterop()
+
+  /**
+   * Indicates that the download is in progress.
+   *
+   * @property totalBytesDownloaded The total number of bytes downloaded so far.
+   */
+  public class DownloadInProgress(public val totalBytesDownloaded: Long) : DownloadStatusInterop()
+
+  /**
+   * Indicates that the download has failed.
+   *
+   * @property exception The exception that caused the download to fail.
+   */
+  public class DownloadFailed(public val exception: FirebaseAIOnDeviceException) :
+    DownloadStatusInterop()
+
+  /** Indicates that the download has completed successfully. */
+  public class DownloadCompleted : DownloadStatusInterop()
+}

--- a/ai-logic/firebase-ai-ondevice-interop/src/main/kotlin/com/google/firebase/ai/ondevice/interop/GenerativeModel.kt
+++ b/ai-logic/firebase-ai-ondevice-interop/src/main/kotlin/com/google/firebase/ai/ondevice/interop/GenerativeModel.kt
@@ -86,4 +86,18 @@ public interface GenerativeModel {
    * @throws [FirebaseAIOnDeviceNotAvailableException] if model is not available.
    */
   public suspend fun warmup()
+
+  /**
+   * Checks the current status / availability of the on-device AI model.
+   *
+   * @return An [OnDeviceModelStatusInterop] indicating the current state of the model.
+   */
+  public suspend fun checkStatus(): OnDeviceModelStatusInterop
+
+  /**
+   * Initiates the download of the on-device AI model.
+   *
+   * @return A [Flow] of [DownloadStatusInterop] objects representing the download lifecycle.
+   */
+  public fun download(): Flow<DownloadStatusInterop>
 }

--- a/ai-logic/firebase-ai-ondevice-interop/src/main/kotlin/com/google/firebase/ai/ondevice/interop/OnDeviceModelStatusInterop.kt
+++ b/ai-logic/firebase-ai-ondevice-interop/src/main/kotlin/com/google/firebase/ai/ondevice/interop/OnDeviceModelStatusInterop.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.ai.ondevice.interop
+
+/** Represents the status of an on-device AI model. */
+public class OnDeviceModelStatusInterop private constructor(private val value: String) {
+  override fun toString(): String = value
+
+  override fun equals(other: Any?): Boolean =
+    other is OnDeviceModelStatusInterop && value == other.value
+
+  override fun hashCode(): Int = value.hashCode()
+
+  public companion object {
+    /** The on-device model is unavailable on the device. */
+    @JvmField
+    public val UNAVAILABLE: OnDeviceModelStatusInterop = OnDeviceModelStatusInterop("UNAVAILABLE")
+
+    /** The on-device model is available for download. */
+    @JvmField
+    public val DOWNLOADABLE: OnDeviceModelStatusInterop = OnDeviceModelStatusInterop("DOWNLOADABLE")
+
+    /** The on-device model is currently being downloaded. */
+    @JvmField
+    public val DOWNLOADING: OnDeviceModelStatusInterop = OnDeviceModelStatusInterop("DOWNLOADING")
+
+    /** The on-device model is available and ready for use. */
+    @JvmField
+    public val AVAILABLE: OnDeviceModelStatusInterop = OnDeviceModelStatusInterop("AVAILABLE")
+  }
+}

--- a/ai-logic/firebase-ai-ondevice/api.txt
+++ b/ai-logic/firebase-ai-ondevice/api.txt
@@ -1,54 +1,44 @@
 // Signature format: 3.0
 package com.google.firebase.ai.ondevice {
 
-  public abstract class DownloadStatus {
-    ctor public DownloadStatus();
+  @Deprecated public abstract class DownloadStatus {
+    ctor @Deprecated public DownloadStatus();
   }
 
-  public static final class DownloadStatus.DownloadCompleted extends com.google.firebase.ai.ondevice.DownloadStatus {
-    ctor public DownloadStatus.DownloadCompleted();
+  @Deprecated public static final class DownloadStatus.DownloadCompleted extends com.google.firebase.ai.ondevice.DownloadStatus {
+    ctor @Deprecated public DownloadStatus.DownloadCompleted();
   }
 
-  public static final class DownloadStatus.DownloadFailed extends com.google.firebase.ai.ondevice.DownloadStatus {
-    method public com.google.firebase.ai.ondevice.interop.FirebaseAIOnDeviceException getException();
-    property public final com.google.firebase.ai.ondevice.interop.FirebaseAIOnDeviceException exception;
+  @Deprecated public static final class DownloadStatus.DownloadFailed extends com.google.firebase.ai.ondevice.DownloadStatus {
+    method @Deprecated public com.google.firebase.ai.ondevice.interop.FirebaseAIOnDeviceException getException();
+    property @Deprecated public final com.google.firebase.ai.ondevice.interop.FirebaseAIOnDeviceException exception;
   }
 
-  public static final class DownloadStatus.DownloadInProgress extends com.google.firebase.ai.ondevice.DownloadStatus {
-    method public long getTotalBytesDownloaded();
-    property public final long totalBytesDownloaded;
+  @Deprecated public static final class DownloadStatus.DownloadInProgress extends com.google.firebase.ai.ondevice.DownloadStatus {
+    method @Deprecated public long getTotalBytesDownloaded();
+    property @Deprecated public final long totalBytesDownloaded;
   }
 
-  public static final class DownloadStatus.DownloadStarted extends com.google.firebase.ai.ondevice.DownloadStatus {
-    method public long getBytesToDownload();
-    property public final long bytesToDownload;
+  @Deprecated public static final class DownloadStatus.DownloadStarted extends com.google.firebase.ai.ondevice.DownloadStatus {
+    method @Deprecated public long getBytesToDownload();
+    property @Deprecated public final long bytesToDownload;
   }
 
   public final class FirebaseAIOnDevice {
-    method public suspend Object? checkStatus(com.google.firebase.ai.ondevice.OnDeviceModelOption option, kotlin.coroutines.Continuation<? super com.google.firebase.ai.ondevice.OnDeviceModelStatus>);
-    method public kotlinx.coroutines.flow.Flow<com.google.firebase.ai.ondevice.DownloadStatus> download(com.google.firebase.ai.ondevice.OnDeviceModelOption option);
+    method @Deprecated public suspend Object? checkStatus(kotlin.coroutines.Continuation<? super com.google.firebase.ai.ondevice.OnDeviceModelStatus>);
+    method @Deprecated public kotlinx.coroutines.flow.Flow<com.google.firebase.ai.ondevice.DownloadStatus> download();
     field public static final com.google.firebase.ai.ondevice.FirebaseAIOnDevice INSTANCE;
   }
 
-  public final class OnDeviceModelOption {
-    field public static final com.google.firebase.ai.ondevice.OnDeviceModelOption.Companion Companion;
-    field public static final com.google.firebase.ai.ondevice.OnDeviceModelOption PREVIEW;
-    field public static final com.google.firebase.ai.ondevice.OnDeviceModelOption PREVIEW_FAST;
-    field public static final com.google.firebase.ai.ondevice.OnDeviceModelOption STABLE;
+  @Deprecated public final class OnDeviceModelStatus {
+    field @Deprecated public static final com.google.firebase.ai.ondevice.OnDeviceModelStatus AVAILABLE;
+    field @Deprecated public static final com.google.firebase.ai.ondevice.OnDeviceModelStatus.Companion Companion;
+    field @Deprecated public static final com.google.firebase.ai.ondevice.OnDeviceModelStatus DOWNLOADABLE;
+    field @Deprecated public static final com.google.firebase.ai.ondevice.OnDeviceModelStatus DOWNLOADING;
+    field @Deprecated public static final com.google.firebase.ai.ondevice.OnDeviceModelStatus UNAVAILABLE;
   }
 
-  public static final class OnDeviceModelOption.Companion {
-  }
-
-  public final class OnDeviceModelStatus {
-    field public static final com.google.firebase.ai.ondevice.OnDeviceModelStatus AVAILABLE;
-    field public static final com.google.firebase.ai.ondevice.OnDeviceModelStatus.Companion Companion;
-    field public static final com.google.firebase.ai.ondevice.OnDeviceModelStatus DOWNLOADABLE;
-    field public static final com.google.firebase.ai.ondevice.OnDeviceModelStatus DOWNLOADING;
-    field public static final com.google.firebase.ai.ondevice.OnDeviceModelStatus UNAVAILABLE;
-  }
-
-  public static final class OnDeviceModelStatus.Companion {
+  @Deprecated public static final class OnDeviceModelStatus.Companion {
   }
 
 }

--- a/ai-logic/firebase-ai-ondevice/src/main/kotlin/com/google/firebase/ai/ondevice/Converters.kt
+++ b/ai-logic/firebase-ai-ondevice/src/main/kotlin/com/google/firebase/ai/ondevice/Converters.kt
@@ -18,11 +18,15 @@ package com.google.firebase.ai.ondevice
 
 import com.google.firebase.ai.ondevice.interop.Candidate
 import com.google.firebase.ai.ondevice.interop.CountTokensResponse
+import com.google.firebase.ai.ondevice.interop.DownloadStatusInterop
 import com.google.firebase.ai.ondevice.interop.FinishReason
+import com.google.firebase.ai.ondevice.interop.FirebaseAIOnDeviceException
 import com.google.firebase.ai.ondevice.interop.FirebaseAIOnDeviceInvalidRequestException
+import com.google.firebase.ai.ondevice.interop.FirebaseAIOnDeviceUnknownException
 import com.google.firebase.ai.ondevice.interop.GenerateContentResponse
 import com.google.firebase.ai.ondevice.interop.GenerationConfig
 import com.google.firebase.ai.ondevice.interop.ModelConfig
+import com.google.firebase.ai.ondevice.interop.OnDeviceModelStatusInterop
 import com.google.mlkit.genai.prompt.GenerateContentRequest
 import com.google.mlkit.genai.prompt.ImagePart
 import com.google.mlkit.genai.prompt.ModelPreference
@@ -121,3 +125,34 @@ private fun generateContentRequest(
   builder.init()
   return builder.build()
 }
+
+// ========================================================================
+// `DownloadStatus` and `OnDeviceModelStatus` converter extension functions
+// ========================================================================
+internal fun com.google.mlkit.genai.common.DownloadStatus.toInterop(): DownloadStatusInterop =
+  when (this) {
+    is com.google.mlkit.genai.common.DownloadStatus.DownloadStarted ->
+      DownloadStatusInterop.DownloadStarted(bytesToDownload)
+    is com.google.mlkit.genai.common.DownloadStatus.DownloadProgress ->
+      DownloadStatusInterop.DownloadInProgress(totalBytesDownloaded)
+    is com.google.mlkit.genai.common.DownloadStatus.DownloadCompleted ->
+      DownloadStatusInterop.DownloadCompleted()
+    is com.google.mlkit.genai.common.DownloadStatus.DownloadFailed ->
+      DownloadStatusInterop.DownloadFailed(FirebaseAIOnDeviceException.from(e))
+    else ->
+      DownloadStatusInterop.DownloadFailed(
+        FirebaseAIOnDeviceUnknownException("Unknown download status")
+      )
+  }
+
+internal fun Int.toInteropStatus(): OnDeviceModelStatusInterop =
+  when (this) {
+    com.google.mlkit.genai.common.FeatureStatus.UNAVAILABLE ->
+      OnDeviceModelStatusInterop.UNAVAILABLE
+    com.google.mlkit.genai.common.FeatureStatus.DOWNLOADABLE ->
+      OnDeviceModelStatusInterop.DOWNLOADABLE
+    com.google.mlkit.genai.common.FeatureStatus.DOWNLOADING ->
+      OnDeviceModelStatusInterop.DOWNLOADING
+    com.google.mlkit.genai.common.FeatureStatus.AVAILABLE -> OnDeviceModelStatusInterop.AVAILABLE
+    else -> OnDeviceModelStatusInterop.UNAVAILABLE
+  }

--- a/ai-logic/firebase-ai-ondevice/src/main/kotlin/com/google/firebase/ai/ondevice/FirebaseAIOnDevice.kt
+++ b/ai-logic/firebase-ai-ondevice/src/main/kotlin/com/google/firebase/ai/ondevice/FirebaseAIOnDevice.kt
@@ -18,13 +18,8 @@ package com.google.firebase.ai.ondevice
 
 import com.google.firebase.ai.ondevice.interop.FirebaseAIOnDeviceException
 import com.google.firebase.ai.ondevice.interop.FirebaseAIOnDeviceUnknownException
-import com.google.firebase.ai.ondevice.interop.GenerationConfig
 import com.google.mlkit.genai.common.FeatureStatus
 import com.google.mlkit.genai.prompt.Generation
-import com.google.mlkit.genai.prompt.ModelPreference as MlKitModelPreference
-import com.google.mlkit.genai.prompt.ModelReleaseStage as MlKitModelReleaseStage
-import com.google.mlkit.genai.prompt.generationConfig
-import com.google.mlkit.genai.prompt.modelConfig
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -38,13 +33,11 @@ public object FirebaseAIOnDevice {
   /**
    * Checks the current status / availability of the on-device AI model.
    *
-   * @param option The configuration option for the model.
    * @return An [OnDeviceModelStatus] object indicating the current state of the model.
    */
-  public suspend fun checkStatus(option: OnDeviceModelOption): OnDeviceModelStatus {
-    return OnDeviceModelStatus.fromFeatureStatus(
-      Generation.getClient(option.toMlKit()).checkStatus()
-    )
+  @Deprecated("Use `GenerativeModel.OnDeviceExtension` from `firebase-ai` instead")
+  public suspend fun checkStatus(): OnDeviceModelStatus {
+    return OnDeviceModelStatus.fromFeatureStatus(Generation.getClient().checkStatus())
   }
 
   /**
@@ -54,52 +47,16 @@ public object FirebaseAIOnDevice {
    * Consumers should collect the flow to start the download process, and optionally process any
    * updates on the download state, progress, and completion or failure.
    *
-   * @param option The configuration option for the model.
    * @return A [Flow] of [DownloadStatus] objects representing the download lifecycle.
    */
-  public fun download(option: OnDeviceModelOption): Flow<DownloadStatus> {
-    return Generation.getClient(option.toMlKit()).download().map { DownloadStatus.fromMlKit(it) }
+  @Deprecated("Use `GenerativeModel.OnDeviceExtension` from `firebase-ai` instead")
+  public fun download(): Flow<DownloadStatus> {
+    return Generation.getClient().download().map { DownloadStatus.fromMlKit(it) }
   }
 }
-
-/** Options for configuring the on-device AI model. */
-public class OnDeviceModelOption private constructor(private val value: String) {
-  override fun toString(): String = value
-
-  public companion object {
-    /** Selects the latest stable model. */
-    @JvmField public val STABLE: OnDeviceModelOption = OnDeviceModelOption("stable")
-
-    /** Selects the latest preview model with full performance. */
-    @JvmField public val PREVIEW: OnDeviceModelOption = OnDeviceModelOption("preview")
-
-    /** Selects the latest preview model optimized for speed. */
-    @JvmField public val PREVIEW_FAST: OnDeviceModelOption = OnDeviceModelOption("preview_fast")
-  }
-}
-
-internal fun OnDeviceModelOption.toMlKit(): com.google.mlkit.genai.prompt.GenerationConfig =
-  generationConfig {
-    modelConfig = modelConfig {
-      when (this@toMlKit) {
-        OnDeviceModelOption.STABLE -> {
-          releaseStage = MlKitModelReleaseStage.STABLE
-          preference = MlKitModelPreference.FULL
-        }
-        OnDeviceModelOption.PREVIEW -> {
-          releaseStage = MlKitModelReleaseStage.PREVIEW
-          preference = MlKitModelPreference.FULL
-        }
-        OnDeviceModelOption.PREVIEW_FAST -> {
-          releaseStage = MlKitModelReleaseStage.PREVIEW
-          preference = MlKitModelPreference.FAST
-        }
-        else -> throw IllegalArgumentException("Unknown option: ${this@toMlKit}")
-      }
-    }
-  }
 
 /** Represents the current status of the on-device AI model. */
+@Deprecated("Use `GenerativeModel.OnDeviceExtension` from `firebase-ai` instead")
 public class OnDeviceModelStatus private constructor(private val status: Int) {
   public companion object {
     /** The on-device model is unavailable on the device. */
@@ -135,6 +92,7 @@ public class OnDeviceModelStatus private constructor(private val status: Int) {
  * This class has several concrete subclasses, each representing a specific stage or outcome of the
  * download process.
  */
+@Deprecated("Use `GenerativeModel.OnDeviceExtension` from `firebase-ai` instead")
 public abstract class DownloadStatus {
   /**
    * Represents when a download has just started.

--- a/ai-logic/firebase-ai-ondevice/src/main/kotlin/com/google/firebase/ai/ondevice/GenerativeModelImpl.kt
+++ b/ai-logic/firebase-ai-ondevice/src/main/kotlin/com/google/firebase/ai/ondevice/GenerativeModelImpl.kt
@@ -17,6 +17,7 @@
 package com.google.firebase.ai.ondevice
 
 import com.google.firebase.ai.ondevice.interop.CountTokensResponse
+import com.google.firebase.ai.ondevice.interop.DownloadStatusInterop
 import com.google.firebase.ai.ondevice.interop.FirebaseAIOnDeviceException
 import com.google.firebase.ai.ondevice.interop.FirebaseAIOnDeviceInvalidRequestException
 import com.google.firebase.ai.ondevice.interop.FirebaseAIOnDeviceNotAvailableException
@@ -24,6 +25,7 @@ import com.google.firebase.ai.ondevice.interop.FirebaseAIOnDeviceUnknownExceptio
 import com.google.firebase.ai.ondevice.interop.GenerateContentRequest
 import com.google.firebase.ai.ondevice.interop.GenerateContentResponse
 import com.google.firebase.ai.ondevice.interop.GenerativeModel
+import com.google.firebase.ai.ondevice.interop.OnDeviceModelStatusInterop
 import com.google.mlkit.genai.common.FeatureStatus
 import com.google.mlkit.genai.common.GenAiException
 import com.google.mlkit.genai.common.GenAiException.ErrorCode
@@ -82,6 +84,14 @@ internal class GenerativeModelImpl(
     } catch (e: GenAiException) {
       throw getMappingException(e)
     }
+
+  override suspend fun checkStatus(): OnDeviceModelStatusInterop {
+    return mlkitModel.checkStatus().toInteropStatus()
+  }
+
+  override fun download(): Flow<DownloadStatusInterop> {
+    return mlkitModel.download().map { it.toInterop() }
+  }
 
   /**
    * Throws the [FirebaseAIOnDeviceException] subclass that maps to the input exception.

--- a/ai-logic/firebase-ai/api.txt
+++ b/ai-logic/firebase-ai/api.txt
@@ -13,6 +13,31 @@ package com.google.firebase.ai {
     property public final java.util.List<com.google.firebase.ai.type.Content> history;
   }
 
+  @com.google.firebase.ai.type.PublicPreviewAPI public abstract sealed class DownloadStatus {
+  }
+
+  public static final class DownloadStatus.DownloadCompleted extends com.google.firebase.ai.DownloadStatus {
+    ctor public DownloadStatus.DownloadCompleted();
+  }
+
+  public static final class DownloadStatus.DownloadFailed extends com.google.firebase.ai.DownloadStatus {
+    ctor public DownloadStatus.DownloadFailed(com.google.firebase.ai.type.FirebaseAIException exception);
+    method public com.google.firebase.ai.type.FirebaseAIException getException();
+    property public final com.google.firebase.ai.type.FirebaseAIException exception;
+  }
+
+  public static final class DownloadStatus.DownloadInProgress extends com.google.firebase.ai.DownloadStatus {
+    ctor public DownloadStatus.DownloadInProgress(long totalBytesDownloaded);
+    method public long getTotalBytesDownloaded();
+    property public final long totalBytesDownloaded;
+  }
+
+  public static final class DownloadStatus.DownloadStarted extends com.google.firebase.ai.DownloadStatus {
+    ctor public DownloadStatus.DownloadStarted(long bytesToDownload);
+    method public long getBytesToDownload();
+    property public final long bytesToDownload;
+  }
+
   public final class FirebaseAI {
     method public com.google.firebase.ai.GenerativeModel generativeModel(String modelName);
     method public com.google.firebase.ai.GenerativeModel generativeModel(String modelName, com.google.firebase.ai.type.GenerationConfig? generationConfig = null);
@@ -78,8 +103,10 @@ package com.google.firebase.ai {
     method public kotlinx.coroutines.flow.Flow<com.google.firebase.ai.type.GenerateContentResponse> generateContentStream(java.util.List<com.google.firebase.ai.type.Content> prompt);
     method public suspend <T> Object? generateObject(com.google.firebase.ai.type.JsonSchema<T> jsonSchema, com.google.firebase.ai.type.Content prompt, com.google.firebase.ai.type.Content[] prompts, kotlin.coroutines.Continuation<? super com.google.firebase.ai.type.GenerateObjectResponse<T>>);
     method public suspend <T> Object? generateObject(com.google.firebase.ai.type.JsonSchema<T> jsonSchema, String prompt, kotlin.coroutines.Continuation<? super com.google.firebase.ai.type.GenerateObjectResponse<T>>);
+    method public com.google.firebase.ai.OnDeviceExtension? getOnDeviceExtension();
     method public com.google.firebase.ai.Chat startChat(java.util.List<com.google.firebase.ai.type.Content> history = emptyList());
-    method @com.google.firebase.ai.type.PublicPreviewAPI public suspend Object? warmUp(kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    method @Deprecated @com.google.firebase.ai.type.PublicPreviewAPI public suspend Object? warmUp(kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    property public final com.google.firebase.ai.OnDeviceExtension? onDeviceExtension;
   }
 
   @Deprecated public final class ImagenModel {
@@ -143,6 +170,12 @@ package com.google.firebase.ai {
   public static final class OnDeviceConfig.Companion {
   }
 
+  @com.google.firebase.ai.type.PublicPreviewAPI public final class OnDeviceExtension {
+    method public suspend Object? checkStatus(kotlin.coroutines.Continuation<? super com.google.firebase.ai.OnDeviceModelStatus>);
+    method public kotlinx.coroutines.flow.Flow<com.google.firebase.ai.DownloadStatus> download();
+    method public suspend Object? warmUp(kotlin.coroutines.Continuation<? super kotlin.Unit>);
+  }
+
   @com.google.firebase.ai.type.PublicPreviewAPI public final class OnDeviceModelOption {
     field public static final com.google.firebase.ai.OnDeviceModelOption.Companion Companion;
     field public static final com.google.firebase.ai.OnDeviceModelOption PREVIEW;
@@ -151,6 +184,17 @@ package com.google.firebase.ai {
   }
 
   public static final class OnDeviceModelOption.Companion {
+  }
+
+  @com.google.firebase.ai.type.PublicPreviewAPI public final class OnDeviceModelStatus {
+    field public static final com.google.firebase.ai.OnDeviceModelStatus AVAILABLE;
+    field public static final com.google.firebase.ai.OnDeviceModelStatus.Companion Companion;
+    field public static final com.google.firebase.ai.OnDeviceModelStatus DOWNLOADABLE;
+    field public static final com.google.firebase.ai.OnDeviceModelStatus DOWNLOADING;
+    field public static final com.google.firebase.ai.OnDeviceModelStatus UNAVAILABLE;
+  }
+
+  public static final class OnDeviceModelStatus.Companion {
   }
 
   @com.google.firebase.ai.type.PublicPreviewAPI public final class TemplateChat {

--- a/ai-logic/firebase-ai/api.txt
+++ b/ai-logic/firebase-ai/api.txt
@@ -13,7 +13,8 @@ package com.google.firebase.ai {
     property public final java.util.List<com.google.firebase.ai.type.Content> history;
   }
 
-  @com.google.firebase.ai.type.PublicPreviewAPI public abstract sealed class DownloadStatus {
+  @com.google.firebase.ai.type.PublicPreviewAPI public abstract class DownloadStatus {
+    ctor public DownloadStatus();
   }
 
   public static final class DownloadStatus.DownloadCompleted extends com.google.firebase.ai.DownloadStatus {

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/GenerativeModel.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/GenerativeModel.kt
@@ -443,7 +443,7 @@ internal constructor(
   /**
    * Initiates the download of the on-device AI model.
    *
-   * @param option The configuration option for the model.
+   *
    * @return A [Flow] of [DownloadStatus] objects representing the download lifecycle.
    */
   public fun download(): Flow<DownloadStatus> {

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/GenerativeModel.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/GenerativeModel.kt
@@ -443,7 +443,6 @@ internal constructor(
   /**
    * Initiates the download of the on-device AI model.
    *
-   *
    * @return A [Flow] of [DownloadStatus] objects representing the download lifecycle.
    */
   public fun download(): Flow<DownloadStatus> {

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/GenerativeModel.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/GenerativeModel.kt
@@ -246,8 +246,8 @@ internal constructor(
    * @throws [FirebaseAIException] if the warmup failed.
    */
   @Deprecated(
-    message = "Use onDevice?.warmUp() instead",
-    replaceWith = ReplaceWith("onDevice?.warmUp()")
+    message = "Use onDeviceExtension?.warmUp() instead",
+    replaceWith = ReplaceWith("onDeviceExtension?.warmUp()")
   )
   @PublicPreviewAPI
   public suspend fun warmUp(): Unit = actualModel.warmUp()

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/GenerativeModel.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/GenerativeModel.kt
@@ -52,6 +52,7 @@ import com.google.firebase.ai.type.content
 import com.google.firebase.appcheck.interop.InteropAppCheckTokenProvider
 import com.google.firebase.auth.internal.InternalAuthProvider
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -62,11 +63,14 @@ import kotlinx.serialization.json.jsonObject
  * types.
  */
 public class GenerativeModel
+@OptIn(PublicPreviewAPI::class)
 internal constructor(
   private val actualModel: GenerativeModelProvider,
   internal val requestOptions: RequestOptions,
-  private val tools: List<Tool> = emptyList()
+  private val tools: List<Tool> = emptyList(),
+  @PublicPreviewAPI public val onDeviceExtension: OnDeviceExtension? = null
 ) {
+
   /**
    * Generates new content from the input [Content] given to the model as a prompt.
    *
@@ -241,7 +245,12 @@ internal constructor(
    *
    * @throws [FirebaseAIException] if the warmup failed.
    */
-  @PublicPreviewAPI public suspend fun warmUp(): Unit = actualModel.warmUp()
+  @Deprecated(
+    message = "Use onDevice?.warmUp() instead",
+    replaceWith = ReplaceWith("onDevice?.warmUp()")
+  )
+  @PublicPreviewAPI
+  public suspend fun warmUp(): Unit = actualModel.warmUp()
 
   internal fun hasFunction(call: FunctionCallPart): Boolean {
     return tools
@@ -384,10 +393,21 @@ internal constructor(
 
     @OptIn(PublicPreviewAPI::class)
     internal fun build(): GenerativeModel {
+      val includesOnDevice =
+        onDeviceFactoryProvider != null && onDeviceConfig.mode != InferenceMode.ONLY_IN_CLOUD
+      val onDeviceExtension =
+        if (includesOnDevice) {
+          onDeviceFactoryProvider
+            ?.newGenerativeModel(onDeviceConfig.modelOption?.toInterop())
+            ?.let { OnDeviceExtension(it) }
+        } else {
+          null
+        }
       return GenerativeModel(
         tools = tools,
         actualModel = getModelProvider(),
-        requestOptions = requestOptions
+        requestOptions = requestOptions,
+        onDeviceExtension = onDeviceExtension
       )
     }
   }
@@ -404,4 +424,38 @@ internal class NetworkStatusChecker(private val connectivityManager: Connectivit
         it.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
     }
       ?: false
+}
+
+/** Extension class for performing on-device operations. */
+@PublicPreviewAPI
+public class OnDeviceExtension
+internal constructor(
+  private val onDeviceGenerativeModel: com.google.firebase.ai.ondevice.interop.GenerativeModel
+) {
+  /**
+   * Checks the current status / availability of the on-device AI model.
+   *
+   * @return An [OnDeviceModelStatus] object indicating the current state of the model.
+   */
+  public suspend fun checkStatus(): OnDeviceModelStatus =
+    OnDeviceModelStatus.fromInterop(onDeviceGenerativeModel.checkStatus())
+
+  /**
+   * Initiates the download of the on-device AI model.
+   *
+   * @param option The configuration option for the model.
+   * @return A [Flow] of [DownloadStatus] objects representing the download lifecycle.
+   */
+  public fun download(): Flow<DownloadStatus> {
+    return onDeviceGenerativeModel.download().map { DownloadStatus.fromInterop(it) }
+  }
+
+  /**
+   * Warms up the model to reduce latency for the first request.
+   *
+   * @throws [FirebaseAIException] if the warmup failed.
+   */
+  public suspend fun warmUp() {
+    onDeviceGenerativeModel.warmup()
+  }
 }

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/OnDeviceConfig.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/OnDeviceConfig.kt
@@ -225,6 +225,8 @@ public abstract class DownloadStatus {
           DownloadCompleted()
         is com.google.firebase.ai.ondevice.interop.DownloadStatusInterop.DownloadFailed ->
           DownloadFailed(FirebaseAIException.from(status.exception))
+        else ->
+          DownloadFailed(FirebaseAIException.from(IllegalStateException("Unknown download status")))
       }
   }
 }

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/OnDeviceConfig.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/OnDeviceConfig.kt
@@ -16,6 +16,7 @@
 
 package com.google.firebase.ai
 
+import com.google.firebase.ai.type.FirebaseAIException
 import com.google.firebase.ai.type.PublicPreviewAPI
 
 /**
@@ -142,3 +143,88 @@ internal fun OnDeviceModelOption.toInterop():
       )
     else -> throw IllegalArgumentException("Unknown option")
   }
+
+/** Represents the current status of the on-device AI model. */
+@PublicPreviewAPI
+public class OnDeviceModelStatus private constructor(private val value: String) {
+  override fun toString(): String = value
+
+  override fun equals(other: Any?): Boolean = other is OnDeviceModelStatus && value == other.value
+
+  override fun hashCode(): Int = value.hashCode()
+
+  public companion object {
+    /** The on-device model is unavailable on the device. */
+    @JvmField public val UNAVAILABLE: OnDeviceModelStatus = OnDeviceModelStatus("UNAVAILABLE")
+
+    /** The on-device model is available for download. */
+    @JvmField public val DOWNLOADABLE: OnDeviceModelStatus = OnDeviceModelStatus("DOWNLOADABLE")
+
+    /** The on-device model is currently being downloaded. */
+    @JvmField public val DOWNLOADING: OnDeviceModelStatus = OnDeviceModelStatus("DOWNLOADING")
+
+    /** The on-device model is available and ready for use. */
+    @JvmField public val AVAILABLE: OnDeviceModelStatus = OnDeviceModelStatus("AVAILABLE")
+
+    internal fun fromInterop(
+      status: com.google.firebase.ai.ondevice.interop.OnDeviceModelStatusInterop
+    ): OnDeviceModelStatus =
+      when (status) {
+        com.google.firebase.ai.ondevice.interop.OnDeviceModelStatusInterop.UNAVAILABLE ->
+          UNAVAILABLE
+        com.google.firebase.ai.ondevice.interop.OnDeviceModelStatusInterop.DOWNLOADABLE ->
+          DOWNLOADABLE
+        com.google.firebase.ai.ondevice.interop.OnDeviceModelStatusInterop.DOWNLOADING ->
+          DOWNLOADING
+        com.google.firebase.ai.ondevice.interop.OnDeviceModelStatusInterop.AVAILABLE -> AVAILABLE
+        else -> UNAVAILABLE
+      }
+  }
+}
+
+/** An abstract class representing the status of an on-device model download operation. */
+@PublicPreviewAPI
+public abstract class DownloadStatus {
+  /** Represents when a download has just started. */
+  public class DownloadStarted(public val bytesToDownload: Long) : DownloadStatus() {
+    override fun equals(other: Any?): Boolean =
+      other is DownloadStarted && bytesToDownload == other.bytesToDownload
+    override fun hashCode(): Int = bytesToDownload.hashCode()
+  }
+
+  /** Represents when a download is actively in progress. */
+  public class DownloadInProgress(public val totalBytesDownloaded: Long) : DownloadStatus() {
+    override fun equals(other: Any?): Boolean =
+      other is DownloadInProgress && totalBytesDownloaded == other.totalBytesDownloaded
+    override fun hashCode(): Int = totalBytesDownloaded.hashCode()
+  }
+
+  /** Represents when a download has failed. */
+  public class DownloadFailed(public val exception: FirebaseAIException) : DownloadStatus() {
+    override fun equals(other: Any?): Boolean =
+      other is DownloadFailed && exception == other.exception
+    override fun hashCode(): Int = exception.hashCode()
+  }
+
+  /** Represents when a download has successfully completed. */
+  public class DownloadCompleted : DownloadStatus() {
+    override fun equals(other: Any?): Boolean = other is DownloadCompleted
+    override fun hashCode(): Int = javaClass.hashCode()
+  }
+
+  internal companion object {
+    internal fun fromInterop(
+      status: com.google.firebase.ai.ondevice.interop.DownloadStatusInterop
+    ): DownloadStatus =
+      when (status) {
+        is com.google.firebase.ai.ondevice.interop.DownloadStatusInterop.DownloadStarted ->
+          DownloadStarted(status.bytesToDownload)
+        is com.google.firebase.ai.ondevice.interop.DownloadStatusInterop.DownloadInProgress ->
+          DownloadInProgress(status.totalBytesDownloaded)
+        is com.google.firebase.ai.ondevice.interop.DownloadStatusInterop.DownloadCompleted ->
+          DownloadCompleted()
+        is com.google.firebase.ai.ondevice.interop.DownloadStatusInterop.DownloadFailed ->
+          DownloadFailed(FirebaseAIException.from(status.exception))
+      }
+  }
+}

--- a/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/GenerativeModelTesting.kt
+++ b/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/GenerativeModelTesting.kt
@@ -66,6 +66,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito
 
 @RunWith(AndroidJUnit4::class)
+@OptIn(PublicPreviewAPI::class)
 internal class GenerativeModelTesting {
   private val TEST_CLIENT_ID = "test"
   private val TEST_APP_ID = "1:android:12345"

--- a/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/OnDeviceExtensionTests.kt
+++ b/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/OnDeviceExtensionTests.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.ai
+
+import com.google.firebase.ai.generativemodel.GenerativeModelProvider
+import com.google.firebase.ai.ondevice.interop.DownloadStatusInterop
+import com.google.firebase.ai.ondevice.interop.GenerativeModel as InteropGenerativeModel
+import com.google.firebase.ai.ondevice.interop.OnDeviceModelStatusInterop
+import com.google.firebase.ai.type.PublicPreviewAPI
+import com.google.firebase.ai.type.RequestOptions
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+@OptIn(PublicPreviewAPI::class)
+internal class OnDeviceExtensionTests {
+
+  private val interopModel = mockk<InteropGenerativeModel>()
+  private val actualModel = mockk<GenerativeModelProvider>()
+
+  @Test
+  fun `checkStatus returns correctly mapped status`() {
+    runBlocking {
+      coEvery { interopModel.checkStatus() } returns OnDeviceModelStatusInterop.AVAILABLE
+
+      val extension = OnDeviceExtension(interopModel)
+      val status = extension.checkStatus()
+
+      status shouldBe OnDeviceModelStatus.AVAILABLE
+    }
+  }
+
+  @Test
+  fun `download returns correctly mapped flow`() {
+    runBlocking {
+      val interopFlow =
+        flowOf(
+          DownloadStatusInterop.DownloadStarted(100),
+          DownloadStatusInterop.DownloadInProgress(50),
+          DownloadStatusInterop.DownloadCompleted()
+        )
+      every { interopModel.download() } returns interopFlow
+
+      val extension = OnDeviceExtension(interopModel)
+      val flow = extension.download()
+
+      val results = flow.toList()
+      results.size shouldBe 3
+      (results[0] as DownloadStatus.DownloadStarted).bytesToDownload shouldBe 100
+      (results[1] as DownloadStatus.DownloadInProgress).totalBytesDownloaded shouldBe 50
+      results[2] shouldBe DownloadStatus.DownloadCompleted()
+    }
+  }
+
+  @Test
+  fun `warmUp calls interopModel warmup`() {
+    runBlocking {
+      coEvery { interopModel.warmup() } returns Unit
+
+      val extension = OnDeviceExtension(interopModel)
+      extension.warmUp()
+
+      coVerify(exactly = 1) { interopModel.warmup() }
+    }
+  }
+
+  @Test
+  fun `onDeviceExtension is null when passed null in constructor`() {
+    val model =
+      GenerativeModel(
+        actualModel = actualModel,
+        requestOptions = RequestOptions(),
+        onDeviceExtension = null
+      )
+    model.onDeviceExtension shouldBe null
+  }
+
+  @Test
+  fun `onDeviceExtension is not null when passed in constructor`() {
+    val extension = OnDeviceExtension(interopModel)
+    val model =
+      GenerativeModel(
+        actualModel = actualModel,
+        requestOptions = RequestOptions(),
+        onDeviceExtension = extension
+      )
+    model.onDeviceExtension shouldBe extension
+  }
+}


### PR DESCRIPTION
Adds `OnDeviceExtension` to `GenerativeModel` in `firebase-ai`, centralizing on-device model management. This extension provides methods for `checkStatus`, `download`, and `warmUp` for on-device models. This removes the need for `firebase-ai-ondevice` SDK to have a public API.

Key changes include:
* Defining: new `DownloadStatus` and `OnDeviceModelStatus` classes in `firebase-ai` for public consumption, marked as `PublicPreviewAPI`.
* Creating: corresponding `DownloadStatusInterop` and `OnDeviceModelStatusInterop` classes in `firebase-ai-ondevice-interop` for internal interop with ML Kit.
* Implementing: `checkStatus` and `download` on the `GenerativeModel` interop interface in `firebase-ai-ondevice`, utilizing ML Kit's APIs and new converter functions.
* Deprecating: the old `FirebaseAIOnDevice.checkStatus`, `FirebaseAIOnDevice.download`, `DownloadStatus`,
`OnDeviceModelStatus`, and `OnDeviceModelOption` in `firebase-ai-ondevice`.
* Deprecating: the top-level `GenerativeModel.warmUp()` method in `firebase-ai` in favor of `onDeviceExtension?.warmUp()`.
* Adding: new unit tests for the `OnDeviceExtension` functionality.