### PR TITLE
dataconnect(test): TurbineUtils.kt: minor tweaks

### DIFF
--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/TurbineUtils.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/TurbineUtils.kt
@@ -64,7 +64,7 @@ suspend inline fun <T, reified U : T> ReceiveTurbine<T>.awaitUntilItemIsInstance
 
 suspend inline fun <reified T : Throwable> ReceiveTurbine<*>.awaitError(
   exceptionDescriptionSuffix: String? = null,
-  predicate: (T) -> Unit = {}
+  validate: (T) -> Unit = {}
 ): T {
   val expectedText = buildString {
     append(T::class.qualifiedName)
@@ -78,10 +78,8 @@ suspend inline fun <reified T : Throwable> ReceiveTurbine<*>.awaitError(
     when (val event = awaitEvent()) {
       Event.Complete -> fail("Flow completed normally, but expected it to throw $expectedText")
       is Event.Error -> event.throwable
-      is Event.Item<*> ->
-        fail(
-          "Flow produced item (${event.value.print()}), " + "but expected it to throw $expectedText"
-        )
+      is Event.Item ->
+        fail("Flow produced item (${event.value.print()}), but expected it to throw $expectedText")
     }
 
   if (exception !is T) {
@@ -92,14 +90,14 @@ suspend inline fun <reified T : Throwable> ReceiveTurbine<*>.awaitError(
     )
   }
 
-  predicate(exception)
+  validate(exception)
 
   return exception
 }
 
 suspend inline fun ReceiveTurbine<*>.awaitStatusException(
   code: Status.Code?,
-  predicate: (StatusException) -> Unit = {}
+  validate: (StatusException) -> Unit = {}
 ): StatusException {
   val exceptionDescriptionSuffix = if (code === null) null else "with code $code"
   val statusException = awaitError<StatusException>(exceptionDescriptionSuffix)
@@ -114,7 +112,7 @@ suspend inline fun ReceiveTurbine<*>.awaitStatusException(
     }
   }
 
-  predicate(statusException)
+  validate(statusException)
 
   return statusException
 }


### PR DESCRIPTION
In the data connect test utilities, modify the "turbine" (Flow testing library) utilities as follows: the `predicate` parameter to renamed to `validate` to more clearly indicate its purpose and some other minor cleanup to improve clarity and consistency.

### Highlights
- Renamed `predicate` parameter to `validate` in `awaitError` and `awaitStatusException` functions for better semantic alignment with validation logic.
- Simplified `Event.Item<*>` pattern matching to `Event.Item` in `awaitError`.

### Changelog
<details>
<summary>Files affected</summary>

- `TurbineUtils.kt`: Renamed parameters and updated event handling logic.
</details>