### PR TITLE
dataconnect(chore): DataConnectGrpcRPCs.kt: fix wasteful conversion to Struct only used for debug logging

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -8,6 +8,8 @@
   ([#8027](https://github.com/firebase/firebase-android-sdk/pull/8027))
 - [changed] Internal change to add protos for realtime query updates.
   ([#8081](https://github.com/firebase/firebase-android-sdk/pull/8081))
+- [changed] Fixed wasteful computation that is only for debug logging.
+  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
 
 # 17.2.1
 

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -9,7 +9,7 @@
 - [changed] Internal change to add protos for realtime query updates.
   ([#8081](https://github.com/firebase/firebase-android-sdk/pull/8081))
 - [changed] Fixed wasteful computation that is only for debug logging.
-  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
+  ([#8126](https://github.com/firebase/firebase-android-sdk/pull/8126))
 
 # 17.2.1
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -174,7 +174,7 @@ internal class DataConnectGrpcRPCs(
       kotlinMethodName = kotlinMethodName,
       grpcMethod = ConnectorServiceGrpc.getExecuteMutationMethod(),
       metadata = metadata,
-      request = request.toStructProto(),
+      request = { request.toStructProto() },
       requestTypeName = "ExecuteMutationRequest",
       authUid = authToken?.authUid,
     )
@@ -185,7 +185,7 @@ internal class DataConnectGrpcRPCs(
       logger.logGrpcReceived(
         requestId = requestId,
         kotlinMethodName = kotlinMethodName,
-        response = it.toStructProto(),
+        response = { it.toStructProto() },
         responseTypeName = "ExecuteMutationResponse",
       )
     }
@@ -242,7 +242,7 @@ internal class DataConnectGrpcRPCs(
       kotlinMethodName = kotlinMethodName,
       grpcMethod = ConnectorServiceGrpc.getExecuteQueryMethod(),
       metadata = metadata,
-      request = request.toStructProto(),
+      request = { request.toStructProto() },
       requestTypeName = "ExecuteQueryRequest",
       authUid = authToken?.authUid,
     )
@@ -267,7 +267,7 @@ internal class DataConnectGrpcRPCs(
       logger.logGrpcReceived(
         requestId = requestId,
         kotlinMethodName = kotlinMethodName,
-        response = response.toStructProto(),
+        response = { response.toStructProto() },
         responseTypeName = "ExecuteQueryResponse",
       )
 
@@ -358,7 +358,7 @@ internal class DataConnectGrpcRPCs(
       logger.logGrpcReceived(
         requestId = requestId,
         kotlinMethodName = kotlinMethodName,
-        response = it.toStructProto(),
+        response = { it.toStructProto() },
         responseTypeName = "EmulatorInfo",
       )
     }
@@ -394,7 +394,7 @@ internal class DataConnectGrpcRPCs(
         logger.logGrpcReceived(
           requestId = requestId,
           kotlinMethodName = kotlinMethodName,
-          response = response.toStructProto(),
+          response = { response.toStructProto() },
           responseTypeName = "EmulatorIssuesResponse"
         )
       }
@@ -489,19 +489,20 @@ internal class DataConnectGrpcRPCs(
       }
     }
 
-    private fun Logger.logGrpcSending(
+    private inline fun Logger.logGrpcSending(
       requestId: String,
       kotlinMethodName: String,
       grpcMethod: MethodDescriptor<*, *>,
       metadata: Metadata,
-      request: Struct,
+      request: () -> Struct,
       requestTypeName: String,
       authUid: String?,
     ) = debug {
+      val requestStruct = request()
       val struct = buildStructProto {
         put("RPC", grpcMethod.fullMethodName)
         put("Metadata", metadata.toStructProto(authUid))
-        put(requestTypeName, request)
+        put(requestTypeName, requestStruct)
       }
       // Sort the keys in the output string to be more meaningful than alphabetical.
       val keySortSelector: (String) -> String = {
@@ -545,13 +546,14 @@ internal class DataConnectGrpcRPCs(
       kotlinMethodName: String,
     ) = debug { "$kotlinMethodName [rid=$requestId] completed" }
 
-    private fun Logger.logGrpcReceived(
+    private inline fun Logger.logGrpcReceived(
       requestId: String,
       kotlinMethodName: String,
-      response: Struct,
+      response: () -> Struct,
       responseTypeName: String
     ) = debug {
-      val struct = buildStructProto { put(responseTypeName, response) }
+      val responseStruct = response()
+      val struct = buildStructProto { put(responseTypeName, responseStruct) }
       "$kotlinMethodName [rid=$requestId] received: ${struct.toCompactString()}"
     }
 


### PR DESCRIPTION
This PR optimizes the gRPC logging in `DataConnectGrpcRPCs.kt` by deferring the conversion of request and response objects to `Struct` protos until they are actually needed for debug logging.

### Highlights

- **Deferred Logging Payloads**: Refactored `logGrpcSending` and `logGrpcReceived` to accept lambdas instead of pre-computed `Struct` objects, preventing unnecessary computation when debug logging is disabled.
- **Inline Logging Functions**: Marked logging helper functions as `inline` to allow the use of lambda parameters without additional allocation overhead.

### Changelog

<details>
<summary>Modified files</summary>

- **CHANGELOG.md**: Added an entry for the optimization of debug logging computation.
- **DataConnectGrpcRPCs.kt**: Refactored gRPC logging to use inline functions with deferred payload evaluation.

</details>