### PR TITLE
[Crashlytics] Updating instrumented tests set up to avoid building errors due to Kotlin upgrade.

### DIFF
--- a/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/AppWithoutGoogleServicesFunctionalTests.kt
+++ b/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/AppWithoutGoogleServicesFunctionalTests.kt
@@ -17,10 +17,10 @@
 package com.google.firebase.crashlytics.buildtools.gradle
 
 import com.google.common.truth.Truth.assertThat
+import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPluginTest.Companion.buildGradleRunner
 import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPluginTest.Companion.mavenLocal
 import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPluginTest.Companion.pluginVersion
 import java.io.File
-import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
@@ -59,11 +59,11 @@ class AppWithoutGoogleServicesFunctionalTests {
 
     val thrown =
       assertThrows(UnexpectedBuildFailure::class.java) {
-        GradleRunner.create()
-          .withGradleVersion("8.1")
-          .withProjectDir(projectDir)
-          .withArguments(":uploadCrashlyticsMappingFileRelease", "--configuration-cache")
-          .build()
+        buildGradleRunner(
+          projectDir,
+          ":uploadCrashlyticsMappingFileRelease",
+          "--configuration-cache"
+        )
       }
 
     assertThat(thrown).hasMessageThat().contains("Google-Services plugin not found")
@@ -94,11 +94,11 @@ class AppWithoutGoogleServicesFunctionalTests {
 
     val thrown =
       assertThrows(UnexpectedBuildFailure::class.java) {
-        GradleRunner.create()
-          .withGradleVersion("8.1")
-          .withProjectDir(projectDir)
-          .withArguments(":uploadCrashlyticsMappingFileRelease", "--configuration-cache")
-          .build()
+        buildGradleRunner(
+          projectDir,
+          ":uploadCrashlyticsMappingFileRelease",
+          "--configuration-cache"
+        )
       }
 
     assertThat(thrown)
@@ -131,11 +131,11 @@ class AppWithoutGoogleServicesFunctionalTests {
 
     val thrown =
       assertThrows(UnexpectedBuildFailure::class.java) {
-        GradleRunner.create()
-          .withGradleVersion("8.1")
-          .withProjectDir(projectDir)
-          .withArguments(":uploadCrashlyticsMappingFileRelease", "--configuration-cache")
-          .build()
+        buildGradleRunner(
+          projectDir,
+          ":uploadCrashlyticsMappingFileRelease",
+          "--configuration-cache"
+        )
       }
 
     assertThat(thrown).hasMessageThat().contains("Google-Services plugin not configured properly")

--- a/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/CrashlyticsExtensionTests.kt
+++ b/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/CrashlyticsExtensionTests.kt
@@ -17,6 +17,7 @@
 package com.google.firebase.crashlytics.buildtools.gradle
 
 import com.google.common.truth.Truth.assertThat
+import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPluginTest.Companion.buildGradleRunner
 import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPluginTest.Companion.pluginVersion
 import java.io.File
 import org.gradle.testkit.runner.GradleRunner
@@ -176,11 +177,7 @@ class CrashlyticsExtensionTests {
 
     val thrown =
       Assertions.assertThrows(UnexpectedBuildFailure::class.java) {
-        GradleRunner.create()
-          .withGradleVersion("8.1")
-          .withProjectDir(projectDir)
-          .withArguments(":tasks", "--configuration-cache")
-          .build()
+        buildGradleRunner(projectDir, "-d", ":tasks", "--configuration-cache")
       }
 
     assertThat(thrown)

--- a/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/CrashlyticsExtensionTests.kt
+++ b/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/CrashlyticsExtensionTests.kt
@@ -20,7 +20,6 @@ import com.google.common.truth.Truth.assertThat
 import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPluginTest.Companion.buildGradleRunner
 import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPluginTest.Companion.pluginVersion
 import java.io.File
-import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -87,12 +86,7 @@ class CrashlyticsExtensionTests {
       """
     )
 
-    val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments("-d", ":tasks", "--configuration-cache")
-        .build()
+    val result = buildGradleRunner(projectDir, "-d", ":tasks", "--configuration-cache")
 
     assertThat(result.output).contains("/some/absolute/string/path")
   }
@@ -131,12 +125,7 @@ class CrashlyticsExtensionTests {
       """
     )
 
-    val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments("-d", ":tasks", "--configuration-cache")
-        .build()
+    val result = buildGradleRunner(projectDir, "-d", ":tasks", "--configuration-cache")
 
     assertThat(result.output).contains("/some/absolute/string/path")
     assertThat(result.output).contains("/another/absolute/string/path")
@@ -182,6 +171,6 @@ class CrashlyticsExtensionTests {
 
     assertThat(thrown)
       .hasMessageThat()
-      .contains("Cannot convert the provided notation to a File or URI: 42")
+      .contains("Cannot convert the provided notation to a File: 42")
   }
 }

--- a/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/CrashlyticsPluginTest.kt
+++ b/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/CrashlyticsPluginTest.kt
@@ -18,9 +18,11 @@ package com.google.firebase.crashlytics.buildtools.gradle
 
 import com.google.common.truth.Truth.assertThat
 import java.io.File
+import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.gradle.util.GradleVersion
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -99,11 +101,11 @@ class CrashlyticsPluginTest {
     // Instead, the test tasks all depend on :crashlytics-gradle:publishToMavenLocal, and the
     // local plugin version is exposed as a system property.
     val result =
-      GradleRunner.create()
-        .withGradleVersion(gradleVersion)
-        .withProjectDir(projectDir)
-        .withArguments(":injectCrashlyticsMappingFileIdRelease", "--configuration-cache")
-        .build()
+      buildGradleRunner(
+        projectDir,
+        ":injectCrashlyticsMappingFileIdRelease",
+        "--configuration-cache"
+      )
 
     assertThat(result.output)
       .contains(
@@ -223,5 +225,13 @@ class CrashlyticsPluginTest {
     val mavenLocal: String =
       System.getProperty("crashlytics.maven.artifacts.path")?.let { """maven(url = "$it")""" }
         ?: "mavenLocal()"
+
+    /** GradleRunner util method used by the whole functional test module. */
+    fun buildGradleRunner(projectDir: File, vararg arguments: String): BuildResult =
+      GradleRunner.create()
+        .withGradleVersion(GradleVersion.current().version)
+        .withProjectDir(projectDir)
+        .withArguments(*arguments)
+        .build()
   }
 }

--- a/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/MultiFlavorAppFunctionalTests.kt
+++ b/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/MultiFlavorAppFunctionalTests.kt
@@ -17,8 +17,8 @@
 package com.google.firebase.crashlytics.buildtools.gradle
 
 import com.google.common.truth.Truth.assertThat
+import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPluginTest.Companion.buildGradleRunner
 import java.io.File
-import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -56,11 +56,11 @@ class MultiFlavorAppFunctionalTests {
     )
 
     val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(":uploadCrashlyticsMappingFileProFrenchRelease", "--configuration-cache")
-        .build()
+      buildGradleRunner(
+        projectDir,
+        ":uploadCrashlyticsMappingFileProFrenchRelease",
+        "--configuration-cache"
+      )
 
     assertThat(result.output).contains(variantAppId)
   }
@@ -68,11 +68,11 @@ class MultiFlavorAppFunctionalTests {
   @Test
   fun `override the app for a specific package name`() {
     val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(":uploadCrashlyticsMappingFileProFrenchProd", "--configuration-cache")
-        .build()
+      buildGradleRunner(
+        projectDir,
+        ":uploadCrashlyticsMappingFileProFrenchProd",
+        "--configuration-cache"
+      )
 
     // This is the app id specific for package name suffix .prod
     assertThat(result.output).contains("1:2:android:2b")

--- a/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/NativeAppFunctionalTests.kt
+++ b/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/NativeAppFunctionalTests.kt
@@ -17,10 +17,10 @@
 package com.google.firebase.crashlytics.buildtools.gradle
 
 import com.google.common.truth.Truth.assertThat
+import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPluginTest.Companion.buildGradleRunner
 import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPluginTest.Companion.mavenLocal
 import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPluginTest.Companion.pluginVersion
 import java.io.File
-import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -33,12 +33,7 @@ class NativeAppFunctionalTests {
 
   @Test
   fun `only variants with nativeSymbolUploadEnabled register symbol tasks`() {
-    val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(":tasks", "--configuration-cache")
-        .build()
+    val result = buildGradleRunner(projectDir, ":tasks", "--configuration-cache")
 
     // The release variant has nativeSymbolUploadEnabled set to true.
     assertThat(result.output).contains("uploadCrashlyticsSymbolFileRelease")
@@ -52,12 +47,7 @@ class NativeAppFunctionalTests {
     val generateTask = ":generateCrashlyticsSymbolFileRelease"
     val uploadTask = ":uploadCrashlyticsSymbolFileRelease"
 
-    val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(uploadTask, "--configuration-cache")
-        .build()
+    val result = buildGradleRunner(projectDir, uploadTask, "--configuration-cache")
 
     assertThat(result.task(generateTask)?.outcome).isEqualTo(SUCCESS)
     assertThat(result.task(uploadTask)?.outcome).isEqualTo(SUCCESS)
@@ -105,12 +95,7 @@ class NativeAppFunctionalTests {
     val generateTask = ":generateCrashlyticsSymbolFileRelease"
     val uploadTask = ":uploadCrashlyticsSymbolFileRelease"
 
-    val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(uploadTask, "--configuration-cache")
-        .build()
+    val result = buildGradleRunner(projectDir, uploadTask, "--configuration-cache")
 
     assertThat(result.task(generateTask)?.outcome).isEqualTo(SUCCESS)
     assertThat(result.task(uploadTask)?.outcome).isEqualTo(SUCCESS)
@@ -130,15 +115,12 @@ class NativeAppFunctionalTests {
     val uploadTask = ":uploadCrashlyticsSymbolFileRelease"
 
     val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(
-          uploadTask,
-          "-Pcom.google.firebase.crashlytics.breakpadBinary=dump_syms.o",
-          "--configuration-cache"
-        )
-        .build()
+      buildGradleRunner(
+        projectDir,
+        uploadTask,
+        "-Pcom.google.firebase.crashlytics.breakpadBinary=dump_syms.o",
+        "--configuration-cache"
+      )
 
     assertThat(result.task(generateTask)?.outcome).isEqualTo(SUCCESS)
     assertThat(result.task(uploadTask)?.outcome).isEqualTo(SUCCESS)
@@ -182,12 +164,7 @@ class NativeAppFunctionalTests {
     val generateTask = ":generateCrashlyticsSymbolFileRelease"
     val uploadTask = ":uploadCrashlyticsSymbolFileRelease"
 
-    val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(uploadTask, "--configuration-cache")
-        .build()
+    val result = buildGradleRunner(projectDir, uploadTask, "--configuration-cache")
 
     assertThat(result.task(generateTask)?.outcome).isEqualTo(SUCCESS)
     assertThat(result.task(uploadTask)?.outcome).isEqualTo(SUCCESS)
@@ -231,17 +208,14 @@ class NativeAppFunctionalTests {
     val generateTask = ":generateCrashlyticsSymbolFileRelease"
     val uploadTask = ":uploadCrashlyticsSymbolFileRelease"
 
+    // Set csym by property, which overrides the extension.
     val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        // Set csym by property, which overrides the extension.
-        .withArguments(
-          uploadTask,
-          "-Pcom.google.firebase.crashlytics.symbolGenerator=csym",
-          "--configuration-cache"
-        )
-        .build()
+      buildGradleRunner(
+        projectDir,
+        uploadTask,
+        "-Pcom.google.firebase.crashlytics.symbolGenerator=csym",
+        "--configuration-cache"
+      )
 
     assertThat(result.task(generateTask)?.outcome).isEqualTo(SUCCESS)
     assertThat(result.task(uploadTask)?.outcome).isEqualTo(SUCCESS)
@@ -257,12 +231,7 @@ class NativeAppFunctionalTests {
     val generateTask = ":generateCrashlyticsSymbolFileRelease"
     val uploadTask = ":uploadCrashlyticsSymbolFileRelease"
 
-    val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(uploadTask, "--configuration-cache")
-        .build()
+    val result = buildGradleRunner(projectDir, uploadTask, "--configuration-cache")
 
     assertThat(result.task(generateTask)?.outcome).isEqualTo(SUCCESS)
     assertThat(result.task(uploadTask)?.outcome).isEqualTo(SUCCESS)
@@ -275,12 +244,7 @@ class NativeAppFunctionalTests {
 
   @Test
   fun `building a native app generates build ids`() {
-    val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(":assembleRelease", "--configuration-cache")
-        .build()
+    val result = buildGradleRunner(projectDir, ":assembleRelease", "--configuration-cache")
 
     assertThat(result.task(":injectCrashlyticsBuildIdsRelease")?.outcome).isEqualTo(SUCCESS)
   }

--- a/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/TypicalAppFunctionalTests.kt
+++ b/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/TypicalAppFunctionalTests.kt
@@ -17,9 +17,9 @@
 package com.google.firebase.crashlytics.buildtools.gradle
 
 import com.google.common.truth.Truth.assertThat
+import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPluginTest.Companion.buildGradleRunner
 import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPluginTest.Companion.pluginVersion
 import java.io.File
-import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.BeforeEach
@@ -40,12 +40,7 @@ class TypicalAppFunctionalTests {
 
   @Test
   fun `inject mapping file id on app build`() {
-    val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(":assembleRelease", "--configuration-cache")
-        .build()
+    val result = buildGradleRunner(projectDir, ":assembleRelease", "--configuration-cache")
 
     assertThat(result.output)
       .contains(
@@ -56,12 +51,7 @@ class TypicalAppFunctionalTests {
 
   @Test
   fun `inject version control info on release app build`() {
-    val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(":assembleRelease")
-        .build()
+    val result = buildGradleRunner(projectDir, ":assembleRelease")
 
     assertThat(result.task(":injectCrashlyticsVersionControlInfoRelease")?.outcome)
       .isEqualTo(SUCCESS)
@@ -69,12 +59,7 @@ class TypicalAppFunctionalTests {
 
   @Test
   fun `upload mapping file automatically during minified app build`() {
-    val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(":assembleRelease", "--configuration-cache")
-        .build()
+    val result = buildGradleRunner(projectDir, ":assembleRelease", "--configuration-cache")
 
     assertThat(result.task(":uploadCrashlyticsMappingFileRelease")?.outcome).isEqualTo(SUCCESS)
     assertThat(result.output)
@@ -86,12 +71,7 @@ class TypicalAppFunctionalTests {
     strings = [":injectCrashlyticsMappingFileIdDebug", ":injectCrashlyticsMappingFileIdRelease"]
   )
   fun `inject some mapping file id regardless of obfuscation`(taskName: String) {
-    val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(taskName)
-        .build()
+    val result = buildGradleRunner(projectDir, taskName)
 
     assertThat(result.output)
       .contains(
@@ -104,12 +84,7 @@ class TypicalAppFunctionalTests {
   fun `upload mapping file with obfuscation`() {
     val taskName = ":uploadCrashlyticsMappingFileRelease"
 
-    val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(taskName, "--configuration-cache")
-        .build()
+    val result = buildGradleRunner(projectDir, taskName, "--configuration-cache")
 
     assertThat(result.output)
       .contains(
@@ -122,12 +97,7 @@ class TypicalAppFunctionalTests {
 
   @Test
   fun `upload mapping file task without obfuscation not registered`() {
-    val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(":tasks", "--configuration-cache")
-        .build()
+    val result = buildGradleRunner(projectDir, ":tasks", "--configuration-cache")
 
     assertThat(result.output).doesNotContain("uploadCrashlyticsMappingFileDebug")
   }
@@ -160,12 +130,7 @@ class TypicalAppFunctionalTests {
       """
     )
 
-    val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(":assembleRelease", "--configuration-cache")
-        .build()
+    val result = buildGradleRunner(projectDir, ":assembleRelease", "--configuration-cache")
 
     assertThat(result.task("uploadCrashlyticsMappingFileRelease")).isNull()
   }
@@ -182,11 +147,7 @@ class TypicalAppFunctionalTests {
   fun `does not register ndk tasks on non-native app`(taskName: String) {
     val thrown =
       assertThrows<UnexpectedBuildFailure> {
-        GradleRunner.create()
-          .withGradleVersion("8.1")
-          .withProjectDir(projectDir)
-          .withArguments(taskName, "--configuration-cache")
-          .build()
+        buildGradleRunner(projectDir, taskName, "--configuration-cache")
       }
 
     assertThat(thrown).hasMessageThat().contains("not found")
@@ -194,12 +155,7 @@ class TypicalAppFunctionalTests {
 
   @Test
   fun `building typical app without obfuscation injects blank mapping file id`() {
-    val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(":assembleDebug", "--configuration-cache")
-        .build()
+    val result = buildGradleRunner(projectDir, ":assembleDebug", "--configuration-cache")
 
     // The debug variant does not have minify enabled, so inject blank mapping file id
     assertThat(result.task(":injectCrashlyticsMappingFileIdDebug")?.outcome).isEqualTo(SUCCESS)
@@ -211,12 +167,7 @@ class TypicalAppFunctionalTests {
 
   @Test
   fun `building typical app with obfuscation injects mapping file id`() {
-    val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(":assembleRelease", "--configuration-cache")
-        .build()
+    val result = buildGradleRunner(projectDir, ":assembleRelease", "--configuration-cache")
 
     // The release variant does have minify enabled
     assertThat(result.task(":injectCrashlyticsMappingFileIdRelease")?.outcome).isEqualTo(SUCCESS)
@@ -257,12 +208,7 @@ class TypicalAppFunctionalTests {
       """
     )
 
-    val result =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(":assembleRelease", "--configuration-cache")
-        .build()
+    val result = buildGradleRunner(projectDir, ":assembleRelease", "--configuration-cache")
 
     assertThat(result.task(":uploadCrashlyticsMappingFileRelease")?.outcome).isEqualTo(SUCCESS)
     assertThat(result.output)


### PR DESCRIPTION
**Context**

https://github.com/firebase/firebase-android-sdk/pull/7896 updated Kotlin version, which broke Crashlytics functional test building since these were using a hardcoded version of Gradle.