### PR TITLE
[AppDistro] Disable automatic integration test execution with check task

### DIFF
--- a/firebase-appdistribution-gradle/firebase-appdistribution-gradle.gradle
+++ b/firebase-appdistribution-gradle/firebase-appdistribution-gradle.gradle
@@ -167,7 +167,7 @@ task integrationTest(type: Test) {
   }
 }
 
-check.dependsOn(integrationTest)
+// check.dependsOn(integrationTest)
 
 task prodTest(type: Test) {
   description = 'Runs prod tests.'


### PR DESCRIPTION
The `check` task no longer implicitly depends on `integrationTest` for the `firebase-appdistribution-gradle` module.

Unit test, unlike integration tests, block submission of PRs, and the test has been failing frequently.

Integration tests can still be run explicitly via `./gradlew :firebase-appdistribution-gradle:integrationTest`.