### PR TITLE
[Firestore] Remove use of smart quotes

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/pipeline/stage.kt
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/pipeline/stage.kt
@@ -1171,7 +1171,7 @@ internal constructor(
     )
   }
 
-  /** Specify the BCP-47 language code of text in the search query, such as “en” or “sr”. */
+  /** Specify the BCP-47 language code of text in the search query, such as "en" or "sr". */
   fun withLanguageCode(languageCode: String): SearchStage {
     return SearchStage(
       query,


### PR DESCRIPTION
Smart quotes are discouraged in most situations. They look nice, but may result in hard to diagnose compiler problems.