### PR TITLE
[AI] Update KDoc links to Markdown style

### DIFF
--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/GoogleMaps.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/GoogleMaps.kt
@@ -23,9 +23,9 @@ import kotlinx.serialization.Serializable
  * location-based information into its responses.
  *
  * Important: If using Grounding with Google Maps, you are required to comply with the "Grounding
- * with Google Maps" usage requirements for your chosen API provider: {@link
- * https://ai.google.dev/gemini-api/terms#grounding-with-google-maps | Gemini Developer API} or
- * Vertex AI Gemini API (see {@link https://cloud.google.com/terms/service-terms | Service Terms}
+ * with Google Maps" usage requirements for your chosen API provider:
+ * [Gemini Developer API](https://ai.google.dev/gemini-api/terms#grounding-with-google-maps) or
+ * Vertex AI Gemini API (see [Service Terms](https://cloud.google.com/terms/service-terms))
  * section within the Service Specific Terms).
  */
 public class GoogleMaps {

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/GoogleMaps.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/GoogleMaps.kt
@@ -25,8 +25,8 @@ import kotlinx.serialization.Serializable
  * Important: If using Grounding with Google Maps, you are required to comply with the "Grounding
  * with Google Maps" usage requirements for your chosen API provider:
  * [Gemini Developer API](https://ai.google.dev/gemini-api/terms#grounding-with-google-maps) or
- * Vertex AI Gemini API (see [Service Terms](https://cloud.google.com/terms/service-terms))
- * section within the Service Specific Terms).
+ * Vertex AI Gemini API (see [Service Terms](https://cloud.google.com/terms/service-terms)) section
+ * within the Service Specific Terms).
  */
 public class GoogleMaps {
   @Serializable internal class Internal()

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/Tool.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/Tool.kt
@@ -143,10 +143,10 @@ internal constructor(
      * incorporate location-based information into its responses.
      *
      * When using this feature, you are required to comply with the "Grounding with Google Maps"
-     * usage requirements for your chosen API provider: {@link
-     * https://ai.google.dev/gemini-api/terms#grounding-with-google-maps | Gemini Developer API} or
-     * Vertex AI Gemini API (see {@link https://cloud.google.com/terms/service-terms | Service
-     * Terms} section within the Service Specific Terms).
+     * usage requirements for your chosen API provider:
+     * [Gemini Developer API](https://ai.google.dev/gemini-api/terms#grounding-with-google-maps) or
+     * Vertex AI Gemini API (see [Service Terms](https://cloud.google.com/terms/service-terms)
+     * section within the Service Specific Terms).
      *
      * @return A [Tool] configured for Google Maps.
      */


### PR DESCRIPTION
Changed KDoc external links in `GoogleMaps.kt` and `Tool.kt` from `{@link ... | ...}` syntax to Markdown-style `[...](...)` for correctness.