### PR TITLE
dataconnect(test): ConnectRPCIntegrationTest.kt added with its first test

### DIFF
--- a/firebase-dataconnect/androidTestutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/DataConnectIntegrationTestBase.kt
+++ b/firebase-dataconnect/androidTestutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/DataConnectIntegrationTestBase.kt
@@ -39,6 +39,8 @@ abstract class DataConnectIntegrationTestBase {
 
   @get:Rule val dataConnectFactory = TestDataConnectFactory(firebaseAppFactory)
 
+  @get:Rule val cleanups = CleanupsRule()
+
   @get:Rule(order = Int.MIN_VALUE) val randomSeedTestRule = RandomSeedTestRule()
 
   val rs: RandomSource by randomSeedTestRule.rs

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/ConnectRPCIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/ConnectRPCIntegrationTest.kt
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.dataconnect
+
+import app.cash.turbine.test
+import com.google.firebase.dataconnect.testutil.DataConnectIntegrationTestBase
+import com.google.firebase.dataconnect.testutil.createGrpcManagedChannel
+import com.google.firebase.dataconnect.testutil.schemas.RealtimeConnector
+import com.google.firebase.dataconnect.util.ProtoUtil.decodeFromStruct
+import com.google.firebase.dataconnect.util.ProtoUtil.encodeToStruct
+import google.firebase.dataconnect.proto.ConnectorStreamServiceGrpcKt.ConnectorStreamServiceCoroutineStub
+import google.firebase.dataconnect.proto.ExecuteRequest
+import google.firebase.dataconnect.proto.StreamRequest
+import google.firebase.dataconnect.proto.StreamResponse
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.result.shouldBeSuccess
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.Codepoint
+import io.kotest.property.arbitrary.az
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.string
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.serializer
+import org.junit.Test
+
+class ConnectRPCIntegrationTest : DataConnectIntegrationTestBase() {
+
+  @Test
+  fun messagesAreReceivedAsEntityChanges() = runTest {
+    val requestId = requestIdArb().sample()
+    val name = nameArb().sample()
+    val (connector, outgoingRequests, incomingResponses) = connect()
+    val key = connector.insertString(name)
+    outgoingRequests.sendInitRequest(requestId = "init", connector.resourceName)
+
+    incomingResponses.test {
+      outgoingRequests.sendGetStringByKeyExecuteRequest(requestId, key)
+      val streamResponse = awaitItem()
+      streamResponse.shouldBeGetStringByKeyDataWithName(requestId = requestId, name = name)
+    }
+  }
+
+  /**
+   * Establishes a connection to the Data Connect `Connect` RPC and returns the streams for
+   * communication.
+   */
+  private fun connect(): ConnectionStreams {
+    val connector = RealtimeConnector.getInstance(dataConnectFactory)
+    val grpcManagedChannel = createGrpcManagedChannel(connector.dataConnect)
+    val outgoingRequests = Channel<StreamRequest>(Channel.UNLIMITED)
+    val stub = ConnectorStreamServiceCoroutineStub(grpcManagedChannel)
+    val incomingResponses = stub.connect(outgoingRequests.consumeAsFlow())
+    return ConnectionStreams(connector, outgoingRequests, incomingResponses)
+  }
+
+  /**
+   * Convenience extension function on [Arb] that gets a non-edge-case value using the [rs] property
+   * of the [DataConnectIntegrationTestBase] superclass for the randomness source.
+   */
+  private fun <T> Arb<T>.sample(): T = sample(rs).value
+}
+
+/**
+ * Creates and returns an [Arb] that generates strings that are suitable for, and recognizable as,
+ * "request IDs" in [StreamRequest] messages.
+ */
+private fun requestIdArb(): Arb<String> = Arb.string(size = 4, Codepoint.az()).map { "rid$it" }
+
+/**
+ * Creates and returns an [Arb] that generates strings that are suitable for, and recognizable as,
+ * "name" values for [RealtimeConnector.InsertStringMutation.Variables.name] and
+ * [RealtimeConnector.UpdateStringMutation.Variables.name].
+ */
+private fun nameArb(): Arb<String> = Arb.string(size = 4, Codepoint.az()).map { "nam$it" }
+
+/** Exception thrown by [sendNonBlockingOrThrow] if sending fails. */
+private class SendChannelTrySendUnsuccessfulException(message: String, cause: Throwable?) :
+  Exception(message, cause)
+
+/**
+ * Sends an element to receiver [SendChannel] in a non-blocking way, throwing an exception if
+ * sending was unsuccessful.
+ *
+ * @throws SendChannelTrySendUnsuccessfulException if [SendChannel.trySend] returns a failed result.
+ */
+private fun <T> SendChannel<T>.sendNonBlockingOrThrow(element: T) {
+  val result = trySend(element)
+  if (!result.isSuccess) {
+    throw SendChannelTrySendUnsuccessfulException(
+      "trySend() failed with isClosed=${result.isClosed}",
+      result.exceptionOrNull()
+    )
+  }
+}
+
+private data class ConnectionStreams(
+  val connector: RealtimeConnector,
+  val outgoingRequests: SendChannel<StreamRequest>,
+  val incomingResponses: Flow<StreamResponse>,
+)
+
+/**
+ * Sends an initialization request to the receiver [ConnectionStreams.outgoingRequests].
+ *
+ * @param requestId The "request ID" to send in the outgoing message.
+ * @param connectorResourceName The "connector resource name" to send in the outgoing message.
+ */
+private fun SendChannel<StreamRequest>.sendInitRequest(
+  requestId: String,
+  connectorResourceName: String
+) {
+  val streamRequest =
+    StreamRequest.newBuilder().let {
+      it.setRequestId(requestId)
+      it.setName(connectorResourceName)
+      it.build()
+    }
+  sendNonBlockingOrThrow(streamRequest)
+}
+
+/**
+ * Sends an execution request for an operation to the receiver [ConnectionStreams.outgoingRequests].
+ *
+ * @param requestId The "request ID" to send in the outgoing message.
+ * @param operationName The "operation name" to send in the outgoing message.
+ * @param variables The "variables" to send in the outgoing message; these variables will be encoded
+ * using the object's default serializer, as determined by the [serializer] function.
+ */
+private inline fun <reified Variables> SendChannel<StreamRequest>.sendExecuteRequest(
+  requestId: String,
+  operationName: String,
+  variables: Variables
+) {
+  sendExecuteRequest(requestId, operationName, variables, serializer(), null)
+}
+
+/**
+ * Sends an execution request for an operation to the receiver [ConnectionStreams.outgoingRequests].
+ *
+ * @param requestId The "request ID" to send in the outgoing message.
+ * @param operationName The "operation name" to send in the outgoing message.
+ * @param variables The "variables" to send in the outgoing message; these variables will be encoded
+ * using the given [serializer] and [serializersModule].
+ * @param serializer The [SerializationStrategy] to use for encoding the given [variables].
+ * @param serializersModule The [SerializersModule] to use when encoding the given [variables].
+ */
+private fun <Variables> SendChannel<StreamRequest>.sendExecuteRequest(
+  requestId: String,
+  operationName: String,
+  variables: Variables,
+  serializer: SerializationStrategy<Variables>,
+  serializersModule: SerializersModule?
+) {
+  val variablesStruct = encodeToStruct(variables, serializer, serializersModule)
+
+  val executeRequest =
+    ExecuteRequest.newBuilder().let {
+      it.setOperationName(operationName)
+      it.setVariables(variablesStruct)
+      it.build()
+    }
+
+  val streamRequest =
+    StreamRequest.newBuilder().let {
+      it.setRequestId(requestId)
+      it.setExecute(executeRequest)
+      it.build()
+    }
+
+  sendNonBlockingOrThrow(streamRequest)
+}
+
+/**
+ * Sends an execution request for a "GetStringByKey" query to the receiver
+ * [ConnectionStreams.outgoingRequests].
+ *
+ * @param requestId The "request ID" to send in the outgoing message.
+ * @param key The "key" to send in the outgoing message for the
+ * [RealtimeConnector.GetStringByKeyQuery.Variables.key] property.
+ */
+private fun SendChannel<StreamRequest>.sendGetStringByKeyExecuteRequest(
+  requestId: String,
+  key: RealtimeConnector.Key
+) {
+  val operationName = RealtimeConnector.GetStringByKeyQuery.OPERATION_NAME
+  val variables = RealtimeConnector.GetStringByKeyQuery.Variables(key)
+  sendExecuteRequest(requestId, operationName, variables)
+}
+
+/**
+ * Assertion to verify that a [StreamResponse] matches the expected "GetStringByKey" data.
+ *
+ * @param requestId The expected request ID.
+ * @param name The expected name in the data.
+ * @param clue An arbitrary string to use as the "clue" to accompany any error messages produced by
+ * this method; if null (the default) then some default clue string will be used.
+ */
+private fun StreamResponse.shouldBeGetStringByKeyDataWithName(
+  requestId: String,
+  name: String,
+  clue: String? = null
+) {
+  withClue(clue ?: "StreamResponse.shouldBeGetStringByKeyDataWithName") {
+    assertSoftly {
+      withClue("requestId") { this.requestId shouldBe requestId }
+      withClue("errorsCount") { this.errorsCount shouldBe 0 }
+
+      val dataDecodeResult = runCatching {
+        decodeFromStruct<RealtimeConnector.GetStringByKeyQuery.Data>(this.data)
+      }
+      withClue("data") {
+        dataDecodeResult shouldBeSuccess { it.item.shouldNotBeNull().name shouldBe name }
+      }
+    }
+  }
+}

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/ConnectRPCIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/ConnectRPCIntegrationTest.kt
@@ -49,7 +49,7 @@ import org.junit.Test
 class ConnectRPCIntegrationTest : DataConnectIntegrationTestBase() {
 
   @Test
-  fun messagesAreReceivedAsEntityChanges() = runTest {
+  fun responseIsReceivedForExecuteQueryRequest() = runTest {
     val requestId = requestIdArb().sample()
     val name = nameArb().sample()
     val (connector, outgoingRequests, incomingResponses) = connect()
@@ -58,8 +58,27 @@ class ConnectRPCIntegrationTest : DataConnectIntegrationTestBase() {
 
     incomingResponses.test {
       outgoingRequests.sendGetStringByKeyExecuteRequest(requestId, key)
+
       val streamResponse = awaitItem()
+
       streamResponse.shouldBeGetStringByKeyDataWithName(requestId = requestId, name = name)
+    }
+  }
+
+  @Test
+  fun responseIsReceivedForExecuteMutationRequest() = runTest {
+    val requestId = requestIdArb().sample()
+    val name = nameArb().sample()
+    val (connector, outgoingRequests, incomingResponses) = connect()
+    outgoingRequests.sendInitRequest(requestId = "init", connector.resourceName)
+
+    incomingResponses.test {
+      outgoingRequests.sendInsertStringExecuteRequest(requestId, name)
+      val streamResponse = awaitItem()
+
+      val key = streamResponse.shouldBeInsertStringData(requestId = requestId)
+
+      connector.getString(key).shouldNotBeNull().name shouldBe name
     }
   }
 
@@ -194,7 +213,7 @@ private fun <Variables> SendChannel<StreamRequest>.sendExecuteRequest(
 }
 
 /**
- * Sends an execution request for a "GetStringByKey" query to the receiver
+ * Sends an execution request for a "RealtimeString_GetByKey" query to the receiver
  * [ConnectionStreams.outgoingRequests].
  *
  * @param requestId The "request ID" to send in the outgoing message.
@@ -211,29 +230,61 @@ private fun SendChannel<StreamRequest>.sendGetStringByKeyExecuteRequest(
 }
 
 /**
- * Assertion to verify that a [StreamResponse] matches the expected "GetStringByKey" data.
+ * Sends an execution request for a "RealtimeString_Insert" query to the receiver
+ * [ConnectionStreams.outgoingRequests].
+ *
+ * @param requestId The "request ID" to send in the outgoing message.
+ * @param name The "name" to send in the outgoing message for the
+ * [RealtimeConnector.InsertStringMutation.Variables.name] property.
+ */
+private fun SendChannel<StreamRequest>.sendInsertStringExecuteRequest(
+  requestId: String,
+  name: String,
+) {
+  val operationName = RealtimeConnector.InsertStringMutation.OPERATION_NAME
+  val variables = RealtimeConnector.InsertStringMutation.Variables(name = name)
+  sendExecuteRequest(requestId, operationName, variables)
+}
+
+/**
+ * Assertion to verify that a [StreamResponse] matches the expected "RealtimeString_GetByKey" data.
  *
  * @param requestId The expected request ID.
  * @param name The expected name in the data.
- * @param clue An arbitrary string to use as the "clue" to accompany any error messages produced by
- * this method; if null (the default) then some default clue string will be used.
  */
-private fun StreamResponse.shouldBeGetStringByKeyDataWithName(
-  requestId: String,
-  name: String,
-  clue: String? = null
-) {
-  withClue(clue ?: "StreamResponse.shouldBeGetStringByKeyDataWithName") {
+private fun StreamResponse.shouldBeGetStringByKeyDataWithName(requestId: String, name: String) {
+  withClue("StreamResponse.shouldBeGetStringByKeyDataWithName") {
     assertSoftly {
-      withClue("requestId") { this.requestId shouldBe requestId }
-      withClue("errorsCount") { this.errorsCount shouldBe 0 }
-
-      val dataDecodeResult = runCatching {
-        decodeFromStruct<RealtimeConnector.GetStringByKeyQuery.Data>(this.data)
-      }
-      withClue("data") {
-        dataDecodeResult shouldBeSuccess { it.item.shouldNotBeNull().name shouldBe name }
-      }
+      val data = shouldBeSuccess<RealtimeConnector.GetStringByKeyQuery.Data>(requestId = requestId)
+      withClue("data") { data.item.shouldNotBeNull().name shouldBe name }
     }
   }
+}
+
+/**
+ * Assertion to verify that a [StreamResponse] matches the expected "RealtimeString_Insert" data.
+ *
+ * @param requestId The expected request ID.
+ */
+private fun StreamResponse.shouldBeInsertStringData(requestId: String): RealtimeConnector.Key =
+  withClue("StreamResponse.shouldBeInsertStringData") {
+    assertSoftly {
+      shouldBeSuccess<RealtimeConnector.InsertStringMutation.Data>(requestId = requestId).key
+    }
+  }
+
+/**
+ * Assertion to verify that a [StreamResponse] matches the expected "RealtimeString_Insert" data.
+ *
+ * @param requestId The expected request ID.
+ * @return the [Data] decoded from the receiver.
+ */
+private inline fun <reified Data> StreamResponse.shouldBeSuccess(requestId: String): Data {
+  withClue("requestId") { this.requestId shouldBe requestId }
+  withClue("errorsCount") { this.errorsCount shouldBe 0 }
+
+  val dataDecodeResult = runCatching { decodeFromStruct<Data>(this.data) }
+  val data = withClue("decodeFromStruct(data)") { dataDecodeResult.shouldBeSuccess() }
+
+  return data
 }

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/ConnectRPCIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/ConnectRPCIntegrationTest.kt
@@ -20,6 +20,8 @@ import app.cash.turbine.test
 import com.google.firebase.dataconnect.testutil.DataConnectIntegrationTestBase
 import com.google.firebase.dataconnect.testutil.createGrpcManagedChannel
 import com.google.firebase.dataconnect.testutil.schemas.RealtimeConnector
+import com.google.firebase.dataconnect.testutil.schemas.RealtimeConnector.GetStringByKeyQuery
+import com.google.firebase.dataconnect.testutil.schemas.RealtimeConnector.InsertStringMutation
 import com.google.firebase.dataconnect.util.ProtoUtil.decodeFromStruct
 import com.google.firebase.dataconnect.util.ProtoUtil.encodeToStruct
 import google.firebase.dataconnect.proto.ConnectorStreamServiceGrpcKt.ConnectorStreamServiceCoroutineStub
@@ -41,9 +43,6 @@ import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.SerializationStrategy
-import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.serializer
 import org.junit.Test
 
 class ConnectRPCIntegrationTest : DataConnectIntegrationTestBase() {
@@ -57,7 +56,19 @@ class ConnectRPCIntegrationTest : DataConnectIntegrationTestBase() {
     outgoingRequests.sendInitRequest(requestId = "init", connector.resourceName)
 
     incomingResponses.test {
-      outgoingRequests.sendGetStringByKeyExecuteRequest(requestId, key)
+      outgoingRequests.sendNonBlockingOrThrow(
+        StreamRequest.newBuilder().let { streamRequest ->
+          streamRequest.setRequestId(requestId)
+          streamRequest.setExecute(
+            ExecuteRequest.newBuilder().let { executeRequest ->
+              executeRequest.setOperationName(GetStringByKeyQuery.OPERATION_NAME)
+              executeRequest.setVariables(encodeToStruct(GetStringByKeyQuery.Variables(key)))
+              executeRequest.build()
+            }
+          )
+          streamRequest.build()
+        }
+      )
 
       val streamResponse = awaitItem()
 
@@ -73,11 +84,23 @@ class ConnectRPCIntegrationTest : DataConnectIntegrationTestBase() {
     outgoingRequests.sendInitRequest(requestId = "init", connector.resourceName)
 
     incomingResponses.test {
-      outgoingRequests.sendInsertStringExecuteRequest(requestId, name)
+      outgoingRequests.sendNonBlockingOrThrow(
+        StreamRequest.newBuilder().let { streamRequest ->
+          streamRequest.setRequestId(requestId)
+          streamRequest.setExecute(
+            ExecuteRequest.newBuilder().let { executeRequest ->
+              executeRequest.setOperationName(InsertStringMutation.OPERATION_NAME)
+              executeRequest.setVariables(encodeToStruct(InsertStringMutation.Variables(name)))
+              executeRequest.build()
+            }
+          )
+          streamRequest.build()
+        }
+      )
+
       val streamResponse = awaitItem()
 
       val key = streamResponse.shouldBeInsertStringData(requestId = requestId)
-
       connector.getString(key).shouldNotBeNull().name shouldBe name
     }
   }
@@ -161,92 +184,6 @@ private fun SendChannel<StreamRequest>.sendInitRequest(
 }
 
 /**
- * Sends an execution request for an operation to the receiver [ConnectionStreams.outgoingRequests].
- *
- * @param requestId The "request ID" to send in the outgoing message.
- * @param operationName The "operation name" to send in the outgoing message.
- * @param variables The "variables" to send in the outgoing message; these variables will be encoded
- * using the object's default serializer, as determined by the [serializer] function.
- */
-private inline fun <reified Variables> SendChannel<StreamRequest>.sendExecuteRequest(
-  requestId: String,
-  operationName: String,
-  variables: Variables
-) {
-  sendExecuteRequest(requestId, operationName, variables, serializer(), null)
-}
-
-/**
- * Sends an execution request for an operation to the receiver [ConnectionStreams.outgoingRequests].
- *
- * @param requestId The "request ID" to send in the outgoing message.
- * @param operationName The "operation name" to send in the outgoing message.
- * @param variables The "variables" to send in the outgoing message; these variables will be encoded
- * using the given [serializer] and [serializersModule].
- * @param serializer The [SerializationStrategy] to use for encoding the given [variables].
- * @param serializersModule The [SerializersModule] to use when encoding the given [variables].
- */
-private fun <Variables> SendChannel<StreamRequest>.sendExecuteRequest(
-  requestId: String,
-  operationName: String,
-  variables: Variables,
-  serializer: SerializationStrategy<Variables>,
-  serializersModule: SerializersModule?
-) {
-  val variablesStruct = encodeToStruct(variables, serializer, serializersModule)
-
-  val executeRequest =
-    ExecuteRequest.newBuilder().let {
-      it.setOperationName(operationName)
-      it.setVariables(variablesStruct)
-      it.build()
-    }
-
-  val streamRequest =
-    StreamRequest.newBuilder().let {
-      it.setRequestId(requestId)
-      it.setExecute(executeRequest)
-      it.build()
-    }
-
-  sendNonBlockingOrThrow(streamRequest)
-}
-
-/**
- * Sends an execution request for a "RealtimeString_GetByKey" query to the receiver
- * [ConnectionStreams.outgoingRequests].
- *
- * @param requestId The "request ID" to send in the outgoing message.
- * @param key The "key" to send in the outgoing message for the
- * [RealtimeConnector.GetStringByKeyQuery.Variables.key] property.
- */
-private fun SendChannel<StreamRequest>.sendGetStringByKeyExecuteRequest(
-  requestId: String,
-  key: RealtimeConnector.Key
-) {
-  val operationName = RealtimeConnector.GetStringByKeyQuery.OPERATION_NAME
-  val variables = RealtimeConnector.GetStringByKeyQuery.Variables(key)
-  sendExecuteRequest(requestId, operationName, variables)
-}
-
-/**
- * Sends an execution request for a "RealtimeString_Insert" query to the receiver
- * [ConnectionStreams.outgoingRequests].
- *
- * @param requestId The "request ID" to send in the outgoing message.
- * @param name The "name" to send in the outgoing message for the
- * [RealtimeConnector.InsertStringMutation.Variables.name] property.
- */
-private fun SendChannel<StreamRequest>.sendInsertStringExecuteRequest(
-  requestId: String,
-  name: String,
-) {
-  val operationName = RealtimeConnector.InsertStringMutation.OPERATION_NAME
-  val variables = RealtimeConnector.InsertStringMutation.Variables(name = name)
-  sendExecuteRequest(requestId, operationName, variables)
-}
-
-/**
  * Assertion to verify that a [StreamResponse] matches the expected "RealtimeString_GetByKey" data.
  *
  * @param requestId The expected request ID.
@@ -255,7 +192,7 @@ private fun SendChannel<StreamRequest>.sendInsertStringExecuteRequest(
 private fun StreamResponse.shouldBeGetStringByKeyDataWithName(requestId: String, name: String) {
   withClue("StreamResponse.shouldBeGetStringByKeyDataWithName") {
     assertSoftly {
-      val data = shouldBeSuccess<RealtimeConnector.GetStringByKeyQuery.Data>(requestId = requestId)
+      val data = shouldBeSuccess<GetStringByKeyQuery.Data>(requestId = requestId)
       withClue("data") { data.item.shouldNotBeNull().name shouldBe name }
     }
   }
@@ -268,9 +205,7 @@ private fun StreamResponse.shouldBeGetStringByKeyDataWithName(requestId: String,
  */
 private fun StreamResponse.shouldBeInsertStringData(requestId: String): RealtimeConnector.Key =
   withClue("StreamResponse.shouldBeInsertStringData") {
-    assertSoftly {
-      shouldBeSuccess<RealtimeConnector.InsertStringMutation.Data>(requestId = requestId).key
-    }
+    assertSoftly { shouldBeSuccess<InsertStringMutation.Data>(requestId = requestId).key }
   }
 
 /**

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/testutil/GrpcTestUtil.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/testutil/GrpcTestUtil.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.dataconnect.testutil
+
+import com.google.firebase.dataconnect.FirebaseDataConnect
+import com.google.firebase.dataconnect.core.DataConnectGrpcRPCs
+import com.google.firebase.dataconnect.core.FirebaseDataConnectInternal
+import com.google.firebase.dataconnect.core.Logger
+import io.grpc.ManagedChannel
+import io.mockk.mockk
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asExecutor
+
+/**
+ * Information about the gRPC configuration used by this [FirebaseDataConnect] instance.
+ *
+ * This is primarily intended for use in tests to inspect or replicate the gRPC connection
+ * parameters, such as the host and whether SSL is enabled.
+ */
+internal val FirebaseDataConnect.grpcTestInfo: DataConnectGrpcRPCs.TestInfo
+  get() = (this as FirebaseDataConnectInternal).grpcRPCs.testInfo
+
+/**
+ * Creates a gRPC [ManagedChannel] that connects to the same remote host as the given
+ * [FirebaseDataConnect] instance, and registers the [ManagedChannel] for automatic cleanup after
+ * the test completes.
+ *
+ * This is useful for integration tests that need to interact with the gRPC layer directly, for
+ * example to verify interceptors or low-level communication.
+ *
+ * @param dataConnect The [FirebaseDataConnect] instance whose gRPC configuration (host, SSL, etc.)
+ * to use to configure the new [ManagedChannel].
+ * @return A new [ManagedChannel] configured to connect to the same backend as [dataConnect].
+ */
+internal fun DataConnectIntegrationTestBase.createGrpcManagedChannel(
+  dataConnect: FirebaseDataConnect
+): ManagedChannel {
+  val (context, host, sslEnabled) = dataConnect.grpcTestInfo
+
+  val managedChannel =
+    DataConnectGrpcRPCs.createGrpcManagedChannel(
+      context,
+      host,
+      sslEnabled,
+      Dispatchers.IO.asExecutor(),
+      mockk<Logger>(name = "TestGrpcManagedChannel", relaxed = true),
+    )
+
+  cleanups.register {
+    managedChannel.shutdownNow()
+    managedChannel.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS)
+  }
+
+  return managedChannel
+}

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/testutil/schemas/RealtimeConnector.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/testutil/schemas/RealtimeConnector.kt
@@ -39,19 +39,19 @@ class RealtimeConnector private constructor(dataConnectInternal: FirebaseDataCon
 
   val deleteString = DeleteStringMutation(this)
 
-  suspend fun getString(key: Key) = getStringByKey.execute(key)
+  suspend fun getString(key: Key): GetStringByKeyQuery.Data.Item? = getStringByKey.execute(key)
 
-  suspend fun insertString(name: String) = insertString.execute(name)
+  suspend fun insertString(name: String): Key = insertString.execute(name)
 
-  suspend fun updateString(key: Key, name: String) = updateString.execute(key, name)
+  suspend fun updateString(key: Key, name: String): Unit = updateString.execute(key, name)
 
-  suspend fun deleteString(key: Key) = deleteString.execute(key)
+  suspend fun deleteString(key: Key): Unit = deleteString.execute(key)
 
   class GetStringByKeyQuery(val connector: RealtimeConnector) {
 
-    suspend fun execute(key: Key) = execute(Variables(key))
+    suspend fun execute(key: Key): Data.Item? = execute(Variables(key))
 
-    suspend fun execute(variables: Variables) = queryRef(variables).execute().data.item
+    suspend fun execute(variables: Variables): Data.Item? = queryRef(variables).execute().data.item
 
     fun queryRef(variables: Variables) =
       connector.dataConnect.query(OPERATION_NAME, variables, serializer<Data>(), serializer())
@@ -72,9 +72,9 @@ class RealtimeConnector private constructor(dataConnectInternal: FirebaseDataCon
     @Serializable data class Variables(val name: String)
     @Serializable data class Data(val key: Key)
 
-    suspend fun execute(name: String) = execute(Variables(name = name))
+    suspend fun execute(name: String): Key = execute(Variables(name = name))
 
-    suspend fun execute(variables: Variables) = mutationRef(variables).execute().data.key
+    suspend fun execute(variables: Variables): Key = mutationRef(variables).execute().data.key
 
     fun mutationRef(variables: Variables) =
       connector.dataConnect.mutation(OPERATION_NAME, variables, serializer<Data>(), serializer())
@@ -87,7 +87,7 @@ class RealtimeConnector private constructor(dataConnectInternal: FirebaseDataCon
   class UpdateStringMutation(val connector: RealtimeConnector) {
     @Serializable data class Variables(val key: Key, val name: String)
 
-    suspend fun execute(key: Key, name: String) = execute(Variables(key = key, name = name))
+    suspend fun execute(key: Key, name: String): Unit = execute(Variables(key = key, name = name))
 
     suspend fun execute(variables: Variables) {
       mutationRef(variables).execute()
@@ -104,7 +104,7 @@ class RealtimeConnector private constructor(dataConnectInternal: FirebaseDataCon
   class DeleteStringMutation(val connector: RealtimeConnector) {
     @Serializable data class Variables(val key: Key)
 
-    suspend fun execute(key: Key) = execute(Variables(key = key))
+    suspend fun execute(key: Key): Unit = execute(Variables(key = key))
 
     suspend fun execute(variables: Variables) {
       mutationRef(variables).execute()

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/testutil/schemas/RealtimeConnector.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/testutil/schemas/RealtimeConnector.kt
@@ -18,13 +18,18 @@ package com.google.firebase.dataconnect.testutil.schemas
 
 import com.google.firebase.dataconnect.ConnectorConfig
 import com.google.firebase.dataconnect.FirebaseDataConnect
+import com.google.firebase.dataconnect.core.FirebaseDataConnectInternal
 import com.google.firebase.dataconnect.serializers.UUIDSerializer
 import com.google.firebase.dataconnect.testutil.TestDataConnectFactory
 import java.util.UUID
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializer
 
-class RealtimeConnector private constructor(val dataConnect: FirebaseDataConnect) {
+class RealtimeConnector private constructor(dataConnectInternal: FirebaseDataConnectInternal) {
+
+  val dataConnect: FirebaseDataConnect = dataConnectInternal
+
+  val resourceName: String = dataConnectInternal.connectorResourceName
 
   val getStringByKey = GetStringByKeyQuery(this)
 
@@ -125,7 +130,7 @@ class RealtimeConnector private constructor(val dataConnect: FirebaseDataConnect
 
     fun getInstance(dataConnectFactory: TestDataConnectFactory): RealtimeConnector {
       val dataConnect = dataConnectFactory.newInstance(config)
-      return RealtimeConnector(dataConnect)
+      return RealtimeConnector(dataConnect as FirebaseDataConnectInternal)
     }
   }
 }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClient.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClient.kt
@@ -39,8 +39,7 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.modules.SerializersModule
 
 internal class DataConnectGrpcClient(
-  projectId: String,
-  connector: ConnectorConfig,
+  private val connectorResourceName: String,
   private val grpcRPCs: DataConnectGrpcRPCs,
   private val dataConnectAuth: DataConnectAuth,
   private val dataConnectAppCheck: DataConnectAppCheck,
@@ -48,12 +47,6 @@ internal class DataConnectGrpcClient(
 ) {
   val instanceId: String
     get() = logger.nameWithId
-
-  private val connectorResourceName =
-    "projects/$projectId/" +
-      "locations/${connector.location}" +
-      "/services/${connector.serviceId}" +
-      "/connectors/${connector.connector}"
 
   data class OperationResult(
     val data: Struct?,

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClient.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClient.kt
@@ -16,6 +16,7 @@
 
 package com.google.firebase.dataconnect.core
 
+import androidx.annotation.VisibleForTesting
 import com.google.firebase.dataconnect.*
 import com.google.firebase.dataconnect.DataConnectPathSegment
 import com.google.firebase.dataconnect.DataSource
@@ -39,7 +40,7 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.modules.SerializersModule
 
 internal class DataConnectGrpcClient(
-  private val connectorResourceName: String,
+  @get:VisibleForTesting val connectorResourceName: String,
   private val grpcRPCs: DataConnectGrpcRPCs,
   private val dataConnectAuth: DataConnectAuth,
   private val dataConnectAppCheck: DataConnectAppCheck,

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -17,6 +17,7 @@
 package com.google.firebase.dataconnect.core
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import com.google.android.gms.security.ProviderInstaller
 import com.google.firebase.dataconnect.CachedDataNotFoundException
 import com.google.firebase.dataconnect.DataConnectPath
@@ -52,12 +53,14 @@ import google.firebase.dataconnect.proto.ExecuteQueryResponse
 import google.firebase.dataconnect.proto.GetEmulatorInfoRequest
 import google.firebase.dataconnect.proto.GraphqlResponseExtensions.DataConnectProperties
 import google.firebase.dataconnect.proto.StreamEmulatorIssuesRequest
+import io.grpc.ManagedChannel
 import io.grpc.ManagedChannelBuilder
 import io.grpc.Metadata
 import io.grpc.MethodDescriptor
 import io.grpc.android.AndroidChannelBuilder
 import java.io.File
 import java.lang.System.currentTimeMillis
+import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
 import kotlinx.coroutines.CancellationException
@@ -92,6 +95,11 @@ internal class DataConnectGrpcRPCs(
     }
   val instanceId: String
     get() = logger.nameWithId
+
+  @VisibleForTesting
+  data class TestInfo(val context: Context, val host: String, val sslEnabled: Boolean)
+
+  @get:VisibleForTesting val testInfo = TestInfo(context, host, sslEnabled)
 
   private val mutex = Mutex()
   private var closed = false
@@ -133,40 +141,8 @@ internal class DataConnectGrpcRPCs(
     SuspendingLazy(mutex = mutex, coroutineContext = blockingCoroutineDispatcher) {
       check(!closed) { "DataConnectGrpcRPCs ${logger.nameWithId} instance has been closed" }
       logger.debug { "Creating GRPC ManagedChannel for host=$host sslEnabled=$sslEnabled" }
-
-      // Upgrade the Android security provider using Google Play Services.
-      //
-      // We need to upgrade the Security Provider before any network channels are initialized
-      // because okhttp maintains a list of supported providers that is initialized when the JVM
-      // first resolves the static dependencies of ManagedChannel.
-      //
-      // If initialization fails for any reason, then a warning is logged and the original,
-      // un-upgraded security provider is used.
-      try {
-        ProviderInstaller.installIfNeeded(context)
-      } catch (e: Exception) {
-        logger.warn(e) { "Failed to update ssl context" }
-      }
-
-      val grpcChannel =
-        ManagedChannelBuilder.forTarget(host).let {
-          if (!sslEnabled) {
-            it.usePlaintext()
-          }
-
-          // Ensure gRPC recovers from a dead connection. This is not typically necessary, as
-          // the OS will usually notify gRPC when a connection dies. But not always. This acts as a
-          // failsafe.
-          it.keepAliveTime(30, TimeUnit.SECONDS)
-
-          it.executor(blockingCoroutineDispatcher.asExecutor())
-
-          // Wrap the `ManagedChannelBuilder` in an `AndroidChannelBuilder`. This allows the channel
-          // to respond more gracefully to network change events, such as switching from cellular to
-          // wifi.
-          AndroidChannelBuilder.usingBuilder(it).context(context).build()
-        }
-
+      val executor = blockingCoroutineDispatcher.asExecutor()
+      val grpcChannel = createGrpcManagedChannel(context, host, sslEnabled, executor, logger)
       logger.debug { "Creating GRPC ManagedChannel for host=$host sslEnabled=$sslEnabled done" }
       grpcChannel
     }
@@ -470,8 +446,50 @@ internal class DataConnectGrpcRPCs(
     }
   }
 
-  private companion object {
-    fun Logger.logGrpcSending(
+  companion object {
+
+    @VisibleForTesting
+    fun createGrpcManagedChannel(
+      context: Context,
+      host: String,
+      sslEnabled: Boolean,
+      executor: Executor,
+      logger: Logger
+    ): ManagedChannel {
+      // Upgrade the Android security provider using Google Play Services.
+      //
+      // We need to upgrade the Security Provider before any network channels are initialized
+      // because okhttp maintains a list of supported providers that is initialized when the JVM
+      // first resolves the static dependencies of ManagedChannel.
+      //
+      // If initialization fails for any reason, then a warning is logged and the original,
+      // un-upgraded security provider is used.
+      try {
+        ProviderInstaller.installIfNeeded(context)
+      } catch (e: Exception) {
+        logger.warn(e) { "Failed to update ssl context" }
+      }
+
+      return ManagedChannelBuilder.forTarget(host).let {
+        if (!sslEnabled) {
+          it.usePlaintext()
+        }
+
+        // Ensure gRPC recovers from a dead connection. This is not typically necessary, as
+        // the OS will usually notify gRPC when a connection dies. But not always. This acts as a
+        // failsafe.
+        it.keepAliveTime(30, TimeUnit.SECONDS)
+
+        it.executor(executor)
+
+        // Wrap the `ManagedChannelBuilder` in an `AndroidChannelBuilder`. This allows the channel
+        // to respond more gracefully to network change events, such as switching from cellular to
+        // wifi.
+        AndroidChannelBuilder.usingBuilder(it).context(context).build()
+      }
+    }
+
+    private fun Logger.logGrpcSending(
       requestId: String,
       kotlinMethodName: String,
       grpcMethod: MethodDescriptor<*, *>,
@@ -497,7 +515,7 @@ internal class DataConnectGrpcRPCs(
       "$kotlinMethodName [rid=$requestId] sending: ${struct.toCompactString(keySortSelector)}"
     }
 
-    fun Logger.logGrpcReturningFromCache(
+    private fun Logger.logGrpcReturningFromCache(
       requestId: String,
       kotlinMethodName: String,
       cachedResult: DataConnectCacheDatabase.GetQueryResultResult.Found,
@@ -507,7 +525,7 @@ internal class DataConnectGrpcRPCs(
         "(expires in ${cachedResult.freshnessRemaining})"
     }
 
-    fun Logger.logGrpcIgnoringStaleCache(
+    private fun Logger.logGrpcIgnoringStaleCache(
       requestId: String,
       kotlinMethodName: String,
       cachedResult: DataConnectCacheDatabase.GetQueryResultResult.Stale,
@@ -516,18 +534,18 @@ internal class DataConnectGrpcRPCs(
         "because it expired ${cachedResult.staleness} ago"
     }
 
-    fun Logger.logGrpcStarting(
+    private fun Logger.logGrpcStarting(
       requestId: String,
       kotlinMethodName: String,
       grpcMethod: MethodDescriptor<*, *>,
     ) = debug { "$kotlinMethodName [rid=$requestId] starting ${grpcMethod.fullMethodName}" }
 
-    fun Logger.logGrpcCompleted(
+    private fun Logger.logGrpcCompleted(
       requestId: String,
       kotlinMethodName: String,
     ) = debug { "$kotlinMethodName [rid=$requestId] completed" }
 
-    fun Logger.logGrpcReceived(
+    private fun Logger.logGrpcReceived(
       requestId: String,
       kotlinMethodName: String,
       response: Struct,
@@ -537,7 +555,7 @@ internal class DataConnectGrpcRPCs(
       "$kotlinMethodName [rid=$requestId] received: ${struct.toCompactString()}"
     }
 
-    fun Logger.logGrpcFailed(
+    private fun Logger.logGrpcFailed(
       requestId: String,
       kotlinMethodName: String,
       throwable: Throwable,

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImpl.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImpl.kt
@@ -72,7 +72,9 @@ internal interface FirebaseDataConnectInternal : FirebaseDataConnect {
   val nonBlockingExecutor: Executor
   val nonBlockingDispatcher: CoroutineDispatcher
 
+  val connectorResourceName: String
   val grpcClient: DataConnectGrpcClient
+  val grpcRPCs: DataConnectGrpcRPCs
   val queryManager: QueryManager
 
   suspend fun awaitAuthReady()
@@ -121,6 +123,12 @@ internal class FirebaseDataConnectImpl(
         }
     )
 
+  override val connectorResourceName =
+    "projects/$projectId/" +
+      "locations/${config.location}" +
+      "/services/${config.serviceId}" +
+      "/connectors/${config.connector}"
+
   private val dataConnectAuth: DataConnectAuth =
     DataConnectAuth(
         deferredAuthProvider = deferredAuthProvider,
@@ -164,6 +172,8 @@ internal class FirebaseDataConnectImpl(
 
   override val grpcClient: DataConnectGrpcClient
     get() = initialize().grpcClient
+  override val grpcRPCs: DataConnectGrpcRPCs
+    get() = initialize().grpcRPCs
   override val queryManager: QueryManager
     get() = initialize().queryManager
 
@@ -282,8 +292,7 @@ internal class FirebaseDataConnectImpl(
 
   private fun createDataConnectGrpcClient(grpcRPCs: DataConnectGrpcRPCs): DataConnectGrpcClient =
     DataConnectGrpcClient(
-      projectId = projectId,
-      connector = config,
+      connectorResourceName = connectorResourceName,
       grpcRPCs = grpcRPCs,
       dataConnectAuth = dataConnectAuth,
       dataConnectAppCheck = dataConnectAppCheck,

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClientUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClientUnitTest.kt
@@ -115,8 +115,7 @@ class DataConnectGrpcClientUnitTest {
   @get:Rule val randomSeedTestRule = RandomSeedTestRule()
 
   private val rs: RandomSource by randomSeedTestRule.rs
-  private val projectId = Arb.dataConnect.projectId().next(rs)
-  private val connectorConfig = Arb.dataConnect.connectorConfig().next(rs)
+  private val connectorResourceName = Arb.dataConnect.connectorResourceName().next(rs)
   private val requestId = Arb.dataConnect.requestId().next(rs)
   private val operationName = Arb.dataConnect.operationName().next(rs)
   private val variables = Arb.proto.struct().next(rs).struct
@@ -144,8 +143,7 @@ class DataConnectGrpcClientUnitTest {
 
   private val dataConnectGrpcClient =
     DataConnectGrpcClient(
-      projectId = projectId,
-      connector = connectorConfig,
+      connectorResourceName = connectorResourceName,
       grpcRPCs = mockDataConnectGrpcRPCs,
       dataConnectAuth = mockDataConnectAuth,
       dataConnectAppCheck = mockDataConnectAppCheck,
@@ -196,14 +194,9 @@ class DataConnectGrpcClientUnitTest {
         fetchPolicy
       )
 
-      val expectedConnectorResourceName =
-        "projects/${projectId}" +
-          "/locations/${connectorConfig.location}" +
-          "/services/${connectorConfig.serviceId}" +
-          "/connectors/${connectorConfig.connector}"
       val expectedRequest =
         ExecuteQueryRequest.newBuilder()
-          .setName(expectedConnectorResourceName)
+          .setName(connectorResourceName)
           .setOperationName(operationName)
           .setVariables(variables)
           .build()
@@ -230,14 +223,9 @@ class DataConnectGrpcClientUnitTest {
   fun `executeMutation() should send the right ExecuteMutationRequest`() = runTest {
     dataConnectGrpcClient.executeMutation(requestId, operationName, variables, callerSdkType)
 
-    val expectedConnectorResourceName =
-      "projects/${projectId}" +
-        "/locations/${connectorConfig.location}" +
-        "/services/${connectorConfig.serviceId}" +
-        "/connectors/${connectorConfig.connector}"
     val expectedRequest =
       ExecuteMutationRequest.newBuilder()
-        .setName(expectedConnectorResourceName)
+        .setName(connectorResourceName)
         .setOperationName(operationName)
         .setVariables(variables)
         .build()

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImplUnitTest.kt
@@ -18,6 +18,7 @@ package com.google.firebase.dataconnect.core
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.firebase.appcheck.interop.InteropAppCheckTokenProvider
 import com.google.firebase.auth.internal.InternalAuthProvider
+import com.google.firebase.dataconnect.ConnectorConfig
 import com.google.firebase.dataconnect.FirebaseDataConnect.CallerSdkType
 import com.google.firebase.dataconnect.testutil.CleanupsRule
 import com.google.firebase.dataconnect.testutil.DataConnectLogLevelRule
@@ -29,13 +30,18 @@ import com.google.firebase.dataconnect.testutil.delayIgnoringTestScheduler
 import com.google.firebase.dataconnect.testutil.property.arbitrary.dataConnect
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.withClue
+import io.kotest.common.ExperimentalKotest
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.kotest.property.Arb
+import io.kotest.property.EdgeConfig
+import io.kotest.property.PropTestConfig
 import io.kotest.property.RandomSource
+import io.kotest.property.ShrinkingMode
 import io.kotest.property.arbitrary.enum
 import io.kotest.property.arbitrary.next
+import io.kotest.property.checkAll
 import io.mockk.mockk
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
@@ -239,18 +245,45 @@ class FirebaseDataConnectImplUnitTest {
       job.join()
     }
 
+  @Test
+  fun `connectorResourceName should be the correct value`() = runTest {
+    checkAll(propTestConfig, Arb.dataConnect.projectId(), Arb.dataConnect.connectorConfig()) {
+      projectId,
+      config ->
+      val dataConnect = newDataConnect(projectId = projectId, config = config)
+      dataConnect.connectorResourceName shouldBe
+        "projects/$projectId/" +
+          "locations/${config.location}" +
+          "/services/${config.serviceId}" +
+          "/connectors/${config.connector}"
+    }
+  }
+
+  @Test
+  fun `connectorResourceName should be correctly passed along to the DataConnectGrpcClient`() =
+    runTest {
+      checkAll(propTestConfig, Arb.dataConnect.projectId(), Arb.dataConnect.connectorConfig()) {
+        projectId,
+        config ->
+        val dataConnect = newDataConnect(projectId = projectId, config = config)
+        dataConnect.grpcClient.connectorResourceName shouldBe dataConnect.connectorResourceName
+      }
+    }
+
   private fun newDataConnect(
     deferredAuthProvider: com.google.firebase.inject.Deferred<InternalAuthProvider> =
       mockk(relaxed = true),
     deferredAppCheckProvider: com.google.firebase.inject.Deferred<InteropAppCheckTokenProvider> =
       mockk(relaxed = true),
+    projectId: String? = null,
+    config: ConnectorConfig? = null,
   ): FirebaseDataConnectImpl {
     val app = firebaseAppFactory.newInstance()
     return FirebaseDataConnectImpl(
         context = app.applicationContext,
         app = app,
-        projectId = app.options.projectId!!,
-        config = Arb.dataConnect.connectorConfig().next(rs),
+        projectId = projectId ?: app.options.projectId!!,
+        config = config ?: Arb.dataConnect.connectorConfig().next(rs),
         blockingExecutor = Dispatchers.IO.asExecutor(),
         nonBlockingExecutor = Dispatchers.Default.asExecutor(),
         deferredAuthProvider = deferredAuthProvider,
@@ -265,3 +298,11 @@ class FirebaseDataConnectImplUnitTest {
   private interface TestVariables
   private interface TestData
 }
+
+@OptIn(ExperimentalKotest::class)
+private val propTestConfig =
+  PropTestConfig(
+    iterations = 200,
+    edgeConfig = EdgeConfig(edgecasesGenerationProbability = 0.33),
+    shrinkingMode = ShrinkingMode.Off,
+  )

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/arbs.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/arbs.kt
@@ -30,6 +30,7 @@ import io.kotest.property.arbitrary.alphanumeric
 import io.kotest.property.arbitrary.arabic
 import io.kotest.property.arbitrary.arbitrary
 import io.kotest.property.arbitrary.ascii
+import io.kotest.property.arbitrary.az
 import io.kotest.property.arbitrary.bind
 import io.kotest.property.arbitrary.boolean
 import io.kotest.property.arbitrary.choice
@@ -159,6 +160,10 @@ object DataConnectArb {
     arbitrary {
       "requestId_${string.bind()}"
     }
+
+  fun connectorResourceName(
+    string: Arb<String> = Arb.string(size = 8, Codepoint.az())
+  ): Arb<String> = arbitrary { "connectorResourceName_${string.bind()}" }
 
   fun operationName(
     string: Arb<String> = Arb.string(size = 8, Codepoint.alphanumeric())


### PR DESCRIPTION
This PR adds the first integration tests for the Data Connect `Connect` RPC and refactors several core classes to improve testability and exposure of gRPC configuration.

### Highlights
- Introduced `ConnectRPCIntegrationTest` to verify end-to-end message flow for the bidirectional streaming `Connect` RPC.
- Refactored `DataConnectGrpcClient` to accept a pre-computed `connectorResourceName`, centralizing its calculation in `FirebaseDataConnectImpl`.
- Enhanced gRPC testability by exposing configuration details and extracting channel creation into a reusable utility.
- Updated `RealtimeConnector` and property-based testing generators to support the new integration tests.

### Changelog
<details>

- `ConnectRPCIntegrationTest.kt`: Added new integration test for the streaming `Connect` RPC.
- `GrpcTestUtil.kt`: Added utility functions for creating and cleaning up gRPC channels in tests.
- `RealtimeConnector.kt`: Updated to expose `resourceName` and use `FirebaseDataConnectInternal`.
- `DataConnectGrpcClient.kt`: Updated constructor to accept `connectorResourceName` directly.
- `DataConnectGrpcRPCs.kt`: Refactored channel creation into a companion object and exposed `TestInfo`.
- `FirebaseDataConnectImpl.kt`: Moved `connectorResourceName` calculation to the implementation class and exposed it.
- `DataConnectGrpcClientUnitTest.kt`: Updated to reflect changes in `DataConnectGrpcClient` constructor.
- `FirebaseDataConnectImplUnitTest.kt`: Added unit tests for `connectorResourceName` calculation and propagation.
- `arbs.kt`: Added `connectorResourceName` generator for property-based testing.
- `DataConnectIntegrationTestBase.kt`: Added `CleanupsRule` for resource management in tests.
</details>