### PR TITLE
dataconnect(test): ConnectRPCIntegrationTest.kt: add more tests

### DIFF
--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/ConnectRPCIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/ConnectRPCIntegrationTest.kt
@@ -19,90 +19,330 @@ package com.google.firebase.dataconnect
 import app.cash.turbine.test
 import com.google.firebase.dataconnect.testutil.DataConnectIntegrationTestBase
 import com.google.firebase.dataconnect.testutil.createGrpcManagedChannel
+import com.google.firebase.dataconnect.testutil.property.arbitrary.pair
+import com.google.firebase.dataconnect.testutil.registerDataConnectKotestPrinters
 import com.google.firebase.dataconnect.testutil.schemas.RealtimeConnector
 import com.google.firebase.dataconnect.testutil.schemas.RealtimeConnector.GetStringByKeyQuery
 import com.google.firebase.dataconnect.testutil.schemas.RealtimeConnector.InsertStringMutation
+import com.google.firebase.dataconnect.testutil.shouldContainWithNonAbuttingText
+import com.google.firebase.dataconnect.testutil.shouldContainWithNonAbuttingTextIgnoringCase
 import com.google.firebase.dataconnect.util.ProtoUtil.decodeFromStruct
 import com.google.firebase.dataconnect.util.ProtoUtil.encodeToStruct
 import google.firebase.dataconnect.proto.ConnectorStreamServiceGrpcKt.ConnectorStreamServiceCoroutineStub
 import google.firebase.dataconnect.proto.ExecuteRequest
 import google.firebase.dataconnect.proto.StreamRequest
 import google.firebase.dataconnect.proto.StreamResponse
+import io.grpc.Status
+import io.grpc.StatusException
 import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.print.print
 import io.kotest.assertions.withClue
+import io.kotest.common.DelicateKotest
+import io.kotest.common.ExperimentalKotest
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.throwable.shouldHaveMessage
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.kotest.property.Arb
+import io.kotest.property.EdgeConfig
+import io.kotest.property.PropTestConfig
+import io.kotest.property.ShrinkingMode
 import io.kotest.property.arbitrary.Codepoint
+import io.kotest.property.arbitrary.arbitrary
 import io.kotest.property.arbitrary.az
+import io.kotest.property.arbitrary.distinct
+import io.kotest.property.arbitrary.enum
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.string
+import io.kotest.property.arbitrary.uuid
+import io.kotest.property.checkAll
+import java.util.UUID
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import org.junit.Before
 import org.junit.Test
 
 class ConnectRPCIntegrationTest : DataConnectIntegrationTestBase() {
 
-  @Test
-  fun responseIsReceivedForExecuteQueryRequest() = runTest {
-    val requestId = requestIdArb().sample()
-    val name = nameArb().sample()
-    val (connector, outgoingRequests, incomingResponses) = connect()
-    val key = connector.insertString(name)
-    outgoingRequests.sendInitRequest(requestId = "init", connector.resourceName)
+  @Before
+  fun registerPrinters() {
+    registerDataConnectKotestPrinters()
+  }
 
-    incomingResponses.test {
-      outgoingRequests.sendNonBlockingOrThrow(
-        StreamRequest.newBuilder().let { streamRequest ->
-          streamRequest.setRequestId(requestId)
-          streamRequest.setExecute(
-            ExecuteRequest.newBuilder().let { executeRequest ->
-              executeRequest.setOperationName(GetStringByKeyQuery.OPERATION_NAME)
-              executeRequest.setVariables(encodeToStruct(GetStringByKeyQuery.Variables(key)))
-              executeRequest.build()
-            }
-          )
-          streamRequest.build()
+  @Test
+  fun executeRequestForQuerySucceeds() = runTest {
+    val name = nameArb().sample()
+    val streams = connect()
+    val key = streams.connector.insertString(name)
+    streams.sendInitRequest()
+
+    val streamResponse =
+      verifyExecuteRequestReturnsCorrectRequestIdAndCancelledTrue(
+        streams,
+        expectedErrorsCount = 0,
+        ExecuteRequest.newBuilder().let { executeRequest ->
+          executeRequest.setOperationName(GetStringByKeyQuery.OPERATION_NAME)
+          executeRequest.setVariables(encodeToStruct(GetStringByKeyQuery.Variables(key)))
+          executeRequest.build()
         }
       )
 
-      val streamResponse = awaitItem()
+    val data = streamResponse.shouldHaveData<GetStringByKeyQuery.Data>()
+    data.item.shouldNotBeNull().name shouldBe name
+  }
 
-      streamResponse.shouldBeGetStringByKeyDataWithName(requestId = requestId, name = name)
+  @Test
+  fun executeRequestForMutationSucceeds() = runTest {
+    val name = nameArb().sample()
+    val streams = connect()
+    streams.sendInitRequest()
+
+    val streamResponse =
+      verifyExecuteRequestReturnsCorrectRequestIdAndCancelledTrue(
+        streams,
+        expectedErrorsCount = 0,
+        ExecuteRequest.newBuilder().let { executeRequest ->
+          executeRequest.setOperationName(InsertStringMutation.OPERATION_NAME)
+          executeRequest.setVariables(encodeToStruct(InsertStringMutation.Variables(name)))
+          executeRequest.build()
+        }
+      )
+
+    val data = streamResponse.shouldHaveData<InsertStringMutation.Data>()
+    streams.connector.getString(data.key).shouldNotBeNull().name shouldBe name
+  }
+
+  @Test
+  fun executeRequestForNonExistentOperationFails() = runTest {
+    val streams = connect()
+    streams.sendInitRequest()
+
+    val streamResponse =
+      verifyExecuteRequestReturnsCorrectRequestIdAndCancelledTrue(
+        streams,
+        expectedErrorsCount = 1,
+        ExecuteRequest.newBuilder().let { executeRequest ->
+          executeRequest.setOperationName("NonExistentOperationName")
+          executeRequest.build()
+        }
+      )
+
+    val error = streamResponse.errorsList.single()
+    withClue("error=${error.print().value}") {
+      error.message shouldContainWithNonAbuttingText "NonExistentOperationName"
     }
   }
 
   @Test
-  fun responseIsReceivedForExecuteMutationRequest() = runTest {
-    val requestId = requestIdArb().sample()
-    val name = nameArb().sample()
-    val (connector, outgoingRequests, incomingResponses) = connect()
-    outgoingRequests.sendInitRequest(requestId = "init", connector.resourceName)
+  fun executeRequestWithoutInitFails() = runTest {
+    checkAll(propTestConfig, validStreamRequestArb()) { streamRequest ->
+      val streams = connect()
+      streams.incomingResponses.test {
+        streams.outgoingRequests.send(streamRequest)
 
-    incomingResponses.test {
-      outgoingRequests.sendNonBlockingOrThrow(
-        StreamRequest.newBuilder().let { streamRequest ->
-          streamRequest.setRequestId(requestId)
-          streamRequest.setExecute(
-            ExecuteRequest.newBuilder().let { executeRequest ->
-              executeRequest.setOperationName(InsertStringMutation.OPERATION_NAME)
-              executeRequest.setVariables(encodeToStruct(InsertStringMutation.Variables(name)))
-              executeRequest.build()
-            }
-          )
-          streamRequest.build()
+        val exception = awaitError()
+
+        val statusException = exception.shouldBeInstanceOf<StatusException>()
+        statusException.status.code shouldBe Status.Code.INVALID_ARGUMENT
+        statusException.message shouldContainWithNonAbuttingTextIgnoringCase
+          "invalid connector name"
+      }
+    }
+  }
+
+  @Test
+  fun closingOutgoingRequestsBeforeSendingAndListeningFailsIncomingResponses() = runTest {
+    val streams = connect()
+    streams.outgoingRequests.close()
+
+    streams.incomingResponses.test {
+      val exception = awaitError()
+
+      val statusException = exception.shouldBeInstanceOf<StatusException>()
+      statusException.status.code shouldBe Status.Code.UNKNOWN
+      statusException.message shouldContainWithNonAbuttingTextIgnoringCase
+        "failed to receive first request"
+    }
+  }
+
+  @Test
+  fun closingOutgoingRequestsBeforeSendingButAfterListeningFailsIncomingResponses() = runTest {
+    val streams = connect()
+
+    streams.incomingResponses.test {
+      streams.outgoingRequests.close()
+
+      val exception = awaitError()
+
+      val statusException = exception.shouldBeInstanceOf<StatusException>()
+      statusException.status.code shouldBe Status.Code.UNKNOWN
+      statusException.message shouldContainWithNonAbuttingTextIgnoringCase
+        "failed to receive first request"
+    }
+  }
+
+  @Test
+  fun closingOutgoingRequestsAfterStreamEstablishedClosesIncomingResponses() = runTest {
+    val streams = connect()
+    streams.sendInitRequest()
+
+    streams.incomingResponses.test {
+      val streamRequest = validStreamRequestArb().sample()
+      streams.outgoingRequests.send(streamRequest)
+      awaitItem().requestId shouldBe streamRequest.requestId
+
+      streams.outgoingRequests.close()
+
+      awaitComplete()
+    }
+  }
+
+  @Test
+  fun closingOutgoingRequestsBeforeSendingWithCancellationExceptionFailsIncomingResponses() =
+    runTest {
+      val streams = connect()
+
+      streams.incomingResponses.test {
+        streams.outgoingRequests.close(CancellationException("forced exception v5bgf9ppmm"))
+
+        val exception = awaitError()
+
+        val cancellationException = exception.shouldBeInstanceOf<CancellationException>()
+        cancellationException shouldHaveMessage "forced exception v5bgf9ppmm"
+      }
+    }
+
+  @Test
+  fun closingOutgoingRequestsBeforeSendingWithNonCancellationExceptionFailsIncomingResponses() =
+    runTest {
+      class TestException(message: String) : Exception(message)
+      val streams = connect()
+
+      streams.incomingResponses.test {
+        streams.outgoingRequests.close(TestException("forced exception gajhw85ajt"))
+
+        val exception = awaitError()
+
+        val testException = exception.shouldBeInstanceOf<TestException>()
+        testException shouldHaveMessage "forced exception gajhw85ajt"
+      }
+    }
+
+  @Test
+  fun collectIncomingResponsesCancelsBeforeCollectingAnyResponses() = runTest {
+    val streams = connect()
+    // Note: Specify CoroutineStart.UNDISPATCHED to guarantee that collect() is called before
+    // cancelling the coroutine via the cancelAndJoin() call.
+    val collectJob =
+      backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+        streams.incomingResponses.collect()
+      }
+    collectJob.cancelAndJoin()
+
+    streams.sendInitRequest()
+    checkAll(propTestConfig, validStreamRequestArb()) { streamRequest ->
+      val sendResult = streams.outgoingRequests.trySend(streamRequest)
+      sendResult.isSuccess shouldBe true
+      sendResult.isClosed shouldBe false
+    }
+  }
+
+  @Test
+  fun collectIncomingResponsesCancelsAfterCollectingResponses() = runTest {
+    val streams = connect()
+    val collectedValues = Channel<StreamResponse>(capacity = UNLIMITED)
+    val collectJob =
+      backgroundScope.launch { streams.incomingResponses.collect(collectedValues::send) }
+
+    val (streamRequest1, streamRequest2) = validStreamRequestArb().pair().sample()
+    streams.sendInitRequest()
+    streams.outgoingRequests.send(streamRequest1)
+    collectedValues.receive().requestId shouldBe streamRequest1.requestId
+    collectJob.cancelAndJoin()
+    val sendResult = streams.outgoingRequests.trySend(streamRequest2)
+
+    sendResult.exceptionOrNull().shouldBeInstanceOf<CancellationException>()
+    sendResult.isClosed shouldBe true
+  }
+
+  @Test
+  fun collectIncomingResponsesThrowsBeforeFirstSendToOutgoingRequests() = runTest {
+    class TestException(message: String) : Exception(message)
+    val streams = connect()
+    val collectJob =
+      backgroundScope.launch {
+        streams.incomingResponses.runCatching {
+          collect { throw TestException("forced exception kxf3z6dbmr") }
         }
-      )
+      }
+
+    val (streamRequest1, streamRequest2) = validStreamRequestArb().pair().sample()
+    streams.sendInitRequest()
+    streams.outgoingRequests.send(streamRequest1)
+    collectJob.join()
+    val sendResult = streams.outgoingRequests.trySend(streamRequest2)
+
+    val cancellationException =
+      sendResult.exceptionOrNull().shouldBeInstanceOf<CancellationException>()
+    val testException = cancellationException.cause.shouldBeInstanceOf<TestException>()
+    testException shouldHaveMessage "forced exception kxf3z6dbmr"
+    sendResult.isClosed shouldBe true
+  }
+
+  @Test
+  fun testValidStreamRequestArb() = runTest {
+    val streams = connect()
+    streams.sendInitRequest()
+
+    streams.incomingResponses.test {
+      checkAll(propTestConfig, validStreamRequestArb()) { streamRequest ->
+        streams.outgoingRequests.send(streamRequest)
+        val streamResponse = awaitItem()
+        streamResponse.requestId shouldBe streamRequest.requestId
+        streamResponse.errorsCount shouldBe 0
+      }
+    }
+  }
+
+  private suspend fun verifyExecuteRequestReturnsCorrectRequestIdAndCancelledTrue(
+    streams: ConnectionStreams,
+    expectedErrorsCount: Int,
+    executeRequest: ExecuteRequest,
+  ): StreamResponse {
+    val requestId = requestIdArb().sample()
+    val streamRequest =
+      StreamRequest.newBuilder().let { streamRequest ->
+        streamRequest.setRequestId(requestId)
+        streamRequest.setExecute(executeRequest)
+        streamRequest.build()
+      }
+
+    val streamResponses = Channel<StreamResponse>(capacity = 1)
+    streams.incomingResponses.test {
+      streams.outgoingRequests.sendNonBlockingOrThrow(streamRequest)
 
       val streamResponse = awaitItem()
 
-      val key = streamResponse.shouldBeInsertStringData(requestId = requestId)
-      connector.getString(key).shouldNotBeNull().name shouldBe name
+      assertSoftly {
+        withClue("requestId") { streamResponse.requestId shouldBe requestId }
+        withClue("cancelled") { streamResponse.cancelled shouldBe true }
+        withClue("errorsCount") { streamResponse.errorsCount shouldBe expectedErrorsCount }
+      }
+
+      streamResponses.send(streamResponse)
     }
+
+    return streamResponses.receive()
   }
 
   /**
@@ -125,6 +365,14 @@ class ConnectRPCIntegrationTest : DataConnectIntegrationTestBase() {
   private fun <T> Arb<T>.sample(): T = sample(rs).value
 }
 
+@OptIn(ExperimentalKotest::class)
+private val propTestConfig =
+  PropTestConfig(
+    iterations = 5,
+    edgeConfig = EdgeConfig(edgecasesGenerationProbability = 0.2),
+    shrinkingMode = ShrinkingMode.Off,
+  )
+
 /**
  * Creates and returns an [Arb] that generates strings that are suitable for, and recognizable as,
  * "request IDs" in [StreamRequest] messages.
@@ -137,6 +385,17 @@ private fun requestIdArb(): Arb<String> = Arb.string(size = 4, Codepoint.az()).m
  * [RealtimeConnector.UpdateStringMutation.Variables.name].
  */
 private fun nameArb(): Arb<String> = Arb.string(size = 4, Codepoint.az()).map { "nam$it" }
+
+/**
+ * Creates and returns an [Arb] that generates "key" objects for rows inserted by
+ * [RealtimeConnector.InsertStringMutation] and fetched by [RealtimeConnector.GetStringByKeyQuery].
+ */
+private fun keyArb(uuid: Arb<UUID> = Arb.uuid()): Arb<RealtimeConnector.Key> =
+  uuid.map(RealtimeConnector::Key)
+
+private fun ConnectionStreams.sendInitRequest() {
+  outgoingRequests.sendInitRequest(requestId = "init", connector.resourceName)
+}
 
 /** Exception thrown by [sendNonBlockingOrThrow] if sending fails. */
 private class SendChannelTrySendUnsuccessfulException(message: String, cause: Throwable?) :
@@ -184,42 +443,57 @@ private fun SendChannel<StreamRequest>.sendInitRequest(
 }
 
 /**
- * Assertion to verify that a [StreamResponse] matches the expected "RealtimeString_GetByKey" data.
+ * Assertion to verify that a [StreamResponse] is successful and has data that matches the given
+ * predicate.
  *
- * @param requestId The expected request ID.
- * @param name The expected name in the data.
+ * @param predicate the function to call with the data to verify it.
+ * @return the [Data] decoded from the receiver, that was specified to the given [predicate].
  */
-private fun StreamResponse.shouldBeGetStringByKeyDataWithName(requestId: String, name: String) {
-  withClue("StreamResponse.shouldBeGetStringByKeyDataWithName") {
-    assertSoftly {
-      val data = shouldBeSuccess<GetStringByKeyQuery.Data>(requestId = requestId)
-      withClue("data") { data.item.shouldNotBeNull().name shouldBe name }
-    }
-  }
+private inline fun <reified Data> StreamResponse.shouldHaveData(
+  predicate: (Data) -> Unit = {}
+): Data {
+  val dataDecodeResult = runCatching { decodeFromStruct<Data>(data) }
+  val data = withClue("decodeFromStruct(data)") { dataDecodeResult.shouldBeSuccess() }
+  withClue("data") { predicate(data) }
+  return data
+}
+
+private enum class ValidStreamRequestType {
+  ExecuteQuery,
+  ExecuteMutation,
 }
 
 /**
- * Assertion to verify that a [StreamResponse] matches the expected "RealtimeString_Insert" data.
- *
- * @param requestId The expected request ID.
+ * Creates and returns an [Arb] that generates [StreamRequest] objects that, when sent to the
+ * [ConnectionStreams.outgoingRequests] after the "init" request, should succeed.
  */
-private fun StreamResponse.shouldBeInsertStringData(requestId: String): RealtimeConnector.Key =
-  withClue("StreamResponse.shouldBeInsertStringData") {
-    assertSoftly { shouldBeSuccess<InsertStringMutation.Data>(requestId = requestId).key }
+private fun validStreamRequestArb(
+  requestId: Arb<String> = @OptIn(DelicateKotest::class) requestIdArb().distinct(),
+  name: Arb<String> = nameArb(),
+  key: Arb<RealtimeConnector.Key> = keyArb(),
+  validStreamRequestType: Arb<ValidStreamRequestType> = Arb.enum<ValidStreamRequestType>(),
+): Arb<StreamRequest> = arbitrary {
+  val streamRequest = StreamRequest.newBuilder()
+  streamRequest.setRequestId(requestId.bind())
+
+  when (validStreamRequestType.bind()) {
+    ValidStreamRequestType.ExecuteQuery ->
+      streamRequest.setExecute(
+        ExecuteRequest.newBuilder().let { executeRequest ->
+          executeRequest.setOperationName(GetStringByKeyQuery.OPERATION_NAME)
+          executeRequest.setVariables(encodeToStruct(GetStringByKeyQuery.Variables(key.bind())))
+          executeRequest.build()
+        }
+      )
+    ValidStreamRequestType.ExecuteMutation ->
+      streamRequest.setExecute(
+        ExecuteRequest.newBuilder().let { executeRequest ->
+          executeRequest.setOperationName(InsertStringMutation.OPERATION_NAME)
+          executeRequest.setVariables(encodeToStruct(InsertStringMutation.Variables(name.bind())))
+          executeRequest.build()
+        }
+      )
   }
 
-/**
- * Assertion to verify that a [StreamResponse] matches the expected "RealtimeString_Insert" data.
- *
- * @param requestId The expected request ID.
- * @return the [Data] decoded from the receiver.
- */
-private inline fun <reified Data> StreamResponse.shouldBeSuccess(requestId: String): Data {
-  withClue("requestId") { this.requestId shouldBe requestId }
-  withClue("errorsCount") { this.errorsCount shouldBe 0 }
-
-  val dataDecodeResult = runCatching { decodeFromStruct<Data>(this.data) }
-  val data = withClue("decodeFromStruct(data)") { dataDecodeResult.shouldBeSuccess() }
-
-  return data
+  streamRequest.build()
 }

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/ConnectRPCIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/ConnectRPCIntegrationTest.kt
@@ -327,22 +327,20 @@ class ConnectRPCIntegrationTest : DataConnectIntegrationTestBase() {
         streamRequest.build()
       }
 
-    val streamResponses = Channel<StreamResponse>(capacity = 1)
+    var streamResponse: StreamResponse? = null
     streams.incomingResponses.test {
       streams.outgoingRequests.sendNonBlockingOrThrow(streamRequest)
 
-      val streamResponse = awaitItem()
+      streamResponse = awaitItem()
 
       assertSoftly {
         withClue("requestId") { streamResponse.requestId shouldBe requestId }
         withClue("cancelled") { streamResponse.cancelled shouldBe true }
         withClue("errorsCount") { streamResponse.errorsCount shouldBe expectedErrorsCount }
       }
-
-      streamResponses.send(streamResponse)
     }
 
-    return streamResponses.receive()
+    return streamResponse!!
   }
 
   /**

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClient.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClient.kt
@@ -19,7 +19,9 @@ package com.google.firebase.dataconnect.core
 import androidx.annotation.VisibleForTesting
 import com.google.firebase.dataconnect.*
 import com.google.firebase.dataconnect.DataConnectPathSegment
+import com.google.firebase.dataconnect.DataConnectUntypedData
 import com.google.firebase.dataconnect.DataSource
+import com.google.firebase.dataconnect.FirebaseDataConnect
 import com.google.firebase.dataconnect.QueryRef.FetchPolicy
 import com.google.firebase.dataconnect.core.DataConnectAppCheck.GetAppCheckTokenResult
 import com.google.firebase.dataconnect.core.DataConnectAuth.GetAuthTokenResult

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadata.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadata.kt
@@ -24,6 +24,7 @@ import com.google.firebase.dataconnect.core.Globals.toScrubbedAccessToken
 import com.google.firebase.dataconnect.core.LoggerGlobals.Logger
 import com.google.firebase.dataconnect.core.LoggerGlobals.debug
 import com.google.firebase.dataconnect.util.ProtoUtil.buildStructProto
+import com.google.firebase.dataconnect.util.StructProtoBuilder
 import com.google.protobuf.Struct
 import io.grpc.Metadata
 
@@ -98,6 +99,7 @@ internal class DataConnectGrpcMetadata(
 
   companion object {
     // TODO: Move this to ProtoUtil.kt where it would live alongside other related methods.
+    // NOTE: Keep the implementation of this method in parity with StructProtoBuilder.putHeaders().
     fun Metadata.toStructProto(authUid: String?): Struct = buildStructProto {
       val keys: List<Metadata.Key<String>> = run {
         val keySet: MutableSet<String> = keys().toMutableSet()
@@ -123,6 +125,36 @@ internal class DataConnectGrpcMetadata(
 
         for (scrubbedValue in scrubbedValues) {
           put(key.name(), scrubbedValue)
+        }
+      }
+    }
+
+    // TODO: Move this to ProtoUtil.kt where it would live alongside other related methods.
+    // NOTE: Keep the implementation of this method in parity with Metadata.toStructProto().
+    fun StructProtoBuilder.putHeaders(authUid: String?, key: String, headers: Map<String, String>) {
+      putStruct(key) {
+        val keys: List<String> =
+          buildSet {
+              addAll(headers.keys)
+              // Always explicitly include the auth header in the returned string, even if it is
+              // absent.
+              add(firebaseAuthTokenHeader.name())
+              add(firebaseAppCheckTokenHeader.name())
+            }
+            .sorted()
+
+        keys.forEach { key ->
+          val value = headers[key]
+          val scrubbedValue =
+            value?.let {
+              when (key) {
+                firebaseAuthTokenHeader.name() -> it.toScrubbedAccessToken() + " (authUid=$authUid)"
+                firebaseAppCheckTokenHeader.name() -> it.toScrubbedAccessToken()
+                else -> it
+              }
+            }
+
+          put(key, scrubbedValue)
         }
       }
     }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/ProtoUtil.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/ProtoUtil.kt
@@ -278,7 +278,7 @@ internal object ProtoUtil {
 
   fun StreamResponse.toStructProto(): Struct = buildStructProto {
     put("requestId", requestId)
-    if (hasData()) putValue("data", data.toValueProto())
+    if (hasData()) put("data", data)
     if (errorsCount > 0) {
       put("errors", errorsList)
     }
@@ -589,10 +589,6 @@ internal class StructProtoBuilder(struct: Struct? = null) {
 
   fun put(key: String, value: ListValue?) {
     builder.putFields(key, value?.toValueProto() ?: nullProtoValue)
-  }
-
-  fun putValue(key: String, value: Value?) {
-    builder.putFields(key, value ?: nullProtoValue)
   }
 
   fun putList(key: String, block: ListValueProtoBuilder.() -> Unit) {

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/ProtoUtil.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/ProtoUtil.kt
@@ -18,6 +18,7 @@ package com.google.firebase.dataconnect.util
 
 import com.google.firebase.dataconnect.DataConnectPath
 import com.google.firebase.dataconnect.DataConnectPathSegment
+import com.google.firebase.dataconnect.core.DataConnectGrpcMetadata.Companion.putHeaders
 import com.google.firebase.dataconnect.toPathString
 import com.google.firebase.dataconnect.util.DeserializeUtils.toErrorInfoImpl
 import com.google.firebase.dataconnect.util.ProtoUtil.nullProtoValue
@@ -37,9 +38,12 @@ import google.firebase.dataconnect.proto.ExecuteMutationRequest
 import google.firebase.dataconnect.proto.ExecuteMutationResponse
 import google.firebase.dataconnect.proto.ExecuteQueryRequest
 import google.firebase.dataconnect.proto.ExecuteQueryResponse
+import google.firebase.dataconnect.proto.ExecuteRequest
 import google.firebase.dataconnect.proto.GraphqlError
 import google.firebase.dataconnect.proto.GraphqlResponseExtensions
 import google.firebase.dataconnect.proto.ServiceInfo
+import google.firebase.dataconnect.proto.StreamRequest
+import google.firebase.dataconnect.proto.StreamResponse
 import java.io.BufferedWriter
 import java.io.CharArrayWriter
 import java.io.DataOutputStream
@@ -256,6 +260,74 @@ internal object ProtoUtil {
 
   fun StructProtoBuilder.put(key: String, errors: Collection<GraphqlError>) {
     putList(key) { errors.forEach { add(it.toErrorInfoImpl().toString()) } }
+  }
+
+  fun streamResponseDefaultKeySortSelector(key: String): String =
+    when (key) {
+      "requestId" -> "\u0000A"
+      "data" -> "\u0000B"
+      "errors" -> "\u0000C"
+      "cancelled" -> "\u0000D"
+      "extensions" -> "\u0000E"
+      else -> key
+    }
+
+  fun StreamResponse.toCompactString(
+    keySortSelector: ((String) -> String)? = ::streamResponseDefaultKeySortSelector
+  ): String = toStructProto().toCompactString(keySortSelector)
+
+  fun StreamResponse.toStructProto(): Struct = buildStructProto {
+    put("requestId", requestId)
+    if (hasData()) putValue("data", data.toValueProto())
+    if (errorsCount > 0) {
+      put("errors", errorsList)
+    }
+    if (cancelled) put("cancelled", cancelled)
+    if (hasExtensions()) {
+      put("extensions", extensions)
+    }
+  }
+
+  private fun streamRequestKeySortSelector(key: String): String =
+    when (key) {
+      "requestId" -> "\u0000A"
+      "name" -> "\u0000B"
+      "headers" -> "\u0000C"
+      else -> key
+    }
+
+  fun StreamRequest.toCompactString(
+    authUid: String?,
+    keySortSelector: ((String) -> String)? = ::streamRequestKeySortSelector,
+  ): String = toStructProto(authUid).toCompactString(keySortSelector)
+
+  fun StreamRequest.toStructProto(authUid: String?): Struct = buildStructProto {
+    name.takeIf { it.isNotEmpty() }?.let { put("name", it) }
+    requestId.takeIf { it.isNotEmpty() }?.let { put("requestId", it) }
+    dataEtag.takeIf { it.isNotEmpty() }?.let { put("data_etag", it) }
+
+    when (requestKindCase) {
+      StreamRequest.RequestKindCase.SUBSCRIBE -> put("subscribe", subscribe)
+      StreamRequest.RequestKindCase.EXECUTE -> put("execute", execute)
+      StreamRequest.RequestKindCase.RESUME -> put("resume", true)
+      StreamRequest.RequestKindCase.CANCEL -> put("cancel", true)
+      StreamRequest.RequestKindCase.REQUESTKIND_NOT_SET -> {}
+    }
+
+    if (headersCount > 0) {
+      putHeaders(authUid, "headers", headersMap)
+    }
+  }
+
+  fun StructProtoBuilder.put(key: String, executeRequest: ExecuteRequest) {
+    putStruct(key) {
+      executeRequest.run {
+        put("operationName", operationName)
+        if (hasVariables()) {
+          put("variables", variables)
+        }
+      }
+    }
   }
 
   fun Duration.toHumanFriendlyString(): String = humanFriendlyStringForDuration(seconds, nanos)
@@ -517,6 +589,10 @@ internal class StructProtoBuilder(struct: Struct? = null) {
 
   fun put(key: String, value: ListValue?) {
     builder.putFields(key, value?.toValueProto() ?: nullProtoValue)
+  }
+
+  fun putValue(key: String, value: Value?) {
+    builder.putFields(key, value ?: nullProtoValue)
   }
 
   fun putList(key: String, block: ListValueProtoBuilder.() -> Unit) {

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/testutil/KotestPrinters.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/testutil/KotestPrinters.kt
@@ -14,17 +14,25 @@
  * limitations under the License.
  */
 
+@file:SharedWithAndroidTest
+
 package com.google.firebase.dataconnect.testutil
 
 import com.google.firebase.dataconnect.DataConnectPathComparator
 import com.google.firebase.dataconnect.DataConnectPathSegment
 import com.google.firebase.dataconnect.sqlite.DehydratedQueryResult
 import com.google.firebase.dataconnect.toPathString
+import com.google.firebase.dataconnect.util.DeserializeUtils.toErrorInfoImpl
 import com.google.firebase.dataconnect.util.ProtoUtil.toCompactString
 import com.google.firebase.dataconnect.util.ProtoUtil.toListValueProto
 import com.google.protobuf.ListValue
 import com.google.protobuf.Struct
 import com.google.protobuf.Value
+import google.firebase.dataconnect.proto.GraphqlError as GraphqlErrorProto
+import google.firebase.dataconnect.proto.GraphqlErrorExtensions as GraphqlErrorExtensionsProto
+import google.firebase.dataconnect.proto.SourceLocation as SourceLocationProto
+import google.firebase.dataconnect.proto.StreamRequest as StreamRequestProto
+import google.firebase.dataconnect.proto.StreamResponse as StreamResponseProto
 import google.firebase.dataconnect.proto.kotlinsdk.Entity as EntityProto
 import google.firebase.dataconnect.proto.kotlinsdk.EntityList as EntityListProto
 import google.firebase.dataconnect.proto.kotlinsdk.EntityOrEntityList as EntityOrEntityListProto
@@ -50,6 +58,11 @@ fun registerDataConnectKotestPrinters() {
   Printers.add(EntityListProto::class, EntityListProtoPrint)
   Printers.add(EntityPathProto::class, EntityPathProtoPrint)
   Printers.add(DehydratedQueryResult::class, DehydratedQueryResultPrint)
+  Printers.add(SourceLocationProto::class, SourceLocationProtoPrint)
+  Printers.add(GraphqlErrorProto::class, GraphqlErrorProtoPrint)
+  Printers.add(GraphqlErrorExtensionsProto::class, GraphqlErrorExtensionsProtoPrint)
+  Printers.add(StreamRequestProto::class, StreamRequestProtoPrint)
+  Printers.add(StreamResponseProto::class, StreamResponseProtoPrint)
 }
 
 private object StructCompactPrint : Print<Struct> {
@@ -195,3 +208,46 @@ class PrintFriendlyDataConnectPath(val path: DataConnectPath) :
 }
 
 fun DataConnectPath.toPrintable(): PrintFriendlyDataConnectPath = PrintFriendlyDataConnectPath(this)
+
+private object GraphqlErrorProtoPrint : Print<GraphqlErrorProto> {
+
+  @Suppress("OVERRIDE_DEPRECATION")
+  override fun print(a: GraphqlErrorProto): Printed = a.toErrorInfoImpl().toString().printed()
+}
+
+private object GraphqlErrorExtensionsProtoPrint : Print<GraphqlErrorExtensionsProto> {
+
+  @Suppress("OVERRIDE_DEPRECATION")
+  override fun print(a: GraphqlErrorExtensionsProto): Printed =
+    toStruct(a).toCompactString().printed()
+
+  fun toStruct(proto: GraphqlErrorExtensionsProto): Struct {
+    val builder = Struct.newBuilder()
+
+    val file = proto.file
+    if (file.isNotBlank()) {
+      builder.putFields("file", file.toValueProto())
+    }
+
+    return builder.build()
+  }
+}
+
+private object StreamRequestProtoPrint : Print<StreamRequestProto> {
+
+  @Suppress("OVERRIDE_DEPRECATION")
+  override fun print(a: StreamRequestProto): Printed =
+    a.toCompactString(authUid = "<unknown>").printed()
+}
+
+private object StreamResponseProtoPrint : Print<StreamResponseProto> {
+
+  @Suppress("OVERRIDE_DEPRECATION")
+  override fun print(a: StreamResponseProto): Printed = a.toCompactString().printed()
+}
+
+private object SourceLocationProtoPrint : Print<SourceLocationProto> {
+  @Suppress("OVERRIDE_DEPRECATION")
+  override fun print(a: SourceLocationProto): Printed =
+    "{line=${a.line}, col=${a.column}}".printed()
+}


### PR DESCRIPTION
This PR significantly expands the integration tests for the Data Connect Connect RPC service and introduces several utility methods for proto manipulation and debugging.

### Highlights
- **Expanded Integration Tests**: Added a wide range of new test cases to `ConnectRPCIntegrationTest.kt`, covering successful operations, error conditions (e.g., non-existent operations, missing init), and various coroutine/channel lifecycle scenarios (cancellation, closure, etc.).
- **Property-Based Testing**: Introduced Kotest property-based testing for `StreamRequest` using a new `validStreamRequestArb` generator.
- **Proto Utilities**: Added several helper methods to `ProtoUtil.kt` for converting `StreamRequest` and `StreamResponse` objects to compact strings and `Struct` protos, facilitating better logging and testing.
- **Structured Header Support**: Implemented `putHeaders` in `DataConnectGrpcMetadata` and `StructProtoBuilder` to allow for consistent, structured representation of gRPC metadata.
- **Enhanced Test Output**: Expanded `KotestPrinters.kt` to include custom printers for various Data Connect proto types, improving the readability of test failure messages.

### Changelog
<details>
<summary>5 files changed</summary>

- **ConnectRPCIntegrationTest.kt**: Significantly expanded with new test cases for queries, mutations, error handling, and channel lifecycle management. Added property-based testing support.
- **DataConnectGrpcClient.kt**: Minor import and visibility adjustments.
- **DataConnectGrpcMetadata.kt**: Added `putHeaders` utility for structured metadata representation.
- **ProtoUtil.kt**: Implemented compact string and `Struct` proto conversion helpers for `StreamRequest` and `StreamResponse`.
- **KotestPrinters.kt**: Added custom printers for `GraphqlError`, `StreamRequest`, `StreamResponse`, and `SourceLocation` protos.
</details>