### PR TITLE
dataconnect(test): ConnectRPCIntegrationTest.kt finished

### DIFF
--- a/firebase-dataconnect/androidTestutil/androidTestutil.gradle.kts
+++ b/firebase-dataconnect/androidTestutil/androidTestutil.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
   implementation(libs.androidx.test.core)
   implementation(libs.androidx.test.junit)
   implementation(libs.auth0.jwt)
+  implementation(libs.grpc.api)
   implementation(libs.kotest.assertions)
   implementation(libs.kotest.property)
   implementation(libs.kotlinx.coroutines.core)

--- a/firebase-dataconnect/androidTestutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/TestDataConnectFactory.kt
+++ b/firebase-dataconnect/androidTestutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/TestDataConnectFactory.kt
@@ -34,6 +34,18 @@ class TestDataConnectFactory(val firebaseAppFactory: TestFirebaseAppFactory) :
       newInstance(Params(connector = connector, location = location, serviceId = serviceId))
     }
 
+  fun newInstance(config: ConnectorConfig, backend: DataConnectBackend?): FirebaseDataConnect =
+    config.run {
+      newInstance(
+        Params(
+          connector = connector,
+          location = location,
+          serviceId = serviceId,
+          backend = backend,
+        )
+      )
+    }
+
   fun newInstance(config: ConnectorConfig, cacheSettings: CacheSettings?): FirebaseDataConnect =
     config.run {
       newInstance(

--- a/firebase-dataconnect/androidTestutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/TurbineUtils.kt
+++ b/firebase-dataconnect/androidTestutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/TurbineUtils.kt
@@ -16,15 +16,105 @@
 
 package com.google.firebase.dataconnect.testutil
 
+import app.cash.turbine.Event
 import app.cash.turbine.ReceiveTurbine
-import javax.annotation.CheckReturnValue
+import io.grpc.Status
+import io.grpc.StatusException
+import io.kotest.assertions.fail
+import io.kotest.assertions.print.print
 
-@CheckReturnValue
-suspend fun <T> ReceiveTurbine<T>.skipItemsWhere(predicate: (T) -> Boolean): T {
+suspend inline fun <T> ReceiveTurbine<T>.awaitUntilItem(
+  predicateDescription: String? = null,
+  onSkippedItem: (T) -> Unit = {},
+  predicate: (T) -> Boolean,
+): T {
+  var skippedItemCount = 0
+
   while (true) {
-    val item = awaitItem()
-    if (!predicate(item)) {
-      return item
+    when (val event = awaitEvent()) {
+      Event.Complete ->
+        fail(
+          "Flow completed normally after skipping $skippedItemCount items produced " +
+            "that didn't match the given predicate ($predicateDescription) " +
+            "but expected it to produce an item that matched the predicate"
+        )
+      is Event.Error ->
+        fail(
+          "Flow failed with exception ${event.throwable} after skipping $skippedItemCount " +
+            "items produced that didn't match the given predicate ($predicateDescription) " +
+            "but expected it to produce an item that matched the predicate"
+        )
+      is Event.Item ->
+        if (predicate(event.value)) {
+          return event.value
+        } else {
+          onSkippedItem(event.value)
+          skippedItemCount++
+        }
     }
   }
+}
+
+suspend inline fun <T, reified U : T> ReceiveTurbine<T>.awaitUntilItemIsInstance(
+  onSkippedItem: (T) -> Unit = {},
+): U {
+  val item = awaitUntilItem("is instance of ${U::class.qualifiedName}", onSkippedItem) { it is U }
+  return item as U
+}
+
+suspend inline fun <reified T : Throwable> ReceiveTurbine<*>.awaitError(
+  exceptionDescriptionSuffix: String? = null,
+  predicate: (T) -> Unit = {}
+): T {
+  val expectedText = buildString {
+    append(T::class.qualifiedName)
+    if (exceptionDescriptionSuffix !== null) {
+      append("with ")
+      append(exceptionDescriptionSuffix)
+    }
+  }
+
+  val exception =
+    when (val event = awaitEvent()) {
+      Event.Complete -> fail("Flow completed normally, but expected it to throw $expectedText")
+      is Event.Error -> event.throwable
+      is Event.Item<*> ->
+        fail(
+          "Flow produced item (${event.value.print()}), " + "but expected it to throw $expectedText"
+        )
+    }
+
+  if (exception !is T) {
+    fail(
+      "Flow failed (as expected) but with the wrong exception type: " +
+        "expected $expectedText but got ${exception::class.qualifiedName} " +
+        "with message: ${exception.message}"
+    )
+  }
+
+  predicate(exception)
+
+  return exception
+}
+
+suspend inline fun ReceiveTurbine<*>.awaitStatusException(
+  code: Status.Code?,
+  predicate: (StatusException) -> Unit = {}
+): StatusException {
+  val exceptionDescriptionSuffix = if (code === null) null else "with code $code"
+  val statusException = awaitError<StatusException>(exceptionDescriptionSuffix)
+
+  if (code !== null) {
+    val actualCode = statusException.status.code
+    if (actualCode != code) {
+      fail(
+        "Flow failed with StatusException (as expected) but with the wrong code: " +
+          "expected $code but got $actualCode"
+      )
+    }
+  }
+
+  predicate(statusException)
+
+  return statusException
 }

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/ConnectRPCIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/ConnectRPCIntegrationTest.kt
@@ -20,6 +20,9 @@ import app.cash.turbine.Event
 import app.cash.turbine.test
 import app.cash.turbine.turbineScope
 import com.google.firebase.dataconnect.testutil.DataConnectIntegrationTestBase
+import com.google.firebase.dataconnect.testutil.awaitError
+import com.google.firebase.dataconnect.testutil.awaitStatusException
+import com.google.firebase.dataconnect.testutil.awaitUntilItemIsInstance
 import com.google.firebase.dataconnect.testutil.createGrpcManagedChannel
 import com.google.firebase.dataconnect.testutil.property.arbitrary.pair
 import com.google.firebase.dataconnect.testutil.registerDataConnectKotestPrinters
@@ -35,7 +38,6 @@ import google.firebase.dataconnect.proto.ExecuteRequest
 import google.firebase.dataconnect.proto.StreamRequest
 import google.firebase.dataconnect.proto.StreamResponse
 import io.grpc.Status
-import io.grpc.StatusException
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.print.print
 import io.kotest.assertions.withClue
@@ -153,12 +155,9 @@ class ConnectRPCIntegrationTest : DataConnectIntegrationTestBase() {
       streams.incomingResponses.test {
         streams.outgoingRequests.send(streamRequest)
 
-        val exception = awaitError()
-
-        val statusException = exception.shouldBeInstanceOf<StatusException>()
-        statusException.status.code shouldBe Status.Code.INVALID_ARGUMENT
-        statusException.message shouldContainWithNonAbuttingTextIgnoringCase
-          "invalid connector name"
+        awaitStatusException(Status.Code.INVALID_ARGUMENT) {
+          it.message shouldContainWithNonAbuttingTextIgnoringCase "invalid connector name"
+        }
       }
     }
   }
@@ -169,12 +168,9 @@ class ConnectRPCIntegrationTest : DataConnectIntegrationTestBase() {
     streams.outgoingRequests.close()
 
     streams.incomingResponses.test {
-      val exception = awaitError()
-
-      val statusException = exception.shouldBeInstanceOf<StatusException>()
-      statusException.status.code shouldBe Status.Code.UNKNOWN
-      statusException.message shouldContainWithNonAbuttingTextIgnoringCase
-        "failed to receive first request"
+      awaitStatusException(Status.Code.UNKNOWN) {
+        it.message shouldContainWithNonAbuttingTextIgnoringCase "failed to receive first request"
+      }
     }
   }
 
@@ -185,12 +181,9 @@ class ConnectRPCIntegrationTest : DataConnectIntegrationTestBase() {
     streams.incomingResponses.test {
       streams.outgoingRequests.close()
 
-      val exception = awaitError()
-
-      val statusException = exception.shouldBeInstanceOf<StatusException>()
-      statusException.status.code shouldBe Status.Code.UNKNOWN
-      statusException.message shouldContainWithNonAbuttingTextIgnoringCase
-        "failed to receive first request"
+      awaitStatusException(Status.Code.UNKNOWN) {
+        it.message shouldContainWithNonAbuttingTextIgnoringCase "failed to receive first request"
+      }
     }
   }
 
@@ -218,10 +211,7 @@ class ConnectRPCIntegrationTest : DataConnectIntegrationTestBase() {
       streams.incomingResponses.test {
         streams.outgoingRequests.close(CancellationException("forced exception v5bgf9ppmm"))
 
-        val exception = awaitError()
-
-        val cancellationException = exception.shouldBeInstanceOf<CancellationException>()
-        cancellationException shouldHaveMessage "forced exception v5bgf9ppmm"
+        awaitError<CancellationException> { it shouldHaveMessage "forced exception v5bgf9ppmm" }
       }
     }
 
@@ -234,10 +224,7 @@ class ConnectRPCIntegrationTest : DataConnectIntegrationTestBase() {
       streams.incomingResponses.test {
         streams.outgoingRequests.close(TestException("forced exception gajhw85ajt"))
 
-        val exception = awaitError()
-
-        val testException = exception.shouldBeInstanceOf<TestException>()
-        testException shouldHaveMessage "forced exception gajhw85ajt"
+        awaitError<TestException> { it shouldHaveMessage "forced exception gajhw85ajt" }
       }
     }
 
@@ -356,11 +343,10 @@ class ConnectRPCIntegrationTest : DataConnectIntegrationTestBase() {
       awaitItem().requestId shouldBe requestId
 
       streams.outgoingRequests.send(streamRequest2)
-      val exception = awaitError()
+      awaitStatusException(Status.Code.FAILED_PRECONDITION) {
+        it.message shouldContainWithNonAbuttingTextIgnoringCase "request_id"
+      }
 
-      val statusException = exception.shouldBeInstanceOf<StatusException>()
-      statusException.status.code shouldBe Status.Code.FAILED_PRECONDITION
-      statusException.message shouldContainWithNonAbuttingTextIgnoringCase "request_id"
     }
   }
 

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/ConnectRPCIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/ConnectRPCIntegrationTest.kt
@@ -19,7 +19,9 @@ package com.google.firebase.dataconnect
 import app.cash.turbine.Event
 import app.cash.turbine.test
 import app.cash.turbine.turbineScope
+import com.google.firebase.dataconnect.testutil.DataConnectBackend
 import com.google.firebase.dataconnect.testutil.DataConnectIntegrationTestBase
+import com.google.firebase.dataconnect.testutil.InProcessDataConnectGrpcStreamingServer
 import com.google.firebase.dataconnect.testutil.awaitError
 import com.google.firebase.dataconnect.testutil.awaitStatusException
 import com.google.firebase.dataconnect.testutil.awaitUntilItemIsInstance
@@ -346,8 +348,67 @@ class ConnectRPCIntegrationTest : DataConnectIntegrationTestBase() {
       awaitStatusException(Status.Code.FAILED_PRECONDITION) {
         it.message shouldContainWithNonAbuttingTextIgnoringCase "request_id"
       }
-
     }
+  }
+
+  @Test
+  fun backendDisconnectDuringConnectionEstablishment() = runTest {
+    val streams = startAndConnectToInProcessDataConnectGrpcStreamingServer()
+    streams.server.setListener { event ->
+      if (event is InProcessDataConnectGrpcStreamingServer.Event.Call) {
+        streams.server.grpcServer.shutdownNow()
+      }
+    }
+
+    streams.incomingResponses.test { awaitStatusException(Status.Code.CANCELLED) }
+  }
+
+  @Test
+  fun backendDisconnectDuringConnectRpcEstablishment() = runTest {
+    val streams = startAndConnectToInProcessDataConnectGrpcStreamingServer()
+    streams.server.setListener { event ->
+      if (event is InProcessDataConnectGrpcStreamingServer.Event.ConnectRpcStarted) {
+        streams.server.grpcServer.shutdownNow()
+      }
+    }
+
+    streams.incomingResponses.test { awaitStatusException(Status.Code.CANCELLED) }
+  }
+
+  @Test
+  fun backendDisconnectMidStream() = runTest {
+    val streams = startAndConnectToInProcessDataConnectGrpcStreamingServer()
+
+    turbineScope {
+      val incomingResponseCollector =
+        streams.incomingResponses.testIn(backgroundScope, name = "incomingResponses")
+      val serverEventReceiver = streams.server.events.testIn(backgroundScope, name = "serverEvents")
+      streams.outgoingRequests.send(StreamRequest.getDefaultInstance())
+      val rpcStartedEvent: InProcessDataConnectGrpcStreamingServer.Event.ConnectRpcStarted =
+        serverEventReceiver.awaitUntilItemIsInstance()
+      serverEventReceiver.cancelAndIgnoreRemainingEvents()
+      rpcStartedEvent.responseObserver.onNext(StreamResponse.getDefaultInstance())
+      incomingResponseCollector.awaitItem()
+
+      streams.server.grpcServer.shutdownNow()
+
+      incomingResponseCollector.awaitStatusException(Status.Code.CANCELLED)
+    }
+  }
+
+  private data class InProcessConnectionStreams(
+    val server: InProcessDataConnectGrpcStreamingServer,
+    val outgoingRequests: SendChannel<StreamRequest>,
+    val incomingResponses: Flow<StreamResponse>,
+  )
+
+  private fun startAndConnectToInProcessDataConnectGrpcStreamingServer():
+    InProcessConnectionStreams {
+    val server = InProcessDataConnectGrpcStreamingServer()
+    cleanups.register(server)
+    server.open()
+    val streams = connect(server)
+    return InProcessConnectionStreams(server, streams.outgoingRequests, streams.incomingResponses)
   }
 
   @Test
@@ -422,13 +483,22 @@ class ConnectRPCIntegrationTest : DataConnectIntegrationTestBase() {
    * Establishes a connection to the Data Connect `Connect` RPC and returns the streams for
    * communication.
    */
-  private fun connect(): ConnectionStreams {
-    val connector = RealtimeConnector.getInstance(dataConnectFactory)
+  private fun connect(backend: DataConnectBackend? = null): ConnectionStreams {
+    val connector = RealtimeConnector.getInstance(dataConnectFactory, backend)
     val grpcManagedChannel = createGrpcManagedChannel(connector.dataConnect)
     val outgoingRequests = Channel<StreamRequest>(UNLIMITED)
     val stub = ConnectorStreamServiceCoroutineStub(grpcManagedChannel)
     val incomingResponses = stub.connect(outgoingRequests.consumeAsFlow())
     return ConnectionStreams(connector, outgoingRequests, incomingResponses)
+  }
+
+  /**
+   * Establishes a connection to the Data Connect `Connect` RPC running in-process, represented by
+   * the given [inProcessServer], and returns the streams for communication.
+   */
+  private fun connect(inProcessServer: InProcessDataConnectGrpcStreamingServer): ConnectionStreams {
+    val backend = DataConnectBackend.Custom("localhost:${inProcessServer.port}", sslEnabled = false)
+    return connect(backend)
   }
 
   /**

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/testutil/InProcessDataConnectGrpcStreamingServer.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/testutil/InProcessDataConnectGrpcStreamingServer.kt
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.dataconnect.testutil
+
+import android.os.ConditionVariable
+import google.firebase.dataconnect.proto.ConnectorStreamServiceGrpc.ConnectorStreamServiceImplBase
+import google.firebase.dataconnect.proto.StreamRequest
+import google.firebase.dataconnect.proto.StreamResponse
+import io.grpc.InsecureServerCredentials
+import io.grpc.Metadata
+import io.grpc.Server
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.ServerInterceptor
+import io.grpc.okhttp.OkHttpServerBuilder
+import io.grpc.stub.StreamObserver
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+/**
+ * An in-process gRPC server for testing Firebase Data Connect streaming features. It starts a
+ * server on a random port and exposes all events (calls, requests, errors) via a [SharedFlow] for
+ * verification in tests.
+ */
+class InProcessDataConnectGrpcStreamingServer : AutoCloseable {
+
+  private val _events = MutableSharedFlow<Event>(extraBufferCapacity = UNLIMITED)
+
+  /**
+   * A flow of events that occur on this server.
+   *
+   * Tests can collect this flow to verify the behavior of the client.
+   *
+   * In order to influence the server's behavior in response to events, register a listener via
+   * [setListener].
+   */
+  val events: SharedFlow<Event> = _events.asSharedFlow()
+
+  private val _port = AtomicInteger(-1)
+
+  /**
+   * The TCP port to which the gRPC server is bound and on which it is listening.
+   *
+   * Will be -1 before [open] has been called.
+   */
+  val port: Int
+    get() = _port.get()
+
+  /**
+   * The gRPC [Server] opened by [open].
+   *
+   * @throws IllegalStateException if accessed before [open] or after [close].
+   */
+  val grpcServer: Server
+    get() =
+      when (val currentState = state.get()) {
+        State.Closed -> error("close() has been called [s6gt7tmktz]")
+        is State.Opened -> currentState.server
+        is State.Unopened -> error("open() has not yet been called [nhcsrt6epf]")
+      }
+
+  private class EventHandler(
+    private val events: MutableSharedFlow<Event>,
+    private val listener: AtomicReference<(Event) -> Unit>,
+  ) {
+
+    fun handleEvent(event: Event) {
+      val emitSuccessful = events.tryEmit(event)
+      check(emitSuccessful) {
+        "internal error vrv8vnpkch: tryEmit($event) was expected to return true " +
+          "(since the MutableSharedFlow was created with extraBufferCapacity=UNLIMITED) " +
+          "but it returned false"
+      }
+
+      listener.get()?.invoke(event)
+    }
+  }
+
+  private val listener = AtomicReference<(Event) -> Unit>()
+
+  private val state: AtomicReference<State> = run {
+    val eventHandler = EventHandler(_events, listener)
+    val server =
+      OkHttpServerBuilder.forPort(0, InsecureServerCredentials.create())
+        .addService(ConnectorStreamingServiceImpl(eventHandler))
+        .intercept(ServerInterceptorImpl(eventHandler))
+        .build()
+
+    AtomicReference(State.Unopened(server, ConditionVariable()))
+  }
+
+  /**
+   * A unique identifier for a connection to the streaming service.
+   *
+   * Each time the "Connect" RPC is started it is assigned a unique identifier. This identifier is
+   * included in [Event] objects to enable correlation of events to a particular RPC.
+   */
+  @JvmInline value class ConnectionId(val value: Long)
+
+  /** Represents an event that occurred on the server. */
+  sealed interface Event {
+
+    /** Represents an incoming gRPC call, before the call is actually processed by the server. */
+    class Call(val call: ServerCall<*, *>, val headers: Metadata) : Event {
+      override fun toString() = "Call"
+    }
+
+    /** Represents the start of a "Connect" RPC. */
+    class ConnectRpcStarted(
+      val connectionId: ConnectionId,
+      val responseObserver: StreamObserver<StreamResponse>,
+    ) : Event {
+      override fun toString() = "ConnectRpcStarted($connectionId)"
+    }
+
+    /** Represents a request received from the client over the stream. */
+    class StreamRequestReceived(
+      val connectionId: ConnectionId,
+      val streamRequest: StreamRequest,
+    ) : Event {
+      override fun toString() =
+        "StreamRequestReceived($connectionId, streamRequest={" +
+          "requestId=${streamRequest.requestId}, kind=${streamRequest.requestKindCase}})"
+    }
+
+    /** Represents an error received from the client or the stream. */
+    class ErrorReceived(val connectionId: ConnectionId, val exception: Throwable) : Event {
+      override fun toString() = "ErrorReceived($connectionId, ${exception::class.qualifiedName})"
+    }
+
+    /** Represents the completion of the stream by the client. */
+    class CompletedReceived(val connectionId: ConnectionId) : Event {
+      override fun toString() = "CompletedReceived($connectionId)"
+    }
+  }
+
+  /**
+   * Opens and starts the gRPC server. If the server is already opened, it blocks until it is fully
+   * started and returns the instance.
+   *
+   * @return The started gRPC [Server] instance.
+   * @throws IllegalStateException if [close] has been called.
+   */
+  fun open(): Server {
+    while (true) {
+      when (val currentState = state.get()) {
+        is State.Unopened ->
+          if (
+            state.compareAndSet(
+              currentState,
+              State.Opened(currentState.server, currentState.startCondition)
+            )
+          ) {
+            currentState.server.start()
+            _port.set(currentState.server.port)
+            currentState.startCondition.open()
+          }
+        is State.Opened -> {
+          currentState.startCondition.block()
+          return currentState.server
+        }
+        State.Closed -> error("close() has been called [zv6n23ry4h]")
+      }
+    }
+  }
+
+  /**
+   * Closes and shuts down the gRPC server.
+   *
+   * This method may be safely called more than once. Each call will block until the entire "close"
+   * operation has completed. If the "close" operation has _already_ completed, then this method
+   * returns immediately.
+   */
+  override fun close() {
+    while (true) {
+      val currentState = state.get()
+      when (currentState) {
+        State.Closed -> return
+        is State.Opened -> {
+          currentState.server.shutdownNow()
+          currentState.server.awaitTermination()
+        }
+        is State.Unopened -> {}
+      }
+
+      state.compareAndSet(currentState, State.Closed)
+    }
+  }
+
+  fun setListener(onEvent: ((Event) -> Unit)) {
+    while (true) {
+      val currentListener = listener.get()
+      if (currentListener !== null) {
+        error("a listener is already registered [fwpeptaxc2]")
+      }
+      if (listener.compareAndSet(currentListener, onEvent)) {
+        break
+      }
+    }
+  }
+
+  private sealed interface State {
+    class Unopened(val server: Server, val startCondition: ConditionVariable) : State {
+      override fun toString() = "Unopened"
+    }
+    class Opened(val server: Server, val startCondition: ConditionVariable) : State {
+      override fun toString() = "Opened(port=${server.port})"
+    }
+    data object Closed : State {
+      override fun toString() = "Closed"
+    }
+  }
+
+  private class ServerInterceptorImpl(private val eventHandler: EventHandler) : ServerInterceptor {
+
+    override fun <ReqT, RespT> interceptCall(
+      call: ServerCall<ReqT, RespT>,
+      headers: Metadata,
+      next: ServerCallHandler<ReqT, RespT>
+    ): ServerCall.Listener<ReqT> {
+      eventHandler.handleEvent(Event.Call(call, headers))
+      return next.startCall(call, headers)
+    }
+  }
+
+  private class ConnectorStreamingServiceImpl(private val eventHandler: EventHandler) :
+    ConnectorStreamServiceImplBase() {
+    override fun connect(
+      responseObserver: StreamObserver<StreamResponse>
+    ): StreamObserver<StreamRequest> {
+      val connectionId = ConnectionId(connectionSequenceNumber.incrementAndGet())
+      eventHandler.handleEvent(Event.ConnectRpcStarted(connectionId, responseObserver))
+
+      return object : StreamObserver<StreamRequest> {
+        override fun onNext(streamRequest: StreamRequest) {
+          eventHandler.handleEvent(Event.StreamRequestReceived(connectionId, streamRequest))
+        }
+
+        override fun onError(exception: Throwable) {
+          eventHandler.handleEvent(Event.ErrorReceived(connectionId, exception))
+        }
+
+        override fun onCompleted() {
+          eventHandler.handleEvent(Event.CompletedReceived(connectionId))
+        }
+      }
+    }
+  }
+}
+
+private val connectionSequenceNumber = AtomicLong(0)

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/testutil/InProcessDataConnectGrpcStreamingServer.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/testutil/InProcessDataConnectGrpcStreamingServer.kt
@@ -16,7 +16,6 @@
 
 package com.google.firebase.dataconnect.testutil
 
-import android.os.ConditionVariable
 import google.firebase.dataconnect.proto.ConnectorStreamServiceGrpc.ConnectorStreamServiceImplBase
 import google.firebase.dataconnect.proto.StreamRequest
 import google.firebase.dataconnect.proto.StreamResponse
@@ -28,6 +27,8 @@ import io.grpc.ServerCallHandler
 import io.grpc.ServerInterceptor
 import io.grpc.okhttp.OkHttpServerBuilder
 import io.grpc.stub.StreamObserver
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
@@ -66,16 +67,18 @@ class InProcessDataConnectGrpcStreamingServer : AutoCloseable {
     get() = _port.get()
 
   /**
-   * The gRPC [Server] opened by [open].
+   * The gRPC [Server] started by [open].
    *
    * @throws IllegalStateException if accessed before [open] or after [close].
    */
   val grpcServer: Server
     get() =
       when (val currentState = state.get()) {
-        State.Closed -> error("close() has been called [s6gt7tmktz]")
+        is State.Unopened -> error("open() has not yet been called [a4zarrmvzd]")
+        is State.Opening -> currentState.server
         is State.Opened -> currentState.server
-        is State.Unopened -> error("open() has not yet been called [nhcsrt6epf]")
+        is State.Closing,
+        State.Closed -> error("close() has been called [s6gt7tmktz]")
       }
 
   private class EventHandler(
@@ -97,16 +100,7 @@ class InProcessDataConnectGrpcStreamingServer : AutoCloseable {
 
   private val listener = AtomicReference<(Event) -> Unit>()
 
-  private val state: AtomicReference<State> = run {
-    val eventHandler = EventHandler(_events, listener)
-    val server =
-      OkHttpServerBuilder.forPort(0, InsecureServerCredentials.create())
-        .addService(ConnectorStreamingServiceImpl(eventHandler))
-        .intercept(ServerInterceptorImpl(eventHandler))
-        .build()
-
-    AtomicReference(State.Unopened(server, ConditionVariable()))
-  }
+  private val state: AtomicReference<State> = AtomicReference(State.Unopened)
 
   /**
    * A unique identifier for a connection to the streaming service.
@@ -163,21 +157,38 @@ class InProcessDataConnectGrpcStreamingServer : AutoCloseable {
   fun open(): Server {
     while (true) {
       when (val currentState = state.get()) {
-        is State.Unopened ->
-          if (
-            state.compareAndSet(
-              currentState,
-              State.Opened(currentState.server, currentState.startCondition)
-            )
-          ) {
-            currentState.server.start()
-            _port.set(currentState.server.port)
-            currentState.startCondition.open()
+        is State.Unopened -> {
+          val future = CompletableFuture<Unit>()
+          val eventHandler = EventHandler(_events, listener)
+          val server =
+            OkHttpServerBuilder.forPort(0, InsecureServerCredentials.create())
+              .addService(ConnectorStreamingServiceImpl(eventHandler))
+              .intercept(ServerInterceptorImpl(eventHandler))
+              .build()
+
+          val openingState = State.Opening(server, future)
+          if (!state.compareAndSet(currentState, openingState)) {
+            continue
           }
-        is State.Opened -> {
-          currentState.startCondition.block()
-          return currentState.server
+          try {
+            server.start()
+            _port.set(server.port)
+            future.complete(Unit)
+          } catch (e: Throwable) {
+            future.completeExceptionally(e)
+            throw e
+          }
         }
+        is State.Opening -> {
+          try {
+            currentState.started.get()
+          } catch (e: ExecutionException) {
+            throw e.cause ?: e
+          }
+          state.compareAndSet(currentState, State.Opened(currentState.server))
+        }
+        is State.Opened -> return currentState.server
+        is State.Closing,
         State.Closed -> error("close() has been called [zv6n23ry4h]")
       }
     }
@@ -192,17 +203,23 @@ class InProcessDataConnectGrpcStreamingServer : AutoCloseable {
    */
   override fun close() {
     while (true) {
-      val currentState = state.get()
-      when (currentState) {
-        State.Closed -> return
-        is State.Opened -> {
-          currentState.server.shutdownNow()
+      when (val currentState = state.get()) {
+        is State.Unopened -> if (state.compareAndSet(currentState, State.Closed)) return
+        is State.Opening ->
+          if (state.compareAndSet(currentState, State.Closing(currentState.server))) {
+            currentState.server.shutdownNow()
+            currentState.started.completeExceptionally(IllegalStateException("close() called"))
+          }
+        is State.Opened ->
+          if (state.compareAndSet(currentState, State.Closing(currentState.server))) {
+            currentState.server.shutdownNow()
+          }
+        is State.Closing -> {
           currentState.server.awaitTermination()
+          state.compareAndSet(currentState, State.Closed)
         }
-        is State.Unopened -> {}
+        State.Closed -> return
       }
-
-      state.compareAndSet(currentState, State.Closed)
     }
   }
 
@@ -219,11 +236,17 @@ class InProcessDataConnectGrpcStreamingServer : AutoCloseable {
   }
 
   private sealed interface State {
-    class Unopened(val server: Server, val startCondition: ConditionVariable) : State {
+    object Unopened : State {
       override fun toString() = "Unopened"
     }
-    class Opened(val server: Server, val startCondition: ConditionVariable) : State {
-      override fun toString() = "Opened(port=${server.port})"
+    class Opening(val server: Server, val started: CompletableFuture<Unit>) : State {
+      override fun toString() = "Opening"
+    }
+    class Opened(val server: Server) : State {
+      override fun toString() = "Opened(${server.port})"
+    }
+    class Closing(val server: Server) : State {
+      override fun toString() = "Closing"
     }
     data object Closed : State {
       override fun toString() = "Closed"

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/testutil/schemas/RealtimeConnector.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/testutil/schemas/RealtimeConnector.kt
@@ -20,6 +20,7 @@ import com.google.firebase.dataconnect.ConnectorConfig
 import com.google.firebase.dataconnect.FirebaseDataConnect
 import com.google.firebase.dataconnect.core.FirebaseDataConnectInternal
 import com.google.firebase.dataconnect.serializers.UUIDSerializer
+import com.google.firebase.dataconnect.testutil.DataConnectBackend
 import com.google.firebase.dataconnect.testutil.TestDataConnectFactory
 import java.util.UUID
 import kotlinx.serialization.Serializable
@@ -128,8 +129,11 @@ class RealtimeConnector private constructor(dataConnectInternal: FirebaseDataCon
         serviceId = "sid2ehn9ct8te",
       )
 
-    fun getInstance(dataConnectFactory: TestDataConnectFactory): RealtimeConnector {
-      val dataConnect = dataConnectFactory.newInstance(config)
+    fun getInstance(
+      dataConnectFactory: TestDataConnectFactory,
+      backend: DataConnectBackend? = null,
+    ): RealtimeConnector {
+      val dataConnect = dataConnectFactory.newInstance(config, backend)
       return RealtimeConnector(dataConnect as FirebaseDataConnectInternal)
     }
   }

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/CleanupsRule.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/CleanupsRule.kt
@@ -17,69 +17,180 @@ package com.google.firebase.dataconnect.testutil
 
 import android.util.Log
 import io.kotest.common.runBlocking
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.atomic.AtomicReference
 import org.junit.rules.ExternalResource
 
 /**
- * A JUnit test rule that allows tests to register "cleanups" to be run on test completion. If any
- * one cleanup throws an exception then the exception will be logged and the rest of the cleanups
- * will be executed, finally throwing the exception of the first failed cleanup. Cleanups will be
- * executed in the opposite order in which they are registered. Instances are thread-safe and
- * cleanups may be registered concurrently from multiple threads.
+ * A JUnit test rule that allows tests to register "cleanups" to be run on test completion.
+ *
+ * If any cleanup throws an exception, the exception will be logged and the remaining cleanups will
+ * still be executed. After all cleanups have been run, the exception from the first failed cleanup
+ * will be thrown. Cleanups are executed in the reverse order of their registration.
+ *
+ * All methods and properties of [CleanupsRule] are thread-safe and may be safely called and/or
+ * accessed concurrently from multiple threads and/or coroutines.
  */
 class CleanupsRule : ExternalResource() {
 
-  private val mutex = Mutex()
-  private var beforeCalled = false
-  private var afterCalled = false
-  private val cleanups = mutableListOf<Cleanup>()
+  private sealed interface State {
+    data object BeforeNotCalled : State
+    class Active(val cleanups: List<Cleanup>) : State
+    data object AfterCalled : State
+  }
+
+  private val state = AtomicReference<State>(State.BeforeNotCalled)
 
   /**
-   * Registers a cleanup. This function potentially blocks briefly while acquiring the lock on the
-   * list of cleanups. Throws an exception if called before [before] or after [after] has started.
+   * Registers an [AutoCloseable] to be closed on test completion.
+   *
+   * @param autoCloseable The resource to register for closing upon test completion.
+   * @return A [Registration] that can be used to unregister this cleanup.
+   * @throws IllegalStateException if called before [before] or after [after].
    */
-  fun register(name: String? = null, cleanup: suspend () -> Unit) = runBlocking {
-    registerSuspending(name, cleanup)
+  fun register(autoCloseable: AutoCloseable): Registration =
+    register(name = autoCloseable::class.qualifiedName, autoCloseable::close)
+
+  /**
+   * Registers a cleanup to be run on test completion.
+   *
+   * @param cleanup The block of code to register for execution upon test completion.
+   * @return A [Registration] that can be used to unregister this cleanup.
+   * @throws IllegalStateException if called before [before] or after [after].
+   */
+  fun register(cleanup: () -> Unit): Registration = register(name = null, cleanup)
+
+  /**
+   * Registers a cleanup to be run on test completion.
+   *
+   * @param name An optional name for the cleanup, used in logging messages for debugging purposes.
+   * @param cleanup The block of code to register for execution upon test completion.
+   * @return A [Registration] that can be used to unregister this cleanup.
+   * @throws IllegalStateException if called before [before] or after [after].
+   */
+  fun register(name: String?, cleanup: () -> Unit): Registration {
+    val registration = Cleanup(name, cleanup)
+
+    while (true) {
+      val currentState = state.get()
+      val activeState: State.Active =
+        when (currentState) {
+          is State.Active -> currentState
+          State.AfterCalled -> error("cleanups can not be registered after after() is called")
+          State.BeforeNotCalled -> error("cleanups can not be registered until before() is called")
+        }
+
+      val newCleanups =
+        buildList(activeState.cleanups.size + 1) {
+          addAll(activeState.cleanups)
+          add(registration)
+        }
+
+      val newState = State.Active(newCleanups)
+      if (state.compareAndSet(currentState, newState)) {
+        break
+      }
+    }
+
+    return registration
   }
 
   /**
-   * Registers a cleanup. This function potentially suspends while acquiring the lock on the list of
-   * cleanups. Throws an exception if called before [before] or after [after] has started.
+   * Registers a suspending cleanup to be run on test completion.
+   *
+   * The suspending cleanup is wrapped in `runBlocking` when executed.
+   *
+   * @param cleanup The block of code to register for execution upon test completion.
+   * @return A [Registration] that can be used to unregister this cleanup.
+   * @throws IllegalStateException if called before [before] or after [after].
    */
-  suspend fun registerSuspending(name: String? = null, cleanup: suspend () -> Unit) {
-    mutex.withLock {
-      check(beforeCalled) {
-        "cleanups can not be registered until before() is called " + "(error code 3yrwbehmvk)"
+  fun registerSuspending(cleanup: suspend () -> Unit): Registration =
+    registerSuspending(name = null, cleanup)
+
+  /**
+   * Registers a suspending cleanup to be run on test completion.
+   *
+   * The suspending cleanup is wrapped in `runBlocking` when executed.
+   *
+   * @param name An optional name for the cleanup, used in logging messages for debugging purposes.
+   * @param cleanup The block of code to register for execution upon test completion.
+   * @return A [Registration] that can be used to unregister this cleanup.
+   * @throws IllegalStateException if called before [before] or after [after].
+   */
+  fun registerSuspending(name: String?, cleanup: suspend () -> Unit): Registration =
+    register(name) { runBlocking { cleanup() } }
+
+  /**
+   * Unregisters a previously registered cleanup.
+   *
+   * If the cleanup has already been unregistered or [after] has been called then this method does
+   * nothing and returns as if successful.
+   *
+   * @param registration The registration object returned by one of the `register` methods to
+   * unregister.
+   */
+  fun unregister(registration: Registration) {
+    while (true) {
+      val currentState = state.get()
+      val activeState: State.Active =
+        when (currentState) {
+          is State.Active -> currentState
+          State.AfterCalled -> return
+          State.BeforeNotCalled -> return
+        }
+
+      val index = activeState.cleanups.indexOfFirst { it === registration }
+      if (index < 0) {
+        return
       }
 
-      check(!afterCalled) {
-        "cleanups can not be registered after after() has started " + "(error code dw92ms797f)"
-      }
+      val newCleanups =
+        activeState.cleanups.toMutableList().let {
+          it.removeAt(index)
+          it.toList()
+        }
 
-      cleanups.add(Cleanup(name, cleanup))
+      val newState = State.Active(newCleanups)
+      if (state.compareAndSet(currentState, newState)) {
+        break
+      }
     }
   }
 
-  override fun before(): Unit = runBlocking {
-    mutex.withLock {
-      check(!beforeCalled) { "before() has already been called (error code hg4a8ab5ve)" }
-      beforeCalled = true
+  override fun before() {
+    while (true) {
+      val currentState = state.get()
+      val newState =
+        when (currentState) {
+          State.BeforeNotCalled -> State.Active(emptyList())
+          is State.Active -> error("before() has already been called")
+          State.AfterCalled -> error("before() cannot be called after after()")
+        }
+      if (state.compareAndSet(currentState, newState)) {
+        break
+      }
     }
   }
 
-  override fun after(): Unit = runBlocking {
-    mutex.withLock {
-      check(!afterCalled) { "after() has already been called (error code brewwkxs6g)" }
-      afterCalled = true
+  override fun after() {
+    val oldState: State
+    while (true) {
+      val currentState = state.get()
+      val newState =
+        when (currentState) {
+          is State.Active -> State.AfterCalled
+          State.BeforeNotCalled -> error("before() must be called before after()")
+          State.AfterCalled -> error("after() has already been called")
+        }
+      if (state.compareAndSet(currentState, newState)) {
+        oldState = currentState
+        break
+      }
     }
 
     var firstException: Throwable? = null
 
-    while (true) {
-      val cleanup = mutex.withLock { cleanups.removeLastOrNull() } ?: break
-
-      val result = cleanup.runCatching { action() }
+    oldState.cleanups.reversed().forEach { cleanup ->
+      val result = cleanup.runCatching { this.action() }
       result.onFailure {
         Log.e("CleanupsRule", "cleanup ${cleanup.name} failed: $it", it)
         if (firstException === null) {
@@ -91,5 +202,7 @@ class CleanupsRule : ExternalResource() {
     firstException?.let { throw it }
   }
 
-  private data class Cleanup(val name: String?, val action: suspend () -> Unit)
+  interface Registration
+
+  private data class Cleanup(val name: String?, val action: () -> Unit) : Registration
 }

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/TestUtils.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/TestUtils.kt
@@ -177,6 +177,10 @@ class DelayUntilTimeoutException(message: String) : Exception(message)
  * Calls `Assert.fail()`, but also returns `Nothing` so that the Kotlin compiler can do better type
  * deduction for code that follows this `fail()` call.
  */
+@Deprecated(
+  "Use io.kotest.assertions.fail instead",
+  replaceWith = ReplaceWith("fail(message)", "io.kotest.assertions.fail")
+)
 fun fail(message: String): Nothing {
   Assert.fail(message)
   throw IllegalStateException("Should never get here")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -124,6 +124,7 @@ genai-prompt = { module = "com.google.mlkit:genai-prompt", version.ref = "genaiP
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 google-api-client = { module = "com.google.api-client:google-api-client", version.ref = "googleApiClient" }
 google-dexmaker = { module = "com.google.dexmaker:dexmaker", version.ref = "dexmakerVersion" }
+grpc-api = { module = "io.grpc:grpc-api", version.ref = "grpc" }
 grpc-android = { module = "io.grpc:grpc-android", version.ref = "grpc" }
 grpc-kotlin-stub = { module = "io.grpc:grpc-kotlin-stub", version.ref = "grpcKotlin" }
 grpc-okhttp = { module = "io.grpc:grpc-okhttp", version.ref = "grpc" }


### PR DESCRIPTION
This PR completes the implementation of `ConnectRPCIntegrationTest.kt` for Firebase Data Connect, adding comprehensive tests for streaming RPCs, including backend disconnect scenarios.

### Highlights
- Added `InProcessDataConnectGrpcStreamingServer` to simulate a gRPC backend for testing streaming features.
- Introduced `TurbineUtils.kt` with helper functions to simplify testing Kotlin Flows with Turbine.
- Refactored and improved `CleanupsRule` for better thread-safety and support for `AutoCloseable`.
- Added integration tests covering backend disconnects during various stages of the connection lifecycle.

### Changelog
<details>
<summary>View file changes</summary>

- **androidTestutil.gradle.kts**: Added `grpc-api` dependency.
- **TestDataConnectFactory.kt**: Added `newInstance` overload accepting a `backend`.
- **TurbineUtils.kt**: Added `awaitUntilItem`, `awaitUntilItemIsInstance`, `awaitError`, and `awaitStatusException` helpers.
- **ConnectRPCIntegrationTest.kt**: Refactored to use new helpers and added tests for backend disconnects.
- **InProcessDataConnectGrpcStreamingServer.kt**: New gRPC server for in-process testing.
- **RealtimeConnector.kt**: Updated `getInstance` to support custom backends.
- **CleanupsRule.kt**: Refactored for thread-safety and `AutoCloseable` support.
- **TestUtils.kt**: Deprecated old `fail` function in favor of Kotest's `fail`.
- **libs.versions.toml**: Added `grpc-api` version.
</details>
