### PR TITLE
[AppCheck] Add initial versioning for Firebase App Check reCAPTCHA Enterprise

### DIFF
--- a/appcheck/firebase-appcheck-recaptchaenterprise/gradle.properties
+++ b/appcheck/firebase-appcheck-recaptchaenterprise/gradle.properties
@@ -1,0 +1,1 @@
+version=16.0.0-beta01


### PR DESCRIPTION
Adds the `gradle.properties` file to the
`firebase-appcheck-recaptchaenterprise` module, setting its initial version to `16.0.0-beta01`.

Current value is only for testing purposes only and is not intended to reflect the actual version of the SDK when released.