### PR TITLE
Address PR #8110 review comments: null-check ActivityManager, log ANR…

### DIFF
--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -943,6 +943,7 @@ class CrashlyticsController {
           .v("ANR feature enabled, but device is API " + android.os.Build.VERSION.SDK_INT);
     }
   }
+
   /** This function must be called before opening the first session. */
   boolean didANROnPreviousExecution() {
     CrashlyticsWorkers.checkBackgroundThread();
@@ -955,6 +956,9 @@ class CrashlyticsController {
     }
     ActivityManager activityManager =
         (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+    if (activityManager == null) {
+      return false;
+    }
     List<ApplicationExitInfo> applicationExitInfoList =
         activityManager.getHistoricalProcessExitReasons(null, 0, 0);
     if (applicationExitInfoList.isEmpty()) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -514,7 +514,8 @@ public class CrashlyticsCore {
     Boolean result;
     try {
       result = future.get(DEFAULT_MAIN_HANDLER_TIMEOUT_SEC, TimeUnit.SECONDS);
-    } catch (Exception ignored) {
+    } catch (Exception ex) {
+      Logger.getLogger().v("Error checking for previous ANR: " + ex.getMessage());
       didANROnPreviousExecution = false;
       return;
     }


### PR DESCRIPTION
… check failures

- Add null guard on ActivityManager from getSystemService() before calling getHistoricalProcessExitReasons() to avoid potential NPE.
- Log exceptions in checkForPreviousAnr() at verbose level instead of silently ignoring them, to aid diagnosability.