### PR TITLE
Prevent R8 to strip out `RequireBuildId` boolean resource

### DIFF
--- a/firebase-crashlytics/src/main/res/raw/firebase_crashlytics_keep.xml
+++ b/firebase-crashlytics/src/main/res/raw/firebase_crashlytics_keep.xml
@@ -14,4 +14,5 @@
   ~ limitations under the License.
   -->
 <resources xmlns:tools="http://schemas.android.com/tools"
-    tools:keep="@string/com.google.firebase.crashlytics_*" />
+    tools:keep="@string/com.google.firebase.crashlytics_*,@bool/com_crashlytics_RequireBuildId" />
+    


### PR DESCRIPTION
- without: `bool:com_crashlytics_RequireBuildId:2131034114 is not reachable`
- with: `bool:com_crashlytics_RequireBuildId:2131034114 reachable from keep xml file`

Note: `_` are used instead of `.` because periods are not valid characters.

Fixes #8146