### PR TITLE
dataconnect(test): RandomSeedTestRule: add seeded constructor, and implementation cleanup

### DIFF
--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/RandomSeedTestRule.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/RandomSeedTestRule.kt
@@ -16,6 +16,7 @@
 package com.google.firebase.dataconnect.testutil
 
 import io.kotest.property.RandomSource
+import org.junit.AssumptionViolatedException
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
@@ -36,16 +37,17 @@ class RandomSeedTestRule(val rs: Lazy<RandomSource>) : TestRule {
   override fun apply(base: Statement, description: Description) =
     object : Statement() {
       override fun evaluate() {
-        val result = base.runCatching { evaluate() }
-        result.onFailure {
-          if (rs.isInitialized()) {
-            println(
+        try {
+          base.evaluate()
+        } catch (throwable: Throwable) {
+          if (rs.isInitialized() && throwable !is AssumptionViolatedException) {
+            System.err.println(
               "WARNING[55negqf33k]: RandomSeedTestRule: Test failed using " +
                 "RandomSource with seed=${rs.value.seed}: ${description.displayName}"
             )
           }
+          throw throwable
         }
-        result.getOrThrow()
       }
     }
 }

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/RandomSeedTestRule.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/RandomSeedTestRule.kt
@@ -27,7 +27,11 @@ import org.junit.runners.model.Statement
  */
 class RandomSeedTestRule(val rs: Lazy<RandomSource>) : TestRule {
 
-  constructor() : this(lazy(LazyThreadSafetyMode.PUBLICATION) { RandomSource.default() })
+  constructor(createRandomSource: () -> RandomSource) : this(lazy(LazyThreadSafetyMode.PUBLICATION, createRandomSource))
+
+  constructor() : this(RandomSource::default)
+
+  constructor(seed: Long) : this({ RandomSource.seeded(seed) })
 
   override fun apply(base: Statement, description: Description) =
     object : Statement() {

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/RandomSeedTestRule.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/RandomSeedTestRule.kt
@@ -25,15 +25,28 @@ import org.junit.runners.model.Statement
  * A JUnit test rule that prints the seed of a [RandomSource] if the test fails, enabling replaying
  * the test with the same seed to investigate failures. If the [Lazy] is never initialized, then the
  * random seed is _not_ printed.
+ *
+ * @property rs A [Lazy] instance that produces the [RandomSource] to be used in the test.
  */
 class RandomSeedTestRule(val rs: Lazy<RandomSource>) : TestRule {
 
+  /**
+   * Creates a [RandomSeedTestRule] with a factory function for the [RandomSource].
+   *
+   * @param createRandomSource A factory function invoked lazily to create the [RandomSource].
+   */
   constructor(
     createRandomSource: () -> RandomSource
   ) : this(lazy(LazyThreadSafetyMode.PUBLICATION, createRandomSource))
 
+  /** Creates a [RandomSeedTestRule] with a default, randomly seeded [RandomSource]. */
   constructor() : this(RandomSource::default)
 
+  /**
+   * Creates a [RandomSeedTestRule] with a [RandomSource] initialized with the specified [seed].
+   *
+   * @param seed The specific seed to initialize the [RandomSource] with.
+   */
   constructor(seed: Long) : this({ RandomSource.seeded(seed) })
 
   override fun apply(base: Statement, description: Description) =

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/RandomSeedTestRule.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/RandomSeedTestRule.kt
@@ -28,7 +28,9 @@ import org.junit.runners.model.Statement
  */
 class RandomSeedTestRule(val rs: Lazy<RandomSource>) : TestRule {
 
-  constructor(createRandomSource: () -> RandomSource) : this(lazy(LazyThreadSafetyMode.PUBLICATION, createRandomSource))
+  constructor(
+    createRandomSource: () -> RandomSource
+  ) : this(lazy(LazyThreadSafetyMode.PUBLICATION, createRandomSource))
 
   constructor() : this(RandomSource::default)
 


### PR DESCRIPTION
This PR adds a seeded constructor to `RandomSeedTestRule` to allow replaying tests with a specific seed and cleans up the rule's implementation.

### Highlights
*   **Seeded Constructor:** Added a new constructor to `RandomSeedTestRule` that accepts a `Long` seed, facilitating the reproduction of test failures that depend on a specific random sequence.
*   **Implementation Cleanup:** Refactored the `evaluate()` method from `runCatching` to a `try-catch` block to improve readability and control flow.
*   **Exception Handling:** Updated the failure logging to ignore `AssumptionViolatedException`, ensuring that skipped tests do not trigger the "test failed" warning message.
*   **Output Stream:** Changed failure log output from `System.out` to `System.err` for better visibility in test logs.
*   **Documentation:** Added KDoc documentation for the class property and its various constructors.

### Changelog
<details>
<summary>1 file changed</summary>

*   `RandomSeedTestRule.kt`: Added a seeded constructor, documented the `rs` property and constructors, and refactored the evaluation logic to use `try-catch` while specifically handling `AssumptionViolatedException`.
</details>
