### PR TITLE
Feature/jrc  4201.api.to.check.previous.anr.2

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -3,6 +3,9 @@
 - [fixed] Fixed race condition that caused logs from background threads to not be attached to
   reports in some cases [#8034]
 - [changed] Updated `firebase-sessions` dependency to v3.0.6
+- [feature] Added `didANRKillOnPreviousExecution()` to `FirebaseCrashlytics`, allowing apps to
+  detect whether they were killed by an ANR in the previous run. Requires API level 30 (Android R)
+  or above; always returns `false` on older versions. [#4201]
 
 # 20.0.5
 

--- a/firebase-crashlytics/api.txt
+++ b/firebase-crashlytics/api.txt
@@ -18,6 +18,7 @@ package com.google.firebase.crashlytics {
   public class FirebaseCrashlytics {
     method public com.google.android.gms.tasks.Task<java.lang.Boolean!> checkForUnsentReports();
     method public void deleteUnsentReports();
+    method public boolean didANRKillOnPreviousExecution();
     method public boolean didCrashOnPreviousExecution();
     method public static com.google.firebase.crashlytics.FirebaseCrashlytics getInstance();
     method public boolean isCrashlyticsCollectionEnabled();

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreInitializationTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreInitializationTest.java
@@ -265,6 +265,18 @@ public class CrashlyticsCoreInitializationTest extends CrashlyticsTestCase {
     assertFalse(getCrashMarkerFile().exists());
   }
 
+  @Test
+  public void testOnPreExecute_didNotANROnPreviousExecution() {
+    // Without any ApplicationExitInfo entries indicating an ANR, didANROnPreviousExecution
+    // should return false.
+    final CrashlyticsCore crashlyticsCore = builder().build();
+    setupBuildIdRequired(String.valueOf(false));
+    setupAppData(BUILD_ID);
+
+    assertTrue(crashlyticsCore.onPreExecute(appData, mockSettingsController));
+    assertFalse(crashlyticsCore.didANROnPreviousExecution());
+  }
+
   private void setupBuildIdRequired(String booleanValue) {
     setupResource(
         RES_ID_REQUIRE_BUILD_ID,

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -463,6 +463,16 @@ public class FirebaseCrashlytics {
   }
 
   /**
+   * Checks whether the app was terminated due to an ANR (Application Not Responding) on its
+   * previous run. Requires Android API 30 (R) or above; returns {@code false} on older versions.
+   *
+   * @return true if an ANR was recorded during the previous run of the app.
+   */
+  public boolean didANRKillOnPreviousExecution() {
+    return core.didANROnPreviousExecution();
+  }
+
+  /**
    * Indicates whether or not automatic data collection is enabled.
    *
    * @return In order of priority:

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -943,5 +943,25 @@ class CrashlyticsController {
           .v("ANR feature enabled, but device is API " + android.os.Build.VERSION.SDK_INT);
     }
   }
+  /** This function must be called before opening the first session. */
+  boolean didANROnPreviousExecution() {
+    CrashlyticsWorkers.checkBackgroundThread();
+    if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+      return false;
+    }
+    final String sessionId = getCurrentSessionId();
+    if (sessionId == null) {
+      return false;
+    }
+    ActivityManager activityManager =
+        (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+    List<ApplicationExitInfo> applicationExitInfoList =
+        activityManager.getHistoricalProcessExitReasons(null, 0, 0);
+    if (applicationExitInfoList.isEmpty()) {
+      return false;
+    }
+    return reportingCoordinator.didRelevantAnrOccur(sessionId, applicationExitInfoList);
+  }
+
   // endregion
 }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -83,6 +83,7 @@ public class CrashlyticsCore {
   private CrashlyticsFileMarker initializationMarker;
   private CrashlyticsFileMarker crashMarker;
   private boolean didCrashOnPreviousExecution;
+  private boolean didANROnPreviousExecution;
 
   private CrashlyticsController controller;
   private final IdManager idManager;
@@ -196,6 +197,7 @@ public class CrashlyticsCore {
       final boolean initializeSynchronously = didPreviousInitializationFail();
 
       checkForPreviousCrash();
+      checkForPreviousAnr();
 
       controller.enableExceptionHandling(
           sessionIdentifier, Thread.getDefaultUncaughtExceptionHandler(), settingsProvider);
@@ -500,6 +502,28 @@ public class CrashlyticsCore {
 
   public boolean didCrashOnPreviousExecution() {
     return didCrashOnPreviousExecution;
+  }
+
+  private void checkForPreviousAnr() {
+    Future<Boolean> future =
+        crashlyticsWorkers
+            .common
+            .getExecutor()
+            .submit(() -> controller.didANROnPreviousExecution());
+
+    Boolean result;
+    try {
+      result = future.get(DEFAULT_MAIN_HANDLER_TIMEOUT_SEC, TimeUnit.SECONDS);
+    } catch (Exception ignored) {
+      didANROnPreviousExecution = false;
+      return;
+    }
+
+    didANROnPreviousExecution = Boolean.TRUE.equals(result);
+  }
+
+  public boolean didANROnPreviousExecution() {
+    return didANROnPreviousExecution;
   }
 
   // endregion

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
@@ -439,6 +439,13 @@ public class SessionReportingCoordinator {
     }
   }
 
+  /** Returns true if an ANR ApplicationExitInfo occurred during the given session. */
+  @RequiresApi(api = Build.VERSION_CODES.R)
+  public boolean didRelevantAnrOccur(
+      String sessionId, List<ApplicationExitInfo> applicationExitInfoList) {
+    return findRelevantApplicationExitInfo(sessionId, applicationExitInfoList) != null;
+  }
+
   /** Finds the first ANR ApplicationExitInfo within the session. */
   @RequiresApi(api = Build.VERSION_CODES.R)
   private @Nullable ApplicationExitInfo findRelevantApplicationExitInfo(

--- a/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinatorRobolectricTest.java
+++ b/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinatorRobolectricTest.java
@@ -165,6 +165,55 @@ public class SessionReportingCoordinatorRobolectricTest {
   }
 
   @Test
+  @SdkSuppress(minSdkVersion = VERSION_CODES.R)
+  public void testDidRelevantAnrOccur_returnsTrueForAnrWithinSession() {
+    final long sessionStartTimestamp = 0;
+    final String sessionId = "testSessionId";
+    when(reportPersistence.getStartTimestampMillis(sessionId)).thenReturn(sessionStartTimestamp);
+
+    addAppExitInfo(ApplicationExitInfo.REASON_ANR);
+    List<ApplicationExitInfo> testApplicationExitInfoList = getAppExitInfoList();
+
+    assertTrue(reportingCoordinator.didRelevantAnrOccur(sessionId, testApplicationExitInfoList));
+  }
+
+  @Test
+  @SdkSuppress(minSdkVersion = VERSION_CODES.R)
+  public void testDidRelevantAnrOccur_returnsFalseForAnrBeforeSession() {
+    // ANR timestamp is 0; session starts at 10, so ANR was before the session.
+    final long sessionStartTimestamp = 10;
+    final String sessionId = "testSessionId";
+    when(reportPersistence.getStartTimestampMillis(sessionId)).thenReturn(sessionStartTimestamp);
+
+    addAppExitInfo(ApplicationExitInfo.REASON_ANR);
+    List<ApplicationExitInfo> testApplicationExitInfoList = getAppExitInfoList();
+
+    assertFalse(reportingCoordinator.didRelevantAnrOccur(sessionId, testApplicationExitInfoList));
+  }
+
+  @Test
+  @SdkSuppress(minSdkVersion = VERSION_CODES.R)
+  public void testDidRelevantAnrOccur_returnsFalseForNonAnrWithinSession() {
+    final long sessionStartTimestamp = 0;
+    final String sessionId = "testSessionId";
+    when(reportPersistence.getStartTimestampMillis(sessionId)).thenReturn(sessionStartTimestamp);
+
+    addAppExitInfo(ApplicationExitInfo.REASON_EXIT_SELF);
+    List<ApplicationExitInfo> testApplicationExitInfoList = getAppExitInfoList();
+
+    assertFalse(reportingCoordinator.didRelevantAnrOccur(sessionId, testApplicationExitInfoList));
+  }
+
+  @Test
+  @SdkSuppress(minSdkVersion = VERSION_CODES.R)
+  public void testDidRelevantAnrOccur_returnsFalseForEmptyList() {
+    final String sessionId = "testSessionId";
+    when(reportPersistence.getStartTimestampMillis(sessionId)).thenReturn(0L);
+
+    assertFalse(reportingCoordinator.didRelevantAnrOccur(sessionId, List.of()));
+  }
+
+  @Test
   public void testconvertInputStreamToString_worksSuccessfully() throws IOException {
     String stackTrace = "-----stacktrace---------";
     InputStream inputStream = new ByteArrayInputStream(stackTrace.getBytes());


### PR DESCRIPTION
## Add didANRKillOnPreviousExecution() to FirebaseCrashlytics

Implements [#4201](https://github.com/firebase/firebase-android-sdk/issues/4201).

### Background

Crashlytics already detects ANRs and files reports for them, and developers have long been able to call `didCrashOnPreviousExecution()` to gate logic that should only run after a fatal crash. However, there was no equivalent API for ANRs: developers who want to adapt their app's behavior after an ANR (e.g., disable a heavy feature on the next cold start, log a custom key, or show a recovery dialog) had no supported way to do so.

`didCrashOnPreviousExecution()` works by reading a marker file written at crash time. ANRs cannot use that mechanism because the main thread is frozen and the crash handler never runs. Instead, the new method uses `ApplicationExitInfo` (API 30+), which records process-exit reasons at the OS level — the same source already queried internally by `SessionReportingCoordinator` when filing ANR reports. The new API delegates to that existing infrastructure rather than introducing a separate detection path.

### Risk

- **API surface**: one new `public` method on `FirebaseCrashlytics` (`didANRKillOnPreviousExecution()`). No existing method signatures changed.
- **Behavior on API < 30**: always returns `false`; no `ApplicationExitInfo` access attempted.
- **Behavior on API 30+**: reads `getHistoricalProcessExitReasons` once at startup on the background thread with a bounded timeout. This is the same`ActivityManager` call already made by the ANR-reporting path; no new system service is introduced.
- **No dependency bumps, no public API removals, no migration required.**

