### PR TITLE
dataconnect: testing connector added for future realtime testing

### DIFF
--- a/firebase-dataconnect/emulator/dataconnect/connector/realtime/connector.yaml
+++ b/firebase-dataconnect/emulator/dataconnect/connector/realtime/connector.yaml
@@ -1,0 +1,8 @@
+connectorId: realtime
+authMode: PUBLIC
+generate:
+  kotlinSdk:
+    outputDir: ../../.generated/realtime
+    package: com.google.firebase.dataconnect.connectors.realtime
+    clientCache:
+      maxAge: 1h

--- a/firebase-dataconnect/emulator/dataconnect/connector/realtime/realtime_ops.gql
+++ b/firebase-dataconnect/emulator/dataconnect/connector/realtime/realtime_ops.gql
@@ -1,0 +1,29 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+mutation RealtimeString_Insert($name: String!) @auth(level: PUBLIC) {
+  key: realtimeString_insert(data: {name: $name})
+}
+
+mutation RealtimeString_Update($key: RealtimeString_Key!, $name: String!) @auth(level: PUBLIC) {
+  realtimeString_update(key: $key, data: {name: $name})
+}
+
+mutation RealtimeString_Delete($key: RealtimeString_Key!) @auth(level: PUBLIC) {
+  realtimeString_delete(key: $key)
+}
+
+query RealtimeString_GetByKey($key: RealtimeString_Key!) @auth(level: PUBLIC) {
+  item: realtimeString(key: $key) { name }
+}

--- a/firebase-dataconnect/emulator/dataconnect/dataconnect.yaml
+++ b/firebase-dataconnect/emulator/dataconnect/dataconnect.yaml
@@ -13,6 +13,7 @@ connectorDirs: [
   "./connector/demo",
   "./connector/alltypes",
   "./connector/keywords",
+  "./connector/realtime",
   "./connector/person",
   "./connector/posts",
 ]

--- a/firebase-dataconnect/emulator/dataconnect/schema/realtime_schema.gql
+++ b/firebase-dataconnect/emulator/dataconnect/schema/realtime_schema.gql
@@ -1,0 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+type RealtimeString @table {
+  name: String!
+}

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/testutil/schemas/RealtimeConnector.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/testutil/schemas/RealtimeConnector.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.dataconnect.testutil.schemas
+
+import com.google.firebase.dataconnect.ConnectorConfig
+import com.google.firebase.dataconnect.FirebaseDataConnect
+import com.google.firebase.dataconnect.serializers.UUIDSerializer
+import com.google.firebase.dataconnect.testutil.TestDataConnectFactory
+import java.util.UUID
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.serializer
+
+class RealtimeConnector private constructor(val dataConnect: FirebaseDataConnect) {
+
+  val getStringByKey = GetStringByKeyQuery(this)
+
+  val insertString = InsertStringMutation(this)
+
+  val updateString = UpdateStringMutation(this)
+
+  val deleteString = DeleteStringMutation(this)
+
+  suspend fun getString(key: Key) = getStringByKey.execute(key)
+
+  suspend fun insertString(name: String) = insertString.execute(name)
+
+  suspend fun updateString(key: Key, name: String) = updateString.execute(key, name)
+
+  suspend fun deleteString(key: Key) = deleteString.execute(key)
+
+  class GetStringByKeyQuery(val connector: RealtimeConnector) {
+
+    suspend fun execute(key: Key) = execute(Variables(key))
+
+    suspend fun execute(variables: Variables) = queryRef(variables).execute().data.item
+
+    fun queryRef(variables: Variables) =
+      connector.dataConnect.query(OPERATION_NAME, variables, serializer<Data>(), serializer())
+
+    @Serializable data class Variables(val key: Key)
+
+    @Serializable
+    data class Data(val item: Item?) {
+      @Serializable data class Item(val name: String)
+    }
+
+    companion object {
+      const val OPERATION_NAME = "RealtimeString_GetByKey"
+    }
+  }
+
+  class InsertStringMutation(val connector: RealtimeConnector) {
+    @Serializable data class Variables(val name: String)
+    @Serializable data class Data(val key: Key)
+
+    suspend fun execute(name: String) = execute(Variables(name = name))
+
+    suspend fun execute(variables: Variables) = mutationRef(variables).execute().data.key
+
+    fun mutationRef(variables: Variables) =
+      connector.dataConnect.mutation(OPERATION_NAME, variables, serializer<Data>(), serializer())
+
+    companion object {
+      const val OPERATION_NAME = "RealtimeString_Insert"
+    }
+  }
+
+  class UpdateStringMutation(val connector: RealtimeConnector) {
+    @Serializable data class Variables(val key: Key, val name: String)
+
+    suspend fun execute(key: Key, name: String) = execute(Variables(key = key, name = name))
+
+    suspend fun execute(variables: Variables) {
+      mutationRef(variables).execute()
+    }
+
+    fun mutationRef(variables: Variables) =
+      connector.dataConnect.mutation(OPERATION_NAME, variables, serializer<Unit>(), serializer())
+
+    companion object {
+      const val OPERATION_NAME = "RealtimeString_Update"
+    }
+  }
+
+  class DeleteStringMutation(val connector: RealtimeConnector) {
+    @Serializable data class Variables(val key: Key)
+
+    suspend fun execute(key: Key) = execute(Variables(key = key))
+
+    suspend fun execute(variables: Variables) {
+      mutationRef(variables).execute()
+    }
+
+    fun mutationRef(variables: Variables) =
+      connector.dataConnect.mutation(OPERATION_NAME, variables, serializer<Unit>(), serializer())
+
+    companion object {
+      const val OPERATION_NAME = "RealtimeString_Delete"
+    }
+  }
+
+  @Serializable data class Key(val id: @Serializable(with = UUIDSerializer::class) UUID)
+
+  companion object {
+    val config =
+      ConnectorConfig(
+        connector = "realtime",
+        location = "us-central1",
+        serviceId = "sid2ehn9ct8te",
+      )
+
+    fun getInstance(dataConnectFactory: TestDataConnectFactory): RealtimeConnector {
+      val dataConnect = dataConnectFactory.newInstance(config)
+      return RealtimeConnector(dataConnect)
+    }
+  }
+}

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/testutil/schemas/RealtimeConnectorIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/testutil/schemas/RealtimeConnectorIntegrationTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.dataconnect.testutil.schemas
+
+import com.google.firebase.dataconnect.testutil.DataConnectIntegrationTestBase
+import com.google.firebase.dataconnect.testutil.property.arbitrary.pair
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbs.firstName
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class RealtimeConnectorIntegrationTest : DataConnectIntegrationTestBase() {
+
+  @Test
+  fun realtimeConnectorBasicFunctionalityTest() = runTest {
+    val connector = RealtimeConnector.getInstance(dataConnectFactory)
+    val (name1, name2) = Arb.firstName().map { it.name }.pair().sample(rs).value
+
+    val key = connector.insertString(name1)
+    connector.getString(key).shouldNotBeNull().name shouldBe name1
+    connector.updateString(key, name2)
+    connector.getString(key).shouldNotBeNull().name shouldBe name2
+    connector.deleteString(key)
+    connector.getString(key).shouldBeNull()
+  }
+}


### PR DESCRIPTION
This PR adds a new "realtime" connector to the Data Connect emulator and Android test utilities to support future real-time testing. It includes the necessary GraphQL schema, operations, and a Kotlin wrapper to facilitate integration testing.

### Highlights
- **New Realtime Connector:** Added a new `realtime` connector to the emulator configuration, including a `RealtimeString` table schema.
- **GraphQL Operations:** Implemented GraphQL mutations and queries for basic CRUD operations (Insert, Update, Delete, GetByKey) on `RealtimeString`.
- **Kotlin Test Wrapper:** Created a `RealtimeConnector` Kotlin wrapper in the `androidTest` source set to simplify calling these operations in tests.
- **Integration Testing:** Added `RealtimeConnectorIntegrationTest` to verify the end-to-end functionality of the new connector and its Kotlin wrapper.

### Changelog

<details>

- **connector.yaml**: Defined the `realtime` connector configuration for the emulator.
- **realtime_ops.gql**: Added GraphQL mutations and queries for `RealtimeString` operations.
- **dataconnect.yaml**: Registered the new `realtime` connector directory in the emulator configuration.
- **realtime_schema.gql**: Defined the database schema for the `RealtimeString` table.
- **RealtimeConnector.kt**: Implemented a Kotlin wrapper to facilitate using the `realtime` connector in Android tests.
- **RealtimeConnectorIntegrationTest.kt**: Added integration tests to verify basic CRUD functionality through the new connector.

</details>