### PR TITLE
[Infra] Update postReleaseCleanup to support execution from main branch

### DIFF
--- a/.github/workflows/post_release_cleanup.yml
+++ b/.github/workflows/post_release_cleanup.yml
@@ -7,6 +7,10 @@ on:
         description: 'Release name'
         required: true
         type: string
+      target-branch:
+        description: 'Target branch'
+        required: true
+        type: string
 
 jobs:
   create-pull-request:
@@ -14,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.target-branch }}
           fetch-depth: 0
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -43,9 +48,9 @@ jobs:
             **/gradle.properties
             **/*.gradle
             **/*.gradle.kts
-          title: '${{ inputs.name}} mergeback'
+          title: '${{ inputs.name }} mergeback'
           body: |
-            Auto-generated PR for cleaning up release ${{ inputs.name}}
+            Auto-generated PR for cleaning up release ${{ inputs.name }}
 
             NO_RELEASE_CHANGE
           commit-message: 'Post release cleanup for ${{ inputs.name }}'


### PR DESCRIPTION
Add target-branch parameter to checkout specific branches while retaining release name for PR metadata.