### PR TITLE
Use String.format in cases where firebase-vendor plugin transforms hardcoded strings

### DIFF
--- a/firebase-appdistribution/CHANGELOG.md
+++ b/firebase-appdistribution/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [fixed] Fixed failing APK downloads due to an invalid file provider authority [#8136]
+
 # 16.0.0-beta18
 
 - [changed] Bump internal dependencies.

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ApkUpdater.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ApkUpdater.java
@@ -227,7 +227,7 @@ class ApkUpdater {
     try {
       String applicationName =
           context.getApplicationInfo().loadLabel(context.getPackageManager()).toString();
-      return applicationName + ".apk";
+      return String.format("%s.%s", applicationName, "apk");
     } catch (Exception e) {
       LogWrapper.w(
           TAG,

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/InstallActivity.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/InstallActivity.java
@@ -148,7 +148,9 @@ public class InstallActivity extends AppCompatActivity {
       Uri apkUri =
           FileProvider.getUriForFile(
               getApplicationContext(),
-              getApplicationContext().getPackageName() + ".FirebaseAppDistributionFileProvider",
+              String.format(
+                  "%s.%s",
+                  getApplicationContext().getPackageName(), "FirebaseAppDistributionFileProvider"),
               apkFile);
       intent.setDataAndType(apkUri, APK_MIME_TYPE);
       intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);


### PR DESCRIPTION
Starting with `16.0.0-beta18`, the vendor plugin is renaming strings in the app distro SDK:

```
> Task :firebase-appdistribution:releaseVendorTransform
...
Changed ".FirebaseAppDistributionFileProvider" -> "com.google.firebase.appdistribution.impl..FirebaseAppDistributionFileProvider"
Changed ".apk" -> "com.google.firebase.appdistribution.impl..apk"
...
```

This is causing the SDK functionality to fail due to malformed strings: https://github.com/firebase/firebase-android-sdk/issues/8136

I don't know the root cause, but this does fix the issue.