### PR TITLE
Update appdistro github workflow to run integration tests on appdistro presubmit

### DIFF
--- a/.github/workflows/app-distribution-gradle-compatibility-tests.yml
+++ b/.github/workflows/app-distribution-gradle-compatibility-tests.yml
@@ -3,6 +3,11 @@ name: App Distribution Gradle Compatibility Tests
 on:
   schedule:
     - cron: '0 6 * * *' # Run daily at 6 AM
+  pull_request:
+    paths:
+      - 'firebase-appdistribution/**'
+      - 'firebase-appdistribution-api/**'
+      - 'firebase-appdistribution-gradle/**'
   workflow_dispatch: # Allow manual triggering
 
 permissions:

--- a/firebase-appdistribution-gradle/firebase-appdistribution-gradle.gradle
+++ b/firebase-appdistribution-gradle/firebase-appdistribution-gradle.gradle
@@ -167,8 +167,6 @@ task integrationTest(type: Test) {
   }
 }
 
-check.dependsOn(integrationTest)
-
 task prodTest(type: Test) {
   description = 'Runs prod tests.'
   group = 'verification'


### PR DESCRIPTION
Removes integration tests from general PR presubmits, preventing appdistro bugs and issues from blocking other products.