### PR TITLE
dataconnect(build): fix CopySharedWithAndroidTestFiles.kt to delete the output directory before writing to it

### DIFF
--- a/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/sharedtest/CopySharedWithAndroidTestFiles.kt
+++ b/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/sharedtest/CopySharedWithAndroidTestFiles.kt
@@ -15,15 +15,17 @@
  */
 package com.google.firebase.dataconnect.gradle.sharedtest
 
+import java.io.File
+import javax.inject.Inject
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.logging.Logger
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import java.io.File
 
 /**
  * A Gradle task that copies Kotlin source files annotated with `@file:SharedWithAndroidTest` from
@@ -41,6 +43,8 @@ abstract class CopySharedWithAndroidTestFiles : DefaultTask() {
 
   @get:OutputDirectory abstract val outputDirectory: DirectoryProperty
 
+  @get:Inject abstract val fileSystemOperations: FileSystemOperations
+
   @TaskAction
   fun run() {
     val inputBaseDirectory: File = inputBaseDirectory.get().asFile
@@ -51,6 +55,16 @@ abstract class CopySharedWithAndroidTestFiles : DefaultTask() {
     logger.info("inputDirectory={}", inputDirectory.absolutePath)
     logger.info("outputDirectory={}", outputDirectory.absolutePath)
 
+    if (outputDirectory.exists()) {
+      logger.info("Deleting output directory: {}", outputDirectory.absolutePath)
+      fileSystemOperations.delete { it.delete(outputDirectory) }
+      if (outputDirectory.exists()) {
+        throw OutputDirectoryDeleteFailedException(
+          "Deleting output directory failed: ${outputDirectory.absolutePath}"
+        )
+      }
+    }
+
     copyAnnotatedFiles(
       srcBaseDir = inputBaseDirectory,
       srcDir = inputDirectory,
@@ -59,6 +73,8 @@ abstract class CopySharedWithAndroidTestFiles : DefaultTask() {
       logger = logger,
     )
   }
+
+  class OutputDirectoryDeleteFailedException(message: String) : GradleException(message)
 }
 
 /**


### PR DESCRIPTION
This PR updates the `CopySharedWithAndroidTestFiles` Gradle task to ensure the output directory is deleted before copying files, preventing stale or conflicting files from persisting across task executions.

## Highlights
- Added `FileSystemOperations` to `CopySharedWithAndroidTestFiles` via Gradle's `@Inject`.
- Implemented a check to delete the `outputDirectory` if it already exists at the start of the task action.
- Introduced `OutputDirectoryDeleteFailedException` to handle cases where the output directory cannot be successfully deleted.

## Changelog
<details>
<summary>1 file affected</summary>

- `CopySharedWithAndroidTestFiles.kt`: Modified the `run()` function to delete the output directory before copying files; added `FileSystemOperations` injection and `OutputDirectoryDeleteFailedException` class.
</details>
