### PR TITLE
Add didANRKillOnPreviousExecution() to FirebaseCrashlytics

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -5,6 +5,9 @@
 - [fixed] Fixed race condition that caused logs from background threads to not be attached to
   reports in some cases [#8034]
 - [changed] Updated `firebase-sessions` dependency to v3.0.6
+- [feature] Added `didANRKillOnPreviousExecution()` to `FirebaseCrashlytics`, allowing apps to
+  detect whether they were killed by an ANR in the previous run. Requires API level 30 (Android R)
+  or above; always returns `false` on older versions. [#4201]
 
 # 20.0.5
 

--- a/firebase-crashlytics/api.txt
+++ b/firebase-crashlytics/api.txt
@@ -18,6 +18,7 @@ package com.google.firebase.crashlytics {
   public class FirebaseCrashlytics {
     method public com.google.android.gms.tasks.Task<java.lang.Boolean!> checkForUnsentReports();
     method public void deleteUnsentReports();
+    method public boolean didANRKillOnPreviousExecution();
     method public boolean didCrashOnPreviousExecution();
     method public static com.google.firebase.crashlytics.FirebaseCrashlytics getInstance();
     method public boolean isCrashlyticsCollectionEnabled();

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreInitializationTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreInitializationTest.java
@@ -265,6 +265,18 @@ public class CrashlyticsCoreInitializationTest extends CrashlyticsTestCase {
     assertFalse(getCrashMarkerFile().exists());
   }
 
+  @Test
+  public void testOnPreExecute_didNotANROnPreviousExecution() {
+    // Without any ApplicationExitInfo entries indicating an ANR, didANROnPreviousExecution
+    // should return false.
+    final CrashlyticsCore crashlyticsCore = builder().build();
+    setupBuildIdRequired(String.valueOf(false));
+    setupAppData(BUILD_ID);
+
+    assertTrue(crashlyticsCore.onPreExecute(appData, mockSettingsController));
+    assertFalse(crashlyticsCore.didANROnPreviousExecution());
+  }
+
   private void setupBuildIdRequired(String booleanValue) {
     setupResource(
         RES_ID_REQUIRE_BUILD_ID,

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -463,6 +463,16 @@ public class FirebaseCrashlytics {
   }
 
   /**
+   * Checks whether the app was terminated due to an ANR (Application Not Responding) on its
+   * previous run. Requires Android API 30 (R) or above; returns {@code false} on older versions.
+   *
+   * @return true if an ANR was recorded during the previous run of the app.
+   */
+  public boolean didANRKillOnPreviousExecution() {
+    return core.didANROnPreviousExecution();
+  }
+
+  /**
    * Indicates whether or not automatic data collection is enabled.
    *
    * @return In order of priority:

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -466,6 +466,10 @@ public class FirebaseCrashlytics {
    * Checks whether the app was terminated due to an ANR (Application Not Responding) on its
    * previous run. Requires Android API 30 (R) or above; returns {@code false} on older versions.
    *
+   * The result is computed lazily on the first call and cached, so the first invocation may
+   * briefly block the calling thread (up to a few seconds) while the system is queried. Call from
+   * a background thread if responsiveness matters.
+   *
    * @return true if an ANR was recorded during the previous run of the app.
    */
   public boolean didANRKillOnPreviousExecution() {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -943,5 +943,25 @@ class CrashlyticsController {
           .v("ANR feature enabled, but device is API " + android.os.Build.VERSION.SDK_INT);
     }
   }
+  /** This function must be called before opening the first session. */
+  boolean didANROnPreviousExecution() {
+    CrashlyticsWorkers.checkBackgroundThread();
+    if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+      return false;
+    }
+    final String sessionId = getCurrentSessionId();
+    if (sessionId == null) {
+      return false;
+    }
+    ActivityManager activityManager =
+        (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+    List<ApplicationExitInfo> applicationExitInfoList =
+        activityManager.getHistoricalProcessExitReasons(null, 0, 0);
+    if (applicationExitInfoList.isEmpty()) {
+      return false;
+    }
+    return reportingCoordinator.didRelevantAnrOccur(sessionId, applicationExitInfoList);
+  }
+
   // endregion
 }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -943,6 +943,7 @@ class CrashlyticsController {
           .v("ANR feature enabled, but device is API " + android.os.Build.VERSION.SDK_INT);
     }
   }
+
   /** This function must be called before opening the first session. */
   boolean didANROnPreviousExecution() {
     CrashlyticsWorkers.checkBackgroundThread();
@@ -955,6 +956,9 @@ class CrashlyticsController {
     }
     ActivityManager activityManager =
         (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+    if (activityManager == null) {
+      return false;
+    }
     List<ApplicationExitInfo> applicationExitInfoList =
         activityManager.getHistoricalProcessExitReasons(null, 0, 0);
     if (applicationExitInfoList.isEmpty()) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -119,6 +119,10 @@ class CrashlyticsController {
   // A token to make sure that checkForUnsentReports only gets called once.
   final AtomicBoolean checkForUnsentReportsCalled = new AtomicBoolean(false);
 
+  // Captured before the previous session is finalized, so didANROnPreviousExecution() can
+  // still resolve the correct session ID after the user calls it later.
+  @Nullable private volatile String previousExecutionSessionId;
+
   CrashlyticsController(
       Context context,
       IdManager idManager,
@@ -944,13 +948,23 @@ class CrashlyticsController {
     }
   }
 
-  /** This function must be called before opening the first session. */
+  /**
+   * Captures the previous run's session ID on the common worker so {@link
+   * #didANROnPreviousExecution} can resolve it later. SDK-internal: the call site (currently
+   * {@link CrashlyticsCore#onPreExecute}) must queue this before {@link #enableExceptionHandling}
+   * (which opens a new session) and before {@link #finalizeSessions} (which removes the previous
+   * one); after either runs, {@link #getCurrentSessionId} no longer refers to the previous run.
+   */
+  void capturePreviousExecutionSessionId() {
+    crashlyticsWorkers.common.submit(() -> previousExecutionSessionId = getCurrentSessionId());
+  }
+
   boolean didANROnPreviousExecution() {
     CrashlyticsWorkers.checkBackgroundThread();
     if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
       return false;
     }
-    final String sessionId = getCurrentSessionId();
+    final String sessionId = previousExecutionSessionId;
     if (sessionId == null) {
       return false;
     }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -83,6 +83,7 @@ public class CrashlyticsCore {
   private CrashlyticsFileMarker initializationMarker;
   private CrashlyticsFileMarker crashMarker;
   private boolean didCrashOnPreviousExecution;
+  private boolean didANROnPreviousExecution;
 
   private CrashlyticsController controller;
   private final IdManager idManager;
@@ -196,6 +197,7 @@ public class CrashlyticsCore {
       final boolean initializeSynchronously = didPreviousInitializationFail();
 
       checkForPreviousCrash();
+      checkForPreviousAnr();
 
       controller.enableExceptionHandling(
           sessionIdentifier, Thread.getDefaultUncaughtExceptionHandler(), settingsProvider);
@@ -500,6 +502,28 @@ public class CrashlyticsCore {
 
   public boolean didCrashOnPreviousExecution() {
     return didCrashOnPreviousExecution;
+  }
+
+  private void checkForPreviousAnr() {
+    Future<Boolean> future =
+        crashlyticsWorkers
+            .common
+            .getExecutor()
+            .submit(() -> controller.didANROnPreviousExecution());
+
+    Boolean result;
+    try {
+      result = future.get(DEFAULT_MAIN_HANDLER_TIMEOUT_SEC, TimeUnit.SECONDS);
+    } catch (Exception ignored) {
+      didANROnPreviousExecution = false;
+      return;
+    }
+
+    didANROnPreviousExecution = Boolean.TRUE.equals(result);
+  }
+
+  public boolean didANROnPreviousExecution() {
+    return didANROnPreviousExecution;
   }
 
   // endregion

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -83,7 +83,9 @@ public class CrashlyticsCore {
   private CrashlyticsFileMarker initializationMarker;
   private CrashlyticsFileMarker crashMarker;
   private boolean didCrashOnPreviousExecution;
-  private boolean didANROnPreviousExecution;
+
+  private final Object didANROnPreviousExecutionLock = new Object();
+  @Nullable private volatile Boolean didANROnPreviousExecutionCached;
 
   private CrashlyticsController controller;
   private final IdManager idManager;
@@ -197,7 +199,10 @@ public class CrashlyticsCore {
       final boolean initializeSynchronously = didPreviousInitializationFail();
 
       checkForPreviousCrash();
-      checkForPreviousAnr();
+
+      // Must run before enableExceptionHandling and finalizeSessions, since both alter the
+      // set of open sessions. didANROnPreviousExecution() uses the captured ID later.
+      controller.capturePreviousExecutionSessionId();
 
       controller.enableExceptionHandling(
           sessionIdentifier, Thread.getDefaultUncaughtExceptionHandler(), settingsProvider);
@@ -504,27 +509,31 @@ public class CrashlyticsCore {
     return didCrashOnPreviousExecution;
   }
 
-  private void checkForPreviousAnr() {
-    Future<Boolean> future =
-        crashlyticsWorkers
-            .common
-            .getExecutor()
-            .submit(() -> controller.didANROnPreviousExecution());
-
-    Boolean result;
-    try {
-      result = future.get(DEFAULT_MAIN_HANDLER_TIMEOUT_SEC, TimeUnit.SECONDS);
-    } catch (Exception ex) {
-      Logger.getLogger().v("Error checking for previous ANR: " + ex.getMessage());
-      didANROnPreviousExecution = false;
-      return;
-    }
-
-    didANROnPreviousExecution = Boolean.TRUE.equals(result);
-  }
-
   public boolean didANROnPreviousExecution() {
-    return didANROnPreviousExecution;
+    Boolean cached = didANROnPreviousExecutionCached;
+    if (cached != null) {
+      return cached;
+    }
+    synchronized (didANROnPreviousExecutionLock) {
+      if (didANROnPreviousExecutionCached != null) {
+        return didANROnPreviousExecutionCached;
+      }
+      Future<Boolean> future =
+          crashlyticsWorkers
+              .common
+              .getExecutor()
+              .submit(() -> controller.didANROnPreviousExecution());
+
+      Boolean result;
+      try {
+        result = future.get(DEFAULT_MAIN_HANDLER_TIMEOUT_SEC, TimeUnit.SECONDS);
+      } catch (Exception ex) {
+        Logger.getLogger().v("Error checking for previous ANR: " + ex.getMessage());
+        result = false;
+      }
+      didANROnPreviousExecutionCached = Boolean.TRUE.equals(result);
+      return didANROnPreviousExecutionCached;
+    }
   }
 
   // endregion

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -514,7 +514,8 @@ public class CrashlyticsCore {
     Boolean result;
     try {
       result = future.get(DEFAULT_MAIN_HANDLER_TIMEOUT_SEC, TimeUnit.SECONDS);
-    } catch (Exception ignored) {
+    } catch (Exception ex) {
+      Logger.getLogger().v("Error checking for previous ANR: " + ex.getMessage());
       didANROnPreviousExecution = false;
       return;
     }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
@@ -439,6 +439,13 @@ public class SessionReportingCoordinator {
     }
   }
 
+  /** Returns true if an ANR ApplicationExitInfo occurred during the given session. */
+  @RequiresApi(api = Build.VERSION_CODES.R)
+  public boolean didRelevantAnrOccur(
+      String sessionId, List<ApplicationExitInfo> applicationExitInfoList) {
+    return findRelevantApplicationExitInfo(sessionId, applicationExitInfoList) != null;
+  }
+
   /** Finds the first ANR ApplicationExitInfo within the session. */
   @RequiresApi(api = Build.VERSION_CODES.R)
   private @Nullable ApplicationExitInfo findRelevantApplicationExitInfo(

--- a/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinatorRobolectricTest.java
+++ b/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinatorRobolectricTest.java
@@ -165,6 +165,55 @@ public class SessionReportingCoordinatorRobolectricTest {
   }
 
   @Test
+  @SdkSuppress(minSdkVersion = VERSION_CODES.R)
+  public void testDidRelevantAnrOccur_returnsTrueForAnrWithinSession() {
+    final long sessionStartTimestamp = 0;
+    final String sessionId = "testSessionId";
+    when(reportPersistence.getStartTimestampMillis(sessionId)).thenReturn(sessionStartTimestamp);
+
+    addAppExitInfo(ApplicationExitInfo.REASON_ANR);
+    List<ApplicationExitInfo> testApplicationExitInfoList = getAppExitInfoList();
+
+    assertTrue(reportingCoordinator.didRelevantAnrOccur(sessionId, testApplicationExitInfoList));
+  }
+
+  @Test
+  @SdkSuppress(minSdkVersion = VERSION_CODES.R)
+  public void testDidRelevantAnrOccur_returnsFalseForAnrBeforeSession() {
+    // ANR timestamp is 0; session starts at 10, so ANR was before the session.
+    final long sessionStartTimestamp = 10;
+    final String sessionId = "testSessionId";
+    when(reportPersistence.getStartTimestampMillis(sessionId)).thenReturn(sessionStartTimestamp);
+
+    addAppExitInfo(ApplicationExitInfo.REASON_ANR);
+    List<ApplicationExitInfo> testApplicationExitInfoList = getAppExitInfoList();
+
+    assertFalse(reportingCoordinator.didRelevantAnrOccur(sessionId, testApplicationExitInfoList));
+  }
+
+  @Test
+  @SdkSuppress(minSdkVersion = VERSION_CODES.R)
+  public void testDidRelevantAnrOccur_returnsFalseForNonAnrWithinSession() {
+    final long sessionStartTimestamp = 0;
+    final String sessionId = "testSessionId";
+    when(reportPersistence.getStartTimestampMillis(sessionId)).thenReturn(sessionStartTimestamp);
+
+    addAppExitInfo(ApplicationExitInfo.REASON_EXIT_SELF);
+    List<ApplicationExitInfo> testApplicationExitInfoList = getAppExitInfoList();
+
+    assertFalse(reportingCoordinator.didRelevantAnrOccur(sessionId, testApplicationExitInfoList));
+  }
+
+  @Test
+  @SdkSuppress(minSdkVersion = VERSION_CODES.R)
+  public void testDidRelevantAnrOccur_returnsFalseForEmptyList() {
+    final String sessionId = "testSessionId";
+    when(reportPersistence.getStartTimestampMillis(sessionId)).thenReturn(0L);
+
+    assertFalse(reportingCoordinator.didRelevantAnrOccur(sessionId, List.of()));
+  }
+
+  @Test
   public void testconvertInputStreamToString_worksSuccessfully() throws IOException {
     String stackTrace = "-----stacktrace---------";
     InputStream inputStream = new ByteArrayInputStream(stackTrace.getBytes());


### PR DESCRIPTION
# Add didANRKillOnPreviousExecution() to FirebaseCrashlytics

Implements [#4201](https://github.com/firebase/firebase-android-sdk/issues/4201).


Crashlytics already detects ANRs and files reports for them, and developers have long been able to call `didCrashOnPreviousExecution()` to gate logic that should only run after a fatal crash. However, there was no equivalent API for ANRs: developers who want to adapt their app's behavior after an ANR (e.g., disable a heavy feature on the next cold start, log a custom key, or show a recovery dialog) had no supported way to do so.

`didCrashOnPreviousExecution()` works by reading a marker file written at crash time. ANRs cannot use that mechanism because the main thread is frozen and the crash handler never runs. Instead, the new method uses `ApplicationExitInfo` (API 30+), which records process-exit reasons at the OS level — the same source already queried internally by `SessionReportingCoordinator` when filing ANR reports. The new API delegates to that existing infrastructure rather than introducing a separate detection path.


## Usage

The API mirrors `didCrashOnPreviousExecution()` — synchronous, returns a boolean. Call it once on a cold start (typically from `Application.onCreate` or your DI startup) and react to the result. The first call may briefly block, so prefer a background thread.

### Kotlin

```kotlin
class MyApplication : Application() {
  override fun onCreate() {
    super.onCreate()

    // Run on a background dispatcher — the first call queries the OS for
    // the previous run's exit reason and may block for up to a few seconds.
    CoroutineScope(Dispatchers.IO).launch {
      val crashlytics = Firebase.crashlytics
      if (crashlytics.didANRKillOnPreviousExecution()) {
        crashlytics.setCustomKey("recovered_from_anr", true)
        // e.g., disable the heavy feature that caused the ANR last run,
        // surface an in-app recovery prompt, etc.
      }
    }
  }
}
```

### What you can do with it

- Set `setCustomKey("recovered_from_anr", true)` to tag any follow-up report this run might file, for correlation in the console.
- Skip a suspected-bad feature for one run, re-enable on the next clean start.
- Show an in-app recovery UI (clear cache, sign out, reset a preference).
- Bump your own analytics counter for ANR-induced restarts.

### What to avoid

- Calling it on the main thread — first call can block up to ~3 s (Binder IPC + filesystem I/O); subsequent calls are cached and free.
- Calling it before `FirebaseCrashlytics.getInstance()` is available.
- Treating `true` as "the user just crashed" — ANRs and fatal crashes are independent; both predicates can fire on the same cold start.
- Relying on the result on API < 30 — safe to call, but always `false`.


## Test plan

- [x] `./gradlew :firebase-crashlytics:testDebugUnitTest` passes locally.
- [x] `SessionReportingCoordinatorRobolectricTest` covers the four `didRelevantAnrOccur` branches.
- [x] `CrashlyticsCoreInitializationTest.testOnPreExecute_didNotANROnPreviousExecution` verifies the happy (no-ANR) path end-to-end through `CrashlyticsCore`, including the lazy first-call path.
