### PR TITLE
dataconnect(ci): downgrade fdc emulator version to 3.4.7 (was 3.4.9)

### DIFF
--- a/firebase-dataconnect/gradleplugin/plugin/src/main/resources/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableVersions.json
+++ b/firebase-dataconnect/gradleplugin/plugin/src/main/resources/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableVersions.json
@@ -1,5 +1,5 @@
 {
-  "defaultVersion": "3.4.9",
+  "defaultVersion": "3.4.7",
   "versions": [
     {
       "version": "1.3.4",
@@ -2088,62 +2088,6 @@
       "arch": "amd64",
       "size": 31518904,
       "sha512DigestHex": "c460801cda734c8d0ebdb418e636d8ae9bd6bb3c7100152e343cad73ab8e0ba755c506de15c878cd0ee6414130acc5cc99e30270a79d6a91dcbefb80de8b0e20"
-    },
-    {
-      "version": "3.4.8",
-      "os": "windows",
-      "arch": "amd64",
-      "size": 32406016,
-      "sha512DigestHex": "745c04c3dcc6c607a6b9f4ab2776d34a7f589c736137eb7a597e645d14a5a9669cd89dca681b6947ecafea4d131246bcceb6ffe9db975c8a67c4bd70c30a7e16"
-    },
-    {
-      "version": "3.4.8",
-      "os": "macos",
-      "arch": "amd64",
-      "size": 32365504,
-      "sha512DigestHex": "ec71d303d6a27664b33f9fcc4763200352a5cda73476feb99456ef9d6d9235e5e1b382f8e805125249d62dc7cbfa408e33bc0bc0351d562bf078703fe515cd5e"
-    },
-    {
-      "version": "3.4.8",
-      "os": "macos",
-      "arch": "arm64",
-      "size": 30504626,
-      "sha512DigestHex": "2d26414035c163872ad867c8bf8bfde6aaf74876945328dbf13b62032b9d033cd4cd20f88e8a67ad76bc44a2134ee1cc2c2811948e861409cc4a5c0f8bc72f32"
-    },
-    {
-      "version": "3.4.8",
-      "os": "linux",
-      "arch": "amd64",
-      "size": 31518904,
-      "sha512DigestHex": "cec4aa440da710b1c4e1af133b1dcb9d8dc6583edb6dd4cdd67a86a193a4e392407d3bd43a6b9018fb7a32c5d712f05a5ca011a0901486a28c8a1cdf6ddfca66"
-    },
-    {
-      "version": "3.4.9",
-      "os": "windows",
-      "arch": "amd64",
-      "size": 32406016,
-      "sha512DigestHex": "745c04c3dcc6c607a6b9f4ab2776d34a7f589c736137eb7a597e645d14a5a9669cd89dca681b6947ecafea4d131246bcceb6ffe9db975c8a67c4bd70c30a7e16"
-    },
-    {
-      "version": "3.4.9",
-      "os": "macos",
-      "arch": "amd64",
-      "size": 32365504,
-      "sha512DigestHex": "ec71d303d6a27664b33f9fcc4763200352a5cda73476feb99456ef9d6d9235e5e1b382f8e805125249d62dc7cbfa408e33bc0bc0351d562bf078703fe515cd5e"
-    },
-    {
-      "version": "3.4.9",
-      "os": "macos",
-      "arch": "arm64",
-      "size": 30504626,
-      "sha512DigestHex": "2d26414035c163872ad867c8bf8bfde6aaf74876945328dbf13b62032b9d033cd4cd20f88e8a67ad76bc44a2134ee1cc2c2811948e861409cc4a5c0f8bc72f32"
-    },
-    {
-      "version": "3.4.9",
-      "os": "linux",
-      "arch": "amd64",
-      "size": 31518904,
-      "sha512DigestHex": "cec4aa440da710b1c4e1af133b1dcb9d8dc6583edb6dd4cdd67a86a193a4e392407d3bd43a6b9018fb7a32c5d712f05a5ca011a0901486a28c8a1cdf6ddfca66"
     }
   ]
 }


### PR DESCRIPTION
As it turns out, v3.4.8 and v3.4.9 of the data connect emulator were duplicates of 3.4.7 and were published in error. They were unceremoniously unpublished today, causing GitHub Actions Workflows to fail with the following error:

```
Downloading Data Connect executable from https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-linux-amd64-v3.4.9 failed with HTTP response code 404: Not Found
```

(example: https://github.com/firebase/firebase-android-sdk/actions/runs/25763193942/job/75676682191)

Moreover, a "new" version 3.4.8 was just published, which has different hashes than the "old" 3.4.8. The "new" 3.4.8 version will be picked up later during regular emulator upgrades. And by "regular" I mean whenever I feel like running the `.gemini/commands/dataconnect_emulator_upgrade.toml` command in gemini-cli.