### PR TITLE
[Infra] Bump actions/upload-artifact to v7.0.1

### DIFF
--- a/.github/workflows/ai-daily-tests.yml
+++ b/.github/workflows/ai-daily-tests.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload logs
         if: failure()
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: logcat.txt
           path: logcat.txt

--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -41,21 +41,21 @@ jobs:
           ./gradlew firebasePublish
 
       - name: Upload m2 repo
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: m2repository
           path: build/m2repository/
           retention-days: 15
 
       - name: Upload release notes
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release_notes
           path: build/release-notes/
           retention-days: 15
 
       - name: Upload kotlindocs
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: kotlindocs
           path: build/firebase-kotlindoc/

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -99,7 +99,7 @@ jobs:
         env:
           MATRIX_MODULE: ${{matrix.module}}
       - name: Upload Test Results
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: unit-test-result-${{env.ARTIFACT_NAME}}

--- a/.github/workflows/create-releases-buildtools.yml
+++ b/.github/workflows/create-releases-buildtools.yml
@@ -40,7 +40,7 @@ jobs:
           ./gradlew \
             -Dmaven.repo.local=${ARTIFACTS} \
             :firebase-appdistribution-gradle:publishToMavenLocal
-      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: firebase-appdistribution-gradle
           path: ${{ env.ARTIFACTS }}
@@ -68,7 +68,7 @@ jobs:
             -Dmaven.repo.local=${ARTIFACTS} \
             :firebase-crashlytics-buildtools:publishToMavenLocal \
             :firebase-crashlytics-gradle:publishToMavenLocal
-      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: firebase-crashlytics-gradle-and-buildtools
           path: ${{ env.ARTIFACTS }}
@@ -95,7 +95,7 @@ jobs:
           ./gradlew \
             -Dmaven.repo.local=${ARTIFACTS} \
             :firebase-perf-gradle:publishToMavenLocal
-      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: firebase-perf-gradle
           path: ${{ env.ARTIFACTS }}

--- a/.github/workflows/dataconnect.yml
+++ b/.github/workflows/dataconnect.yml
@@ -259,7 +259,7 @@ jobs:
             set -eux && ./gradlew --warning-mode all ${{ (inputs.gradleInfoLog && '--info') || '' }} :firebase-dataconnect:connectedCheck :firebase-dataconnect:connectors:connectedCheck
 
       - name: Upload Log Files
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: integration_test_logs
           path: "**/*.log"
@@ -267,7 +267,7 @@ jobs:
           compression-level: 9
 
       - name: Upload Gradle Build Reports
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: integration_test_gradle_build_reports
           path: firebase-dataconnect/**/build/reports/

--- a/.github/workflows/dataconnect_demo_app.yml
+++ b/.github/workflows/dataconnect_demo_app.yml
@@ -128,21 +128,21 @@ jobs:
           ${{ (inputs.gradleInfoLog && '--info') || '' }} \
           dokkaGeneratePublicationHtml
 
-      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: apks
           path: firebase-dataconnect/demo/build/**/*.apk
           if-no-files-found: warn
           compression-level: 0
 
-      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gradle_build_reports
           path: firebase-dataconnect/demo/build/reports/
           if-no-files-found: warn
           compression-level: 9
 
-      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ktdoc
           path: firebase-dataconnect/demo/build/dokka/html

--- a/.github/workflows/fireperf-e2e.yml
+++ b/.github/workflows/fireperf-e2e.yml
@@ -96,7 +96,7 @@ jobs:
             }
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-artifacts (${{ matrix.environment }})
           path: |

--- a/.github/workflows/firestore_ci_tests.yml
+++ b/.github/workflows/firestore_ci_tests.yml
@@ -94,7 +94,7 @@ jobs:
             ./gradlew firebase-firestore:connectedCheck withErrorProne -PtargetBackend="prod" -PbackendEdition="standard" -PtargetDatabaseId="(default)"
       - name: Upload logs
         if: failure()
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: logcat.txt
           path: logcat.txt
@@ -188,7 +188,7 @@ jobs:
             ./gradlew firebase-firestore:connectedCheck withErrorProne -PtargetBackend="prod" -PbackendEdition="enterprise" -PtargetDatabaseId="enterprise"
       - name: Upload logs
         if: failure()
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: named-db-logcat.txt
           path: logcat.txt
@@ -254,7 +254,7 @@ jobs:
             ./gradlew firebase-firestore:connectedCheck withErrorProne -PtargetBackend="nightly" -PbackendEdition="enterprise" -PtargetDatabaseId="enterprise"
       - name: Upload logs
         if: failure()
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-logcat.txt
           path: logcat.txt
@@ -331,7 +331,7 @@ jobs:
             ./gradlew firebase-firestore:connectedCheck withErrorProne -PtargetBackend="emulator" -PbackendEdition="enterprise"
       - name: Upload logs
         if: failure()
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: emulator-logcat.txt
           path: logcat.txt

--- a/.github/workflows/make-bom.yml
+++ b/.github/workflows/make-bom.yml
@@ -29,21 +29,21 @@ jobs:
           ./gradlew buildBomBundleZip
 
       - name: Upload bom
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bom
           path: build/bom/
           retention-days: 15
 
       - name: Upload release notes
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bom_release_notes
           path: build/bomReleaseNotes.md
           retention-days: 15
 
       - name: Upload recipe version update
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: recipe_version
           path: build/recipeVersionUpdate.txt

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -73,7 +73,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: Upload artifact
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: smoke-tests-artifacts
           path: |


### PR DESCRIPTION
Updated the actions/upload-artifact GitHub Action version to v7.0.1 across all CI workflow files to ensure consistent and updated artifact management.