### PR TITLE
dataconnect(chore): Refactor realtime queries to use SharedFlow features

### DIFF
--- a/firebase-dataconnect/RealtimeTodo.md
+++ b/firebase-dataconnect/RealtimeTodo.md
@@ -37,8 +37,8 @@ network comes back.
 
 Replace the simplistic retry logic with:
 1. **Exponential Backoff**: Increase the delay between retries exponentially (with jitter) to avoid
-   overwhelming the server and the client.
+overwhelming the server and the client.
 2. **Network State Integration**: Integrate with the OS network state monitoring (e.g., Android's
-   `ConnectivityManager`) to proactively trigger a reconnection attempt as soon as the device
-   regains internet connectivity, rather than waiting for a backoff timer.
+`ConnectivityManager`) to proactively trigger a reconnection attempt as soon as the device
+regains internet connectivity, rather than waiting for a backoff timer.
 

--- a/firebase-dataconnect/RealtimeTodo.md
+++ b/firebase-dataconnect/RealtimeTodo.md
@@ -1,43 +1,6 @@
 # Realtime Query Subscription TODO List
 
-### TODO 1: Lack of Connection Health Monitoring / Reconnection
-
-* **File:** RealtimeQueryManager.kt
-* **Severity:** `CRITICAL`
-
-#### Description
-
-Once `RealtimeQueryManager` successfully transitions to `State.Connected(stream)`, it remains in
-this state permanently. If the underlying bidirectional gRPC connection is lost or the stream is
-closed (due to network issues, server-side termination, or client-side close), the manager does not
-detect this. Any future calls to `subscribe()` will read `State.Connected` and try to use the dead
-stream, causing new subscriptions to silently hang or fail indefinitely without any reconnection
-attempts.
-
-#### Recommendation
-
-Add connection health monitoring or detect when the stream has completed/failed, and transition
-the manager's state back to `State.Disconnected` (or clean up resources) to allow subsequent
-subscription calls to trigger a new connection.
-
----
-
-### TODO 2: Permanent Lock-out / Stuck in `Connecting` State on Connection Failure
-
-* **File:** RealtimeQueryManager.kt
-* **Severity:** `CRITICAL`
-
-#### Description
-
-In `ensureConnected`, `currentState.job.await()` is called to wait for the lazy `Deferred`
-connection job. If the connection attempt fails (e.g., due to a temporary network issue) and
-throws an exception, the exception propagates out of the method. Because the exception is thrown
-before the state is updated, the manager's state remains permanently stuck in
-`State.Connecting(job)`. Any future connection attempts will call `await()` on the same failed
-`Deferred` job, which immediately and permanently re-throws the same cached exception, making the
-manager completely unusable until the app or SDK instance is restarted.
-
-### TODO 3: Memory and Resource Leak of Subscription Flows in `flowByQueryId`
+### TODO 1: Memory and Resource Leak of Subscription Flows in `flowByQueryId`
 
 * **File:** RealtimeQueryManager.kt
 * **Severity:** `HIGH`
@@ -56,33 +19,26 @@ wasting bandwidth and server resources.
 Implement a reference-counting mechanism or a cleanup callback upon flow completion to remove the
 query from `flowByQueryId` once the active collector count drops to zero.
 
-### TODO 4: Late Subscribers Hang Indefinitely on Completed Stream
+---
+
+### TODO 2: Simplistic Retry Logic / Lack of Exponential Backoff and Network State Integration
 
 * **File:** DataConnectBidiConnectStream.kt
 * **Severity:** `HIGH`
 
 #### Description
 
-Late subscribers to a stream that has already completed (server-side) will hang indefinitely.
-This occurs because `incomingResponses` is a `SharedFlow` with `replay = 0`. If the stream
-completes, the `IncomingResponse.Completed` signal is emitted and lost for future subscribers.
-These subscribers will then wait in `transformWhile` for new emissions that will never come.
-
-The current implementation of `onCompletion` does not prevent the hang for late subscribers.
-Because `streams.incomingResponses` is a `SharedFlow` with `replay = 0`, if the stream has already
-completed, the `IncomingResponse.Completed` signal is lost. A new subscriber will begin collecting
-from `incomingResponses` and wait indefinitely for emissions that will never arrive. The
-`onCompletion` block is only executed *after* the flow collection completes, so it cannot resolve a
-hang that occurs *during* the collection process.
-
-Discovered by gemini code assist:
-https://github.com/firebase/firebase-android-sdk/pull/8158#discussion_r3240286966
+The retry logic in `connectionFlow` is extremely simplistic: it retries up to 2 times with a flat
+1-second delay between attempts. If a connection is lost due to a sustained network outage (longer
+than 2 seconds), the stream will fail permanently and will not attempt to recover even after the
+network comes back.
 
 #### Recommendation
 
-You should check `streams.completedResponse` before starting the flow collection to ensure the
-stream is still active.
+Replace the simplistic retry logic with:
+1. **Exponential Backoff**: Increase the delay between retries exponentially (with jitter) to avoid
+   overwhelming the server and the client.
+2. **Network State Integration**: Integrate with the OS network state monitoring (e.g., Android's
+   `ConnectivityManager`) to proactively trigger a reconnection attempt as soon as the device
+   regains internet connectivity, rather than waiting for a backoff timer.
 
-To address this, you should check the state of `streams.completedResponse` *before* or *at the
-start* of the flow collection (e.g., inside the `flow { ... }` builder) to verify if the stream is
-already finished, and emit the completion signal or throw the cached exception immediately if it is.

--- a/firebase-dataconnect/docs/README.md
+++ b/firebase-dataconnect/docs/README.md
@@ -20,7 +20,13 @@ Before modifying any significant component, starting a new feature, or refactori
 When you need to make a significant architectural choice (e.g., choosing a library, changing data flow, defining a new component boundary):
 1.  Create a new file in this directory named `adr-NNNN-short-description.md`, starting from `adr-0001.md`.
 2.  Use the template in [adr-template.md](adr-template.md).
-3.  Fill out the sections honestly and concisely.
+3.  Fill out the sections honestly and concisely. Prioritize explaining the **WHY** behind the
+decisions, the benefits, and why the choices are valid and worthwhile. **AVOID** merely repeating
+the technical choices without any justifications (developers can just read the git commit
+history for what changed; ADRs exist to capture the reasoning). If the rationale, trade-offs,
+or benefits are not fully known or clear, **liberally ask the user for clarification** before
+writing. It is of paramount importance that these details are recorded accurately and are
+absolutely correct.
 4.  Update the **Decision Registry** in this file (`docs/README.md`) to list your new ADR.
 
 ---
@@ -45,14 +51,29 @@ When you need to make a significant architectural choice (e.g., choosing a libra
 > (Or `../scripts/spotlessApply.zsh` if running from within the `docs/` directory).
 > A task is NOT considered complete until the files have been successfully formatted by this script.
 
+### 3. Focus on the "Why" (Rationale and Benefits)
+
+> [!IMPORTANT]
+> When writing ADRs, prioritize explaining the **rationale, trade-offs, and benefits** of the
+> decisions. Do not just repeat the technical implementation details—explain **WHY** they were
+> chosen and why the solutions are valid. ADRs are design documents meant to convey historical
+> context and reasoning, not code diff summaries (which can be read in the git commit history).
+>
+> **CRITICAL**: If the rationale, trade-offs, or benefits of a decision are not fully known or are
+> unclear to you, **you MUST liberally ask the user for clarification** before writing the document.
+> It is of paramount importance that these architectural details are recorded accurately and are
+> absolutely correct. Do not make assumptions or guess.
+
 ---
 
 ## Decision Registry
 
-| ID                                                                     | Title                                                | Date                         | Status   | Tags                                              |
-|:-----------------------------------------------------------------------|:-----------------------------------------------------|:-----------------------------|:---------|:--------------------------------------------------|
-| [0001](adr-0001-rewire-bidi-connection-to-grpcbidiflow.md)             | Rewire Bidirectional gRPC Connection to GrpcBidiFlow | Fri May 15 18:33:07 EDT 2026 | accepted | network, grpc, coroutines, reactive-streams       |
-| [0002](adr-0002-use-replay-expiration-millis-0-in-while-subscribed.md) | Use replayExpirationMillis = 0 in WhileSubscribed    | Sat May 16 22:34:19 EDT 2026 | accepted | network, grpc, coroutines, flow, reactive-streams |
-| [0003](adr-0003-sequence-number-filtering-for-stale-replayed-data.md)  | Sequence Number Filtering for Stale Replayed Data    | Sun May 17 00:02:50 EDT 2026 | accepted | network, grpc, coroutines, flow, multiplexing     |
+| ID                                                                                          | Title                                                                   | Date                         | Status     | Tags                                                       |
+|:--------------------------------------------------------------------------------------------|:------------------------------------------------------------------------|:-----------------------------|:-----------|:-----------------------------------------------------------|
+| [0001](adr-0001-rewire-bidi-connection-to-grpcbidiflow.md)                                  | Rewire Bidirectional gRPC Connection to GrpcBidiFlow                    | Fri May 15 18:33:07 EDT 2026 | accepted   | network, grpc, coroutines, reactive-streams                |
+| [0002](adr-0002-use-replay-expiration-millis-0-in-while-subscribed.md)                      | Use replayExpirationMillis = 0 in WhileSubscribed                       | Sat May 16 22:34:19 EDT 2026 | superseded | network, grpc, coroutines, flow, reactive-streams          |
+| [0003](adr-0003-sequence-number-filtering-for-stale-replayed-data.md)                       | Sequence Number Filtering for Stale Replayed Data                       | Sun May 17 00:02:50 EDT 2026 | superseded | network, grpc, coroutines, flow, multiplexing              |
+| [0004](adr-0004-coordinate-multiplexed-subscriptions-using-conflatedsignal-and-replay-0.md) | Coordinate Multiplexed Subscriptions using ConflatedSignal and Replay=0 | Tue May 19 15:58:34 EDT 2026 | accepted   | network, grpc, coroutines, flow, multiplexing              |
+| [0005](adr-0005-configure-flow-control-and-conflation-for-realtime-queries.md)              | Configure Flow Control and Conflation for Realtime Queries              | Tue May 19 17:28:33 EDT 2026 | accepted   | network, grpc, coroutines, flow, backpressure, performance |
 
 *(Add new records to this table in chronological order. Refer to the status lifecycle: `proposed` -> `accepted` -> `superseded`/`deprecated`)*

--- a/firebase-dataconnect/docs/adr-0002-use-replay-expiration-millis-0-in-while-subscribed.md
+++ b/firebase-dataconnect/docs/adr-0002-use-replay-expiration-millis-0-in-while-subscribed.md
@@ -78,3 +78,25 @@ This design guarantees that the subscription request is sent exactly once, safel
 * **Negative/Risks:**
   * If a subscriber disconnects and immediately reconnects within less than a millisecond, they might not get the replay cache, but since they want a fresh reconnection anyway when the stream is closed, this is the desirable behavior.
 
+---
+
+## Amendment (May 19, 2026)
+
+### Status: Superseded
+
+The design described in this ADR has been **superseded** by the architecture documented in
+[ADR 0004](adr-0004-coordinate-multiplexed-subscriptions-using-conflatedsignal-and-replay-0.md).
+
+**Key changes since this decision:**
+- The internal `sharedFlow` was changed from `replay = 1` to `replay = 0` (disabling the replay
+cache completely).
+- `SubscriptionStateManager` and `Subscriber` were removed.
+- A new thread-safe utility `ConflatedSignal` was introduced to coordinate `subscribe` and
+`resume` requests.
+- The connection state is now managed via `SubscriptionState` (`Disconnected`,
+`DisconnectedWithPendingSubscription`, `Connected`).
+
+By switching to `replay = 0` and using `ConflatedSignal`, we completely eliminated the stale
+replay cache issues, rendering the complex `replayExpirationMillis = 0` cache clearance and the
+`SubscriptionStateManager` obsolete.
+

--- a/firebase-dataconnect/docs/adr-0003-sequence-number-filtering-for-stale-replayed-data.md
+++ b/firebase-dataconnect/docs/adr-0003-sequence-number-filtering-for-stale-replayed-data.md
@@ -3,7 +3,7 @@
 id: 0003
 title: Sequence Number Filtering for Stale Replayed Data
 date: Sun May 17 00:02:50 EDT 2026
-status: accepted
+status: obsolete
 deciders: [Jetski, dconeybe]
 tags: [network, grpc, coroutines, flow, multiplexing]
 -----------------------------------------------------
@@ -83,4 +83,28 @@ A potential client-side mitigation that builds upon the sequence number approach
   * Clear documentation of the protocol's limitations.
 * **Negative/Risks:**
   * A late subscriber that starts collecting *exactly* in the small window between another subscriber's request and its response will still receive that in-flight response. This is mitigated by the fact that the data is still technically the "latest" data, but in unit tests asserting strict deterministic sequence of distinct datasets, this causes test failures.
+
+---
+
+## Amendment (May 19, 2026)
+
+### Status: Obsolete (Implementation Retired)
+
+This ADR is now **obsolete** and has been retired. The sequence number filtering mechanism was
+completely **removed** from `DataConnectBidiConnectStream.kt` as an implementation detail.
+
+**Why it was removed:**
+We refactored the stream sharing policy from `replay = 1` to `replay = 0` (as documented in
+[ADR 0004](adr-0004-coordinate-multiplexed-subscriptions-using-conflatedsignal-and-replay-0.md)).
+Because the replay cache was eliminated entirely, the "stale replayed data" issue (which sequence
+numbers originally filtered) no longer exists.
+
+**Outstanding Race Condition:**
+It is **IMPORTANT** to note that the **"in-flight request" race condition** described in this ADR
+has **NOT** been resolved by these changes. Because sequence numbers were removed and no
+alternative correlation mechanism was introduced, concurrently starting subscribers sharing the
+same query can still consume in-flight responses intended for other subscribers.
+
+This remains a known, outstanding limitation that will likely require server-side protocol
+cooperation (e.g., transaction/correlation IDs echoed in `StreamResponse`) to fully resolve.
 

--- a/firebase-dataconnect/docs/adr-0004-coordinate-multiplexed-subscriptions-using-conflatedsignal-and-replay-0.md
+++ b/firebase-dataconnect/docs/adr-0004-coordinate-multiplexed-subscriptions-using-conflatedsignal-and-replay-0.md
@@ -1,0 +1,106 @@
+---
+
+id: 0004
+title: Coordinate Multiplexed Subscriptions using ConflatedSignal and Replay=0
+date: Tue May 19 15:58:34 EDT 2026
+status: accepted
+deciders: [Jetski, dconeybe]
+tags: [network, grpc, coroutines, flow, multiplexing]
+supersedes: [0002, 0003]
+------------------------
+
+# Coordinate Multiplexed Subscriptions using ConflatedSignal and Replay=0
+
+## Context
+
+In previous designs (documented in ADR 0002 and ADR 0003), we shared the multiplexed bidirectional
+gRPC connection flow using `replay = 1` to allow late subscribers to join an active connection.
+This introduced a critical issue where new subscribers immediately received stale connection
+lifecycle and data events from the replay cache.
+
+We attempted to solve this by setting `replayExpirationMillis = 0` to clear the cache when
+subscribers dropped to zero (ADR 0002), and by introducing a client-side sequence number filter
+to discard stale replayed data when new subscribers joined while the stream was already active
+(ADR 0003).
+
+However, there was a severe, latent **in-flight request race condition** (documented in ADR 0003)
+that the sequence number approach could not address: if a new subscriber joined exactly between
+another subscriber's `subscribe` request and its corresponding response from the server, the new
+subscriber would incorrectly consume that in-flight response, as its sequence number was valid.
+
+Additionally, the state management implemented by `SubscriptionStateManager` and
+`SubscriptionStateManager.Subscriber` was highly complex, fragile, and difficult to serialize
+safely under concurrent access.
+
+## Decision
+
+We will:
+1.  **Disable Replay Cache**: Share the connection flow in `DataConnectBidiConnectStream.kt` with
+`replay = 0`, completely eliminating the replay cache.
+2.  **Remove Sequence Numbers**: Completely remove the sequence number tracking and filtering
+from the codebase since there is no longer a replay cache to filter.
+3.  **Retire SubscriptionStateManager**: Completely delete the `SubscriptionStateManager` and its
+nested `Subscriber` class.
+4.  **Introduce `ConflatedSignal`**: Introduce a new internal coroutine utility, `ConflatedSignal`,
+to coordinate subscription events.
+5.  **Implement `SubscriptionState` Machine**: Manage connection states via a robust, lock-free
+`AtomicReference<SubscriptionState>` state machine with three states:
+*   `Disconnected`: No active connection and no pending subscriptions.
+*   `DisconnectedWithPendingSubscription`: Disconnected, but has a subscription that needs to
+be sent once reconnected.
+*   `Connected`: Active stream connection, holding reference to the outgoing channel, a
+`ConflatedSignal` for request coordination, and a lazy `subscribeOrResumeLoop` coroutine job.
+
+## Rationale
+
+* **Eliminating Stale Data by Design**: By setting `replay = 0`, we resolve all stale-cache
+  bugs fundamentally. Late subscribers can no longer receive stale events because the stream
+  maintains no replay history.
+* **Simplified Architecture**: Removing `SubscriptionStateManager` and sequence number
+  filtering drastically reduces code complexity, making the codebase much easier to maintain
+  and debug.
+* **Race-Resistant Coordination**: Instead of relying on the flow's replay cache to distribute
+  the `outgoingRequests` channel to subscribers (so they can send their own requests), we
+  inverted the responsibility:
+  * Subscribers simply signal the connection's `ConflatedSignal` that they want to subscribe
+    or resume.
+  * The `Connected` state runs a dedicated, serialized `subscribeOrResumeLoop` that collects
+    these signals and safely sends the appropriate `subscribe` or `resume` requests over the
+    channel.
+  * This ensures that all request transmissions are naturally coordinated.
+* **Resilient Reconnection**: The `SubscriptionState` explicitly tracks if a subscription was
+  pending when a disconnect occurred (`DisconnectedWithPendingSubscription`). Upon reconnection,
+  it immediately triggers `subscribeOrResumeSignal.signal()`, seamlessly resuming the
+  subscription.
+
+## Options Considered
+
+* **Option A: Maintain `replay = 1` and implement complex request-response correlation**
+  * *Pros:* Keeps the existing flow distribution structure.
+  * *Cons:* Requires server-side protocol changes to echo back correlation tokens in
+    `StreamResponse` to solve the in-flight race condition. This is highly impractical for
+    a pure client-side SDK update.
+  * *Reason for Rejection:* It is not feasible to require server-side protocol changes, and
+    any client-side attempt to serialize requests without changing `replay = 1` was
+    excessively complex.
+* **Option B: Rebuild connection flow on every subscription**
+  * *Pros:* Simple 1-to-1 connection-to-subscriber mapping.
+  * *Cons:* Bypasses multiplexing entirely. We would open multiple costly gRPC connections
+    for identical queries, wasting client and server resources.
+  * *Reason for Rejection:* Multiplexing queries over a single connection is a core
+    performance requirement of the Data Connect SDK.
+
+## Consequences
+
+* **Positive:**
+  * Complete elimination of stale replay cache bugs.
+  * Significant code reduction (deleted `SubscriptionStateManager` and sequence filtering).
+  * Native, elegant support for automatic reconnection and subscription resumption.
+* **Negative/Risks / Known Limitations:**
+  * Requires maintaining a new concurrency utility (`ConflatedSignal`), though this class is
+    lightweight, heavily unit-tested, and stable.
+  * The **"in-flight request" race condition** (where a late subscriber can consume a response
+    intended for a different subscriber) remains unresolved. Because we removed sequence
+    numbers and have no alternative correlation mechanism, this remains a known limitation
+    that will likely require server cooperation (e.g., correlation tokens) to fully fix.
+

--- a/firebase-dataconnect/docs/adr-0004-coordinate-multiplexed-subscriptions-using-conflatedsignal-and-replay-0.md
+++ b/firebase-dataconnect/docs/adr-0004-coordinate-multiplexed-subscriptions-using-conflatedsignal-and-replay-0.md
@@ -13,92 +13,118 @@ supersedes: [0002, 0003]
 
 ## Context
 
-In previous designs (documented in ADR 0002 and ADR 0003), we shared the multiplexed bidirectional
-gRPC connection flow using `replay = 1` to allow late subscribers to join an active connection.
-This introduced a critical issue where new subscribers immediately received stale connection
-lifecycle and data events from the replay cache.
+The Data Connect SDK manages a multiplexed bidirectional gRPC connection to support realtime query
+subscriptions. Historically, query multiplexing was achieved using a single, connection-level
+shared flow (the **"upper" shared flow**), while the tracking of active query subscribers, their
+individual states, and the orchestration of `subscribe`, `resume`, and `cancel` requests was
+managed manually by a complex utility called `SubscriptionStateManager`.
 
-We attempted to solve this by setting `replayExpirationMillis = 0` to clear the cache when
-subscribers dropped to zero (ADR 0002), and by introducing a client-side sequence number filter
-to discard stale replayed data when new subscribers joined while the stream was already active
-(ADR 0003).
+To support late subscribers joining active queries, the connection flow used `replay = 1`. This,
+however, introduced a critical issue where new subscribers immediately received stale events from
+the replay cache. We attempted to mitigate this with `replayExpirationMillis = 0` (ADR 0002) and
+client-side sequence number filtering (ADR 0003).
 
-However, there was a severe, latent **in-flight request race condition** (documented in ADR 0003)
-that the sequence number approach could not address: if a new subscriber joined exactly between
-another subscriber's `subscribe` request and its corresponding response from the server, the new
-subscriber would incorrectly consume that in-flight response, as its sequence number was valid.
-
-Additionally, the state management implemented by `SubscriptionStateManager` and
-`SubscriptionStateManager.Subscriber` was highly complex, fragile, and difficult to serialize
-safely under concurrent access.
+Despite these workarounds, the architecture remained fragile. It suffered from a latent
+**in-flight request race condition** (documented in ADR 0003) where a late subscriber could consume
+an in-flight response intended for a different subscriber, because sequence numbers could not
+physically differentiate responses. Furthermore, `SubscriptionStateManager` was highly complex,
+hard to maintain, and had extremely subtle, error-prone multithreading requirements.
 
 ## Decision
 
-We will:
-1.  **Disable Replay Cache**: Share the connection flow in `DataConnectBidiConnectStream.kt` with
-`replay = 0`, completely eliminating the replay cache.
-2.  **Remove Sequence Numbers**: Completely remove the sequence number tracking and filtering
-from the codebase since there is no longer a replay cache to filter.
-3.  **Retire SubscriptionStateManager**: Completely delete the `SubscriptionStateManager` and its
-nested `Subscriber` class.
-4.  **Introduce `ConflatedSignal`**: Introduce a new internal coroutine utility, `ConflatedSignal`,
-to coordinate subscription events.
-5.  **Implement `SubscriptionState` Machine**: Manage connection states via a robust, lock-free
-`AtomicReference<SubscriptionState>` state machine with three states:
+We will completely redesign the multiplexing and connection lifecycle architecture to utilize **two
+levels of `SharedFlow`** coordinated by a lock-free connection state machine and a new
+`ConflatedSignal` utility.
+
+Specifically, we will:
+1.  **Establish Two Levels of SharedFlow**:
+*   **Upper Shared Flow (`connectionFlow`)**: Maintains the active bidirectional gRPC connection
+with the server. Shared using `replay = 0` and `SharingStarted.WhileSubscribed(0)`.
+*   **Lower Shared Flows**: Spawned per unique query (cached in `RealtimeQueryManager`'s
+`flowByQueryId`). Each lower flow is shared using `replay = 0` and `WhileSubscribed(0)`.
+It multiplexes all active local subscribers for queries sharing the exact same operation
+name and variables.
+2.  **Retire `SubscriptionStateManager` and Sequence Numbers**: Completely delete the fragile,
+manual subscriber-tracking class and remove all sequence number filtering logic.
+3.  **Coordinate via `ConflatedSignal`**: Introduce a thread-safe, lock-free coroutine utility
+`ConflatedSignal` to coordinate `subscribe` and `resume` requests.
+4.  **Implement `SubscriptionState` Machine**: Manage query-specific connection states via an
+`AtomicReference<SubscriptionState>` transitioning through:
 *   `Disconnected`: No active connection and no pending subscriptions.
-*   `DisconnectedWithPendingSubscription`: Disconnected, but has a subscription that needs to
-be sent once reconnected.
-*   `Connected`: Active stream connection, holding reference to the outgoing channel, a
-`ConflatedSignal` for request coordination, and a lazy `subscribeOrResumeLoop` coroutine job.
+*   `DisconnectedWithPendingSubscription`: Disconnected, but has an active subscriber waiting
+for reconnection.
+*   `Connected`: Connected, holding the channel, a `ConflatedSignal`, and running a lazy
+`subscribeOrResumeLoop` coroutine.
 
 ## Rationale
 
-* **Eliminating Stale Data by Design**: By setting `replay = 0`, we resolve all stale-cache
-  bugs fundamentally. Late subscribers can no longer receive stale events because the stream
-  maintains no replay history.
-* **Simplified Architecture**: Removing `SubscriptionStateManager` and sequence number
-  filtering drastically reduces code complexity, making the codebase much easier to maintain
-  and debug.
-* **Race-Resistant Coordination**: Instead of relying on the flow's replay cache to distribute
-  the `outgoingRequests` channel to subscribers (so they can send their own requests), we
-  inverted the responsibility:
-  * Subscribers simply signal the connection's `ConflatedSignal` that they want to subscribe
-    or resume.
-  * The `Connected` state runs a dedicated, serialized `subscribeOrResumeLoop` that collects
-    these signals and safely sends the appropriate `subscribe` or `resume` requests over the
-    channel.
-  * This ensures that all request transmissions are naturally coordinated.
-* **Resilient Reconnection**: The `SubscriptionState` explicitly tracks if a subscription was
-  pending when a disconnect occurred (`DisconnectedWithPendingSubscription`). Upon reconnection,
-  it immediately triggers `subscribeOrResumeSignal.signal()`, seamlessly resuming the
-  subscription.
+The entire two-level `SharedFlow` design was motivated by the desire to leverage **standard,
+declarative coroutines library operators** that perfectly express our desired semantics, rather
+than building and maintaining complex custom synchronization logic.
+
+### Leveraging Built-In Coroutine Operators
+
+* **`WhileSubscribed(replayExpirationMillis = 0)`**: By using this policy at both the upper and
+  lower flow levels, we let the coroutines library handle the subscription reference-counting
+  natively. The connection automatically opens when the first query is subscribed to, and closes
+  when the last subscriber leaves. Similarly, the query-level resources automatically clean up
+  when a query has zero active collectors.
+* **`retryWhen`**: Relying on standard flow sharing allows us to use `retryWhen` on the upper flow.
+  This provides a clean, robust, and standardized hook to implement upcoming reliability
+  features, such as exponential backoff and instant reconnection on system network state change
+  events.
+
+### Bypassing Stale Cache and Race Conditions by Design (`replay = 0`)
+
+By setting `replay = 0` at both levels, we eliminate the replay cache entirely. New query
+subscribers no longer receive stale replayed messages. Because they wait for fresh emissions
+originating from the newly coordinated `subscribe` or `resume` requests, the latent "in-flight"
+race condition is naturally avoided for subsequent subscribers.
+
+### Rationale for `resume` on Late Subscribers
+
+When a new subscriber joins an already active query flow, the lower flow's `onSubscription` block
+triggers and signals the connection's `ConflatedSignal`. Because we are already subscribed to the
+query, the `subscribeOrResumeLoop` sends a `resume` request to the server.
+
+This `resume` request kicks the server to immediately re-run the query and send an updated result
+down the stream. This is highly valuable because:
+1.  **Data Freshness**: Some queries are not "fully" real-time and may not emit updates frequently. A
+`resume` ensures the late subscriber does not receive stale data that has been residing on the
+client.
+2.  **User Intent Proxy**: A new local subscriber (e.g., a user navigating to a new screen) is a
+strong proxy for user intent indicating they want the absolute latest results.
 
 ## Options Considered
 
-* **Option A: Maintain `replay = 1` and implement complex request-response correlation**
-  * *Pros:* Keeps the existing flow distribution structure.
-  * *Cons:* Requires server-side protocol changes to echo back correlation tokens in
-    `StreamResponse` to solve the in-flight race condition. This is highly impractical for
-    a pure client-side SDK update.
-  * *Reason for Rejection:* It is not feasible to require server-side protocol changes, and
-    any client-side attempt to serialize requests without changing `replay = 1` was
-    excessively complex.
-* **Option B: Rebuild connection flow on every subscription**
+* **Option A: The Old Code (Single Shared Flow + Manual `SubscriptionStateManager`)**
+  * *Pros:* Avoids the minor overhead of creating multiple `SharedFlow` and `Job` instances
+    per query.
+  * *Cons:* Extremely complex, fragile, and required custom multithreading locks. The team was
+    effectively rebuilding `WhileSubscribed` logic manually, which is highly error-prone.
+  * *Reason for Rejection:* The manual state tracking was too fragile. The benefits of delegating
+    concurrency and lifecycle to standard, battle-tested library operators far outweighed the
+    minimal overhead of secondary flows.
+* **Option B: Rebuilding Connection Flow on every subscription**
   * *Pros:* Simple 1-to-1 connection-to-subscriber mapping.
-  * *Cons:* Bypasses multiplexing entirely. We would open multiple costly gRPC connections
-    for identical queries, wasting client and server resources.
-  * *Reason for Rejection:* Multiplexing queries over a single connection is a core
-    performance requirement of the Data Connect SDK.
+  * *Cons:* Severely wastes server and client resources by opening multiple distinct gRPC
+    connections for identical or overlapping queries.
+  * *Reason for Rejection:* Multiplexing over a single connection is a hard performance
+    requirement of the SDK.
 
 ## Consequences
 
 * **Positive:**
-  * Complete elimination of stale replay cache bugs.
-  * Significant code reduction (deleted `SubscriptionStateManager` and sequence filtering).
-  * Native, elegant support for automatic reconnection and subscription resumption.
-* **Negative/Risks / Known Limitations:**
-  * Requires maintaining a new concurrency utility (`ConflatedSignal`), though this class is
-    lightweight, heavily unit-tested, and stable.
+  * Massive complexity reduction by replacing fragile custom state with standard operators
+    (`WhileSubscribed` and `retryWhen`).
+  * Complete eradication of stale replay cache bugs.
+  * Seamless, native support for automatic reconnection and subscription resumption.
+  * Clean foundation for implementing robust exponential backoff in the future.
+* **Negative/Risks / Tradeoffs:**
+  * Requires developers to have a highly sophisticated and intricate understanding of
+    `SharedFlow` internals (such as subscription counters, start policies, and cache expiration).
+    However, this is a necessary tradeoff, as implementing these concurrency semantics manually
+    would require the same deep knowledge and result in far more fragile code.
   * The **"in-flight request" race condition** (where a late subscriber can consume a response
     intended for a different subscriber) remains unresolved. Because we removed sequence
     numbers and have no alternative correlation mechanism, this remains a known limitation

--- a/firebase-dataconnect/docs/adr-0005-configure-flow-control-and-conflation-for-realtime-queries.md
+++ b/firebase-dataconnect/docs/adr-0005-configure-flow-control-and-conflation-for-realtime-queries.md
@@ -1,0 +1,71 @@
+---
+
+id: 0005
+title: Configure Flow Control and Conflation for Realtime Queries
+date: Tue May 19 17:28:33 EDT 2026
+status: accepted
+deciders: [Jetski, dconeybe]
+tags: [network, grpc, coroutines, flow, backpressure, performance]
+------------------------------------------------------------------
+
+# Configure Flow Control and Conflation for Realtime Queries
+
+## Context
+
+We recently refactored query subscriptions to use a two-level `SharedFlow` architecture (ADR 0004) to
+support declarative, self-healing connections. Initially, both the **upper connection flow**
+(`connectionFlow` in `DataConnectBidiConnectStream.kt`) and the **lower query flows** (returned by
+`subscribe()`) were configured with `.buffer(capacity = Channel.UNLIMITED)`.
+
+Using `Channel.UNLIMITED` buffers introduces three severe architectural and stability risks:
+1.  **Out-of-Memory (OOM) Risks**: If the backend emits updates faster than the client coroutines
+can process them, the unlimited buffer will queue messages indefinitely in memory. Under sustained
+high-load conditions, this leads to severe memory inflation and eventual application crashes.
+2.  **No Backpressure Coordination**: Standard gRPC and HTTP/2 protocols rely on finite receive buffers
+to coordinate backpressure. With `Channel.UNLIMITED`, the client never stops reading from the
+socket, meaning the server is never signaled to slow down. This wastes server resources and client
+network bandwidth.
+3.  **UI Rendering Backlog (Staleness)**: Query subscriptions represent declarative, state-based data
+(e.g. the latest document state) rather than discrete event logs. If a subscriber (such as a UI
+component) is slow to process updates due to main-thread rendering overhead, an unlimited buffer
+will queue historic intermediate states. When the UI catches up, it wastefully processes and renders
+a long backlog of stale intermediate states sequentially, causing visible UI lag and wasted CPU
+cycles.
+
+## Decision
+
+We will establish distinct, appropriate buffer configurations for each level of the flow:
+1.  **Upper Connection Flow**: Limit the `connectionFlow` buffer to a finite capacity using
+`.buffer(capacity = RECEIVE_BUFFER_SIZE)` (configured as `64`).
+2.  **Lower Query Flows**: Configure the query-specific subscription flows to use conflation via
+`.buffer(capacity = Channel.CONFLATED)`.
+
+## Rationale
+
+By applying different buffering strategies to each level, we achieve both optimal system stability
+and maximum user-visible performance.
+
+### Activating Backpressure on the Connection Flow (`RECEIVE_BUFFER_SIZE = 64`)
+
+By changing the connection-level buffer from `UNLIMITED` to `64`, we activate native gRPC and HTTP/2
+flow control.
+*   If the client falls behind in processing, the connection-level buffer will fill up.
+*   Once filled, the gRPC client halts reading from the transport layer.
+*   This causes the TCP/HTTP/2 receive windows to shrink, sending a backpressure signal back to the
+server, forcing it to slow down or buffer updates.
+*   A buffer size of `64` is chosen as it is large enough to absorb transient bursts of concurrent
+updates across multiplexed queries, while small enough to trigger backpressure quickly if the
+client is genuinely stuck, preventing OOMs.
+
+### Guaranteeing Data Freshness on Individual Queries (`Channel.CONFLATED`)
+
+For query subscriptions, the user only cares about the *latest* state. Intermediate states are
+transient and obsolete as soon as a newer update arrives.
+*   By using `Channel.CONFLATED` (which has a capacity of 1 and overwrites on new emissions), we
+guarantee that a subscriber will never process a backlog of historic, stale updates.
+*   If a subscriber is busy when an update arrives, older pending updates in its queue are immediately
+dropped.
+*   When the subscriber finishes its current work and suspends, it instantly receives the newest update.
+This saves valuable CPU cycles, prevents main-thread rendering lag, and ensures the UI is always
+up-to-date.
+

--- a/firebase-dataconnect/scripts/test_execute.zsh
+++ b/firebase-dataconnect/scripts/test_execute.zsh
@@ -130,6 +130,7 @@ find_package_line() {
 
   local -r file_path="$1"
   local line
+  local IFS
 
   # Explicitly clear IFS for 'read' to preserve exact line contents
   while IFS= read -r line; do

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -410,11 +410,7 @@ internal class DataConnectBidiConnectStream(
       while (true) {
         when (val currentState = state.get()) {
           SubscriptionState.Disconnected,
-          SubscriptionState.DisconnectedWithPendingSubscription ->
-            error(
-              "internal error vv4verqchm: got Disconnected event, " +
-                "but state=$currentState (expected state=Connected)"
-            )
+          SubscriptionState.DisconnectedWithPendingSubscription -> break
           is SubscriptionState.Connected -> {
             currentState.cancelSubscribeOrResumeJob("got Disconnected event")
             val newState =

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -17,6 +17,7 @@
 package com.google.firebase.dataconnect.core
 
 import com.google.firebase.dataconnect.ExperimentalRealtimeQueries
+import com.google.firebase.dataconnect.util.CoroutineUtils.completedFlow
 import com.google.firebase.dataconnect.util.GrpcBidiFlow
 import com.google.firebase.dataconnect.util.ProtoUtil.toCompactString
 import com.google.firebase.dataconnect.util.SequencedReference.Companion.nextSequenceNumber
@@ -28,24 +29,25 @@ import google.firebase.dataconnect.proto.GraphqlResponseExtensions.DataConnectPr
 import google.firebase.dataconnect.proto.ResumeRequest
 import google.firebase.dataconnect.proto.StreamRequest as StreamRequestProto
 import google.firebase.dataconnect.proto.StreamResponse as StreamResponseProto
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
-import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.buffer
-import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onSubscription
+import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.transformWhile
 import kotlinx.coroutines.sync.Mutex
@@ -69,48 +71,43 @@ internal class DataConnectBidiConnectStream(
   private val coroutineScope: CoroutineScope,
 ) {
 
-  private val scopeCompletedFlow: Flow<Event.Completed> = callbackFlow {
-    val job =
-      coroutineScope.coroutineContext[Job]
-        ?: run {
-          close()
-          return@callbackFlow
+  private val sharedFlow: SharedFlow<SubscriptionEvent>
+
+  init {
+    val scopeCompletedFlow: Flow<SubscriptionEvent.ScopeCompleted> =
+      coroutineScope.completedFlow().map { SubscriptionEvent.ScopeCompleted }
+
+    val connectionState =
+      MutableStateFlow<SubscriptionEvent.Connection>(SubscriptionEvent.Disconnected)
+
+    val messageFlow: Flow<SubscriptionEvent.Message> =
+      flow
+        .onEach { event ->
+          if (event is GrpcBidiFlow.Event.ConnectionInfo) {
+            connectionState.value = SubscriptionEvent.Connected(event)
+          }
+        }
+        .filterIsInstance<GrpcBidiFlow.Event.Message<StreamResponseProto>>()
+        .map(SubscriptionEvent::Message)
+        .onCompletion { connectionState.value = SubscriptionEvent.Disconnected }
+        .retryWhen { _, attempt ->
+          if (attempt < 2) {
+            false
+          } else {
+            delay(1.seconds)
+            true
+          }
         }
 
-    val disposableHandle =
-      job.invokeOnCompletion { throwable ->
-        trySend(Event.Completed(throwable))
-        close()
-      }
-
-    awaitClose { disposableHandle.dispose() }
+    sharedFlow =
+      merge(scopeCompletedFlow, connectionState, messageFlow)
+        .buffer(capacity = Channel.UNLIMITED)
+        .shareIn(
+          coroutineScope,
+          started = SharingStarted.WhileSubscribed(replayExpirationMillis = 0),
+          replay = 0,
+        )
   }
-
-  private val sharedFlow: SharedFlow<Event> =
-    flow
-      .map { event ->
-        when (event) {
-          is GrpcBidiFlow.Event.ConnectionInfo -> Event.Ready(event.outgoingRequests)
-          is GrpcBidiFlow.Event.Message ->
-            Event.Message(
-              nextSequenceNumber(),
-              event.message,
-              event.connectionInfo.outgoingRequests
-            )
-        }
-      }
-      .onCompletion { throwable ->
-        if (throwable === null) {
-          emit(Event.Completed(null))
-        }
-      }
-      .catch { emit(Event.Completed(throwable = it)) }
-      .buffer(capacity = Channel.UNLIMITED)
-      .shareIn(
-        coroutineScope,
-        started = SharingStarted.WhileSubscribed(replayExpirationMillis = 0),
-        replay = 1
-      )
 
   /**
    * Starts a subscription for the query with the given [operationName] and [variables].
@@ -193,57 +190,35 @@ internal class DataConnectBidiConnectStream(
     operator fun component3() = extensions
   }
 
-  /**
-   * Represents an internal wrapper around incoming server responses and lifecycle signals.
-   *
-   * This sealed interface allows the internal [SharedFlow] to multiplex actual response data
-   * alongside control signals like completion, subscriber readiness, and buffer flushes.
-   */
-  private sealed interface Event {
+  private sealed interface SubscriptionEvent {
 
-    /**
-     * The event emitted once per collection, that provides the channel to use to send requests over
-     * the bidirectional stream.
-     */
-    class Ready(val outgoingRequests: SendChannel<StreamRequestProto>) : Event {
-      override fun toString() = "Ready"
+    class Message(val connectionId: String, val message: StreamResponseProto) : SubscriptionEvent {
+      constructor(
+        event: GrpcBidiFlow.Event.Message<StreamResponseProto>
+      ) : this(event.connectionId, event.message)
+      override fun toString() =
+        "Message(connectionId=$connectionId, message=${message.toCompactString()})"
     }
 
-    /** Represents a standard data response from the server. */
-    class Message(
-      val sequenceNumber: Long,
-      val streamResponse: StreamResponseProto,
+    object ScopeCompleted : SubscriptionEvent {
+      override fun toString() = "ScopeCompleted"
+    }
+
+    sealed interface Connection : SubscriptionEvent
+
+    class Connected(
+      val connectionId: String,
       val outgoingRequests: SendChannel<StreamRequestProto>,
-    ) : Event {
-      override fun toString() = "Message(${streamResponse.toCompactString()})"
+    ) : Connection {
+      constructor(
+        event: GrpcBidiFlow.Event.ConnectionInfo<StreamRequestProto>
+      ) : this(event.connectionId, event.outgoingRequests)
+
+      override fun toString() = "Connected(connectionId=$connectionId)"
     }
 
-    /**
-     * Represents the termination of the incoming stream, either naturally or due to an error.
-     *
-     * By placing this in the [SharedFlow], new or existing subscribers can be notified immediately
-     * if the underlying stream is disconnected.
-     *
-     * @property throwable The exception that caused termination, or null if the stream completed
-     * normally.
-     */
-    class Completed(val throwable: Throwable?) : Event {
-      override fun toString() = "Completed(throwable=$throwable)"
-    }
-
-    /**
-     * A control signal used to synchronize the start of outgoing requests with the readiness of the
-     * collector.
-     *
-     * Emitted locally inside the [subscribe] method's `onSubscription` block. This guarantees that
-     * the collector in `transformWhile` is fully registered and actively listening to the
-     * [SharedFlow] *before* the [StreamRequestProto] is actually sent to the server. Without this
-     * signal, there is a race condition where the server might respond to the request so fast that
-     * the resulting [Message] is processed by the [SharedFlow] before the `subscribe` collector has
-     * started listening, leading to silently lost responses.
-     */
-    object Subscribed : Event {
-      override fun toString() = "Subscribed"
+    object Disconnected : Connection {
+      override fun toString() = "Disconnected"
     }
   }
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -20,7 +20,17 @@ import com.google.firebase.dataconnect.ExperimentalRealtimeQueries
 import com.google.firebase.dataconnect.util.CoroutineUtils.completedFlow
 import com.google.firebase.dataconnect.util.GrpcBidiFlow
 import com.google.firebase.dataconnect.util.ProtoUtil.toCompactString
+import com.google.firebase.dataconnect.util.update
+import com.google.protobuf.Empty as EmptyProto
 import com.google.protobuf.Struct
+import google.firebase.dataconnect.proto.ExecuteRequest as ExecuteRequestProto
+import google.firebase.dataconnect.proto.GraphqlError as GraphqlErrorProto
+import google.firebase.dataconnect.proto.GraphqlResponseExtensions.DataConnectProperties as DataConnectPropertiesProto
+import google.firebase.dataconnect.proto.ResumeRequest as ResumeRequestProto
+import google.firebase.dataconnect.proto.StreamRequest as StreamRequestProto
+import google.firebase.dataconnect.proto.StreamResponse as StreamResponseProto
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
@@ -49,15 +59,6 @@ import kotlinx.coroutines.flow.transformWhile
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.util.concurrent.atomic.AtomicReference
-import kotlin.time.Duration.Companion.seconds
-import com.google.protobuf.Empty as EmptyProto
-import google.firebase.dataconnect.proto.ExecuteRequest as ExecuteRequestProto
-import google.firebase.dataconnect.proto.GraphqlError as GraphqlErrorProto
-import google.firebase.dataconnect.proto.GraphqlResponseExtensions.DataConnectProperties as DataConnectPropertiesProto
-import google.firebase.dataconnect.proto.ResumeRequest as ResumeRequestProto
-import google.firebase.dataconnect.proto.StreamRequest as StreamRequestProto
-import google.firebase.dataconnect.proto.StreamResponse as StreamResponseProto
 
 /**
  * Manages a bidirectional gRPC stream for Data Connect operations.
@@ -128,66 +129,82 @@ internal class DataConnectBidiConnectStream(
     operationName: String,
     variables: Struct,
   ): Flow<ExecuteResponse> {
-    val state =
-      AtomicReference<SubscriptionState>(
-        SubscriptionState.Disconnected(pendingSubscription = false)
-      )
+    val state = AtomicReference<SubscriptionState>(SubscriptionState.Disconnected)
 
-    val x =
-      sharedFlow
-        .transformToMessage(requestId, operationName, variables, state)
-        .map<_, MessageOrSubscribe> { MessageOrSubscribe.Message(it) }
-        .buffer(capacity = Channel.UNLIMITED)
-        .shareIn(
-          coroutineScope,
-          started = SharingStarted.WhileSubscribed(replayExpirationMillis = 0),
-          replay = 0,
-        )
-        .onSubscription { emit(MessageOrSubscribe.Subscribed) }
-        .transform { messageOrSubscribe ->
-          when (messageOrSubscribe) {
-            is MessageOrSubscribe.Message -> emit(messageOrSubscribe.message)
-            MessageOrSubscribe.Subscribed -> {
-              while (true) {
-                when (val currentState = state.get()) {
-                  is SubscriptionState.Disconnected ->
-                    if (currentState.pendingSubscription) {
-                      break
-                    } else if (state.compareAndSet(currentState, SubscriptionState.Disconnected(pendingSubscription = true))) {
-                      break
-                    }
-                  is SubscriptionState.Connected -> {
-                    currentState.enqueueSubscribeOrResume()
-                  }
-                }
-              }
+    fun sendSubscribeOrResume() {
+      while (true) {
+        when (val currentState = state.get()) {
+          is SubscriptionState.Connected -> {
+            currentState.enqueueSubscribeOrResume()
+          }
+          SubscriptionState.DisconnectedWithPendingSubscription -> break
+          SubscriptionState.Disconnected ->
+            if (
+              state.compareAndSet(
+                currentState,
+                SubscriptionState.DisconnectedWithPendingSubscription
+              )
+            ) {
+              break
+            }
+        }
+      }
+    }
+
+    return sharedFlow
+      .onCompletion {
+        state.update { currentState ->
+          if (currentState is SubscriptionState.Connected) {
+            currentState.cancelSubscribeOrResumeJob("all subscribers have unsubscribed")
+          }
+          SubscriptionState.Disconnected
+        }
+      }
+      .transformToMessage(requestId, operationName, variables, state)
+      .map<_, MessageOrSubscribe> { MessageOrSubscribe.Message(it) }
+      .buffer(capacity = Channel.UNLIMITED)
+      .shareIn(
+        coroutineScope,
+        started = SharingStarted.WhileSubscribed(replayExpirationMillis = 0),
+        replay = 0,
+      )
+      .onSubscription { emit(MessageOrSubscribe.Subscribed) }
+      .transform { messageOrSubscribe ->
+        when (messageOrSubscribe) {
+          MessageOrSubscribe.Subscribed -> sendSubscribeOrResume()
+          is MessageOrSubscribe.Message -> {
+            val executeResponse = messageOrSubscribe.message.toExecuteResponse()
+            if (executeResponse !== null) {
+              emit(executeResponse)
             }
           }
         }
-
-    TODO()
+      }
   }
 
   private sealed interface MessageOrSubscribe {
+
+    object Subscribed : MessageOrSubscribe
 
     class Message(val message: StreamResponseProto) : MessageOrSubscribe {
       constructor(event: SubscriptionEvent.Message) : this(event.message)
       override fun toString() = "Message(message=${message.toCompactString()}"
     }
-
-    object Subscribed : MessageOrSubscribe
-
   }
 
-  private sealed interface SubscriptionState {
+  sealed interface SubscriptionState {
 
-    class Disconnected(val pendingSubscription: Boolean) : SubscriptionState {
-      override fun toString(): String = "Disconnected(pendingSubscription=$pendingSubscription)"
+    object Disconnected : SubscriptionState {
+      override fun toString() = "Disconnected"
+    }
+
+    object DisconnectedWithPendingSubscription : SubscriptionState {
+      override fun toString() = "DisconnectedWithPendingSubscription"
     }
 
     class Connected(
       val outgoingRequests: SendChannel<StreamRequestProto>,
-      val wasPendingSubscription: Boolean,
+      private val hadPendingSubscription: Boolean,
       private val enqueuedSubscribeOrResume: MutableStateFlow<Boolean>,
       private val subscribeOrResumeJob: Job,
     ) : SubscriptionState {
@@ -201,13 +218,18 @@ internal class DataConnectBidiConnectStream(
         subscribeOrResumeJob.cancel(message)
       }
 
+      fun wasSubscribeOrResumeJobStarted(): Boolean =
+        subscribeOrResumeJob.run {
+          hadPendingSubscription || isActive || isCompleted || isCancelled
+        }
+
       override fun toString(): String =
         "Connected(" +
-            "wasPendingSubscription=$wasPendingSubscription " +
-            "enqueuedSubscribeOrResume=${enqueuedSubscribeOrResume.value} " +
-            "subscribeOrResumeJob={isActive=${subscribeOrResumeJob.isActive}, " +
-            "isCancelled=${subscribeOrResumeJob.isCancelled}, " +
-            "isCompleted=${subscribeOrResumeJob.isCompleted}})"
+          "hadPendingSubscription=$hadPendingSubscription, " +
+          "enqueuedSubscribeOrResume=${enqueuedSubscribeOrResume.value} " +
+          "subscribeOrResumeJob={isActive=${subscribeOrResumeJob.isActive}, " +
+          "isCancelled=${subscribeOrResumeJob.isCancelled}, " +
+          "isCompleted=${subscribeOrResumeJob.isCompleted}})"
     }
   }
 
@@ -263,13 +285,12 @@ internal class DataConnectBidiConnectStream(
     }
   }
 
-  private fun SharedFlow<SubscriptionEvent>.transformToMessage(
+  private fun Flow<SubscriptionEvent>.transformToMessage(
     requestId: String,
     operationName: String,
     variables: Struct,
     state: AtomicReference<SubscriptionState>,
   ): Flow<SubscriptionEvent.Message> {
-
     val subscribeRequest =
       StreamRequestProto.newBuilder().let { streamRequest ->
         streamRequest.setRequestId(requestId)
@@ -297,36 +318,59 @@ internal class DataConnectBidiConnectStream(
         streamRequest.build()
       }
 
-    suspend fun SendChannel<StreamRequestProto>.subscribeOrResumeLoop(authUid: String?, enqueuedSubscribeOrResume: MutableStateFlow<Boolean>) {
-      fun sendRequest(request: StreamRequestProto) {
-        val sendResult = trySend(request)
-        sendResult.onFailure { exception ->
-          if (!sendResult.isClosed) {
-            throw exception
-              ?: error(
-                "internal error gt2ms5wwby: outgoingRequests.trySend() failed, " +
+    return transformToMessage(
+      state,
+      subscribeRequest = subscribeRequest,
+      resumeRequest = resumeRequest,
+      cancelRequest = cancelRequest,
+    )
+  }
+
+  private fun Flow<SubscriptionEvent>.transformToMessage(
+    state: AtomicReference<SubscriptionState>,
+    subscribeRequest: StreamRequestProto,
+    resumeRequest: StreamRequestProto,
+    cancelRequest: StreamRequestProto,
+  ): Flow<SubscriptionEvent.Message> {
+
+    fun SendChannel<StreamRequestProto>.trySendOrThrow(
+      authUid: String?,
+      request: StreamRequestProto
+    ) {
+      val sendResult = trySend(request)
+      sendResult.onFailure { exception ->
+        if (!sendResult.isClosed) {
+          throw exception
+            ?: error(
+              "internal error gt2ms5wwby: outgoingRequests.trySend() failed, " +
                 "but should have succeeded because outgoingRequests is created " +
-                    "with capacity=UNLIMITED (request=${request.toCompactString(authUid)})"
-              )
-          }
+                "with capacity=UNLIMITED (request=${request.toCompactString(authUid)})"
+            )
         }
       }
+    }
 
+    suspend fun SendChannel<StreamRequestProto>.subscribeOrResumeLoop(
+      authUid: String?,
+      enqueuedSubscribeOrResume: MutableStateFlow<Boolean>
+    ) {
       var subscribed = false
       try {
-        enqueuedSubscribeOrResume.filter { it }.collect {
-          enqueuedSubscribeOrResume.value = false
-          if (! subscribed) {
-            sendRequest(subscribeRequest)
-            subscribed = true
-          } else {
-            sendRequest(resumeRequest)
+        enqueuedSubscribeOrResume
+          .filter { it }
+          .collect {
+            enqueuedSubscribeOrResume.value = false
+            if (!subscribed) {
+              trySendOrThrow(authUid, subscribeRequest)
+              subscribed = true
+            } else {
+              trySendOrThrow(authUid, resumeRequest)
+            }
           }
-        }
       } finally {
         withContext(NonCancellable) {
           if (subscribed) {
-            sendRequest(cancelRequest)
+            trySendOrThrow(authUid, cancelRequest)
           }
         }
       }
@@ -334,29 +378,37 @@ internal class DataConnectBidiConnectStream(
 
     fun transitionToConnectedState(event: SubscriptionEvent.Connected) {
       while (true) {
-        when (val currentState = state.get()) {
-          is SubscriptionState.Connected ->
-            error(
-              "internal error nqe9gre3ny: got event $event, " +
-                "but state=$currentState (expected state=Disconnected)"
-            )
-          is SubscriptionState.Disconnected -> {
-            val enqueuedSubscribeOrResume = MutableStateFlow(currentState.pendingSubscription)
-            val newState =
-              SubscriptionState.Connected(
-                event.outgoingRequests,
-                wasPendingSubscription = currentState.pendingSubscription,
-                enqueuedSubscribeOrResume = enqueuedSubscribeOrResume,
-                subscribeOrResumeJob =
-                  coroutineScope.launch(start = CoroutineStart.LAZY) {
-                    event.outgoingRequests.subscribeOrResumeLoop(event.authUid, enqueuedSubscribeOrResume)
-                  }
+        val currentState = state.get()
+
+        val isPendingSubscription =
+          when (currentState) {
+            is SubscriptionState.Connected ->
+              error(
+                "internal error nqe9gre3ny: got event $event, " +
+                  "but state=$currentState (expected state=Disconnected)"
               )
-            if (state.compareAndSet(currentState, newState)) {
-              newState.enqueueSubscribeOrResume()
-              break
-            }
+            is SubscriptionState.Disconnected -> false
+            is SubscriptionState.DisconnectedWithPendingSubscription -> true
           }
+
+        val enqueuedSubscribeOrResume = MutableStateFlow(isPendingSubscription)
+        val subscribeOrResumeJob =
+          coroutineScope.launch(start = CoroutineStart.LAZY) {
+            event.outgoingRequests.subscribeOrResumeLoop(event.authUid, enqueuedSubscribeOrResume)
+          }
+
+        val newState =
+          SubscriptionState.Connected(
+            event.outgoingRequests,
+            enqueuedSubscribeOrResume = enqueuedSubscribeOrResume,
+            hadPendingSubscription = isPendingSubscription,
+            subscribeOrResumeJob = subscribeOrResumeJob,
+          )
+        if (state.compareAndSet(currentState, newState)) {
+          if (isPendingSubscription) {
+            subscribeOrResumeJob.start()
+          }
+          break
         }
       }
     }
@@ -364,7 +416,8 @@ internal class DataConnectBidiConnectStream(
     fun transitionToDisconnectedState(@Suppress("unused") event: SubscriptionEvent.Disconnected) {
       while (true) {
         when (val currentState = state.get()) {
-          is SubscriptionState.Disconnected ->
+          SubscriptionState.Disconnected,
+          SubscriptionState.DisconnectedWithPendingSubscription ->
             error(
               "internal error vv4verqchm: got Disconnected event, " +
                 "but state=$currentState (expected state=Connected)"
@@ -372,9 +425,11 @@ internal class DataConnectBidiConnectStream(
           is SubscriptionState.Connected -> {
             currentState.cancelSubscribeOrResumeJob("got Disconnected event")
             val newState =
-              SubscriptionState.Disconnected(
-                pendingSubscription = currentState.wasPendingSubscription
-              )
+              if (currentState.wasSubscribeOrResumeJobStarted()) {
+                SubscriptionState.DisconnectedWithPendingSubscription
+              } else {
+                SubscriptionState.Disconnected
+              }
             if (state.compareAndSet(currentState, newState)) {
               break
             }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -20,6 +20,7 @@ import com.google.firebase.dataconnect.ExperimentalRealtimeQueries
 import com.google.firebase.dataconnect.util.CoroutineUtils.completedFlow
 import com.google.firebase.dataconnect.util.GrpcBidiFlow
 import com.google.firebase.dataconnect.util.ProtoUtil.toCompactString
+import com.google.firebase.dataconnect.util.coroutines.ConflatedSignal
 import com.google.firebase.dataconnect.util.update
 import com.google.protobuf.Empty as EmptyProto
 import com.google.protobuf.Struct
@@ -35,7 +36,6 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
@@ -59,7 +59,6 @@ import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.flow.transformWhile
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 /**
  * Manages a bidirectional gRPC stream for Data Connect operations.
@@ -221,12 +220,12 @@ internal class DataConnectBidiConnectStream(
     class Connected(
       val outgoingRequests: SendChannel<StreamRequestProto>,
       private val hadPendingSubscription: Boolean,
-      private val enqueuedSubscribeOrResume: MutableStateFlow<Boolean>,
+      private val subscribeOrResumeSignal: ConflatedSignal,
       private val subscribeOrResumeJob: Job,
     ) : SubscriptionState {
 
       fun enqueueSubscribeOrResume() {
-        enqueuedSubscribeOrResume.value = true
+        subscribeOrResumeSignal.signal()
         subscribeOrResumeJob.start()
       }
 
@@ -242,7 +241,7 @@ internal class DataConnectBidiConnectStream(
       override fun toString(): String =
         "Connected(" +
           "hadPendingSubscription=$hadPendingSubscription, " +
-          "enqueuedSubscribeOrResume=${enqueuedSubscribeOrResume.value} " +
+          "subscribeOrResumeSignal.hasPendingSignal=${subscribeOrResumeSignal.hasPendingSignal}, " +
           "subscribeOrResumeJob={isActive=${subscribeOrResumeJob.isActive}, " +
           "isCancelled=${subscribeOrResumeJob.isCancelled}, " +
           "isCompleted=${subscribeOrResumeJob.isCompleted}})"
@@ -362,26 +361,21 @@ internal class DataConnectBidiConnectStream(
 
     suspend fun SendChannel<StreamRequestProto>.subscribeOrResumeLoop(
       authUid: String?,
-      enqueuedSubscribeOrResume: MutableStateFlow<Boolean>
+      subscribeOrResumeSignal: ConflatedSignal,
     ) {
       var subscribed = false
       try {
-        enqueuedSubscribeOrResume
-          .filter { it }
-          .collect {
-            enqueuedSubscribeOrResume.value = false
-            if (!subscribed) {
-              trySendOrThrow(authUid, subscribeRequest)
-              subscribed = true
-            } else {
-              trySendOrThrow(authUid, resumeRequest)
-            }
+        subscribeOrResumeSignal.signals.collect {
+          if (!subscribed) {
+            trySendOrThrow(authUid, subscribeRequest)
+            subscribed = true
+          } else {
+            trySendOrThrow(authUid, resumeRequest)
           }
+        }
       } finally {
-        withContext(NonCancellable) {
-          if (subscribed) {
-            trySendOrThrow(authUid, cancelRequest)
-          }
+        if (subscribed) {
+          trySendOrThrow(authUid, cancelRequest)
         }
       }
     }
@@ -401,17 +395,20 @@ internal class DataConnectBidiConnectStream(
             is SubscriptionState.DisconnectedWithPendingSubscription -> true
           }
 
-        val enqueuedSubscribeOrResume = MutableStateFlow(isPendingSubscription)
+        val subscribeOrResumeSignal = ConflatedSignal()
+        if (isPendingSubscription) {
+          subscribeOrResumeSignal.signal()
+        }
         val subscribeOrResumeJob =
           coroutineScope.launch(start = CoroutineStart.LAZY) {
-            event.outgoingRequests.subscribeOrResumeLoop(event.authUid, enqueuedSubscribeOrResume)
+            event.outgoingRequests.subscribeOrResumeLoop(event.authUid, subscribeOrResumeSignal)
           }
 
         val newState =
           SubscriptionState.Connected(
             event.outgoingRequests,
-            enqueuedSubscribeOrResume = enqueuedSubscribeOrResume,
             hadPendingSubscription = isPendingSubscription,
+            subscribeOrResumeSignal = subscribeOrResumeSignal,
             subscribeOrResumeJob = subscribeOrResumeJob,
           )
         if (state.compareAndSet(currentState, newState)) {

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -17,6 +17,7 @@
 package com.google.firebase.dataconnect.core
 
 import com.google.firebase.dataconnect.ExperimentalRealtimeQueries
+import com.google.firebase.dataconnect.core.LoggerGlobals.debug
 import com.google.firebase.dataconnect.util.CoroutineUtils.completedFlow
 import com.google.firebase.dataconnect.util.GrpcBidiFlow
 import com.google.firebase.dataconnect.util.ProtoUtil.toCompactString
@@ -30,7 +31,6 @@ import google.firebase.dataconnect.proto.GraphqlResponseExtensions.DataConnectPr
 import google.firebase.dataconnect.proto.ResumeRequest as ResumeRequestProto
 import google.firebase.dataconnect.proto.StreamRequest as StreamRequestProto
 import google.firebase.dataconnect.proto.StreamResponse as StreamResponseProto
-import java.io.IOException
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
@@ -100,14 +100,14 @@ internal class DataConnectBidiConnectStream(
         .map(SubscriptionEvent::Message)
         .onCompletion { throwable ->
           connectionStateFlow.value = SubscriptionEvent.Disconnected
-          // Throw an exception to trigger the `retryWhen` logic.
-          throw throwable ?: IOException("server closed the stream gracefully? that's unexpected")
+          throw throwable ?: Exception("to be handled by retryWhen")
         }
         .retryWhen { _, attempt ->
           if (attempt > 2) {
             false
           } else {
             delay(1.seconds)
+            logger.debug { "retrying connection" }
             true
           }
         }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -78,6 +78,12 @@ internal class DataConnectBidiConnectStream(
   private val coroutineScope: CoroutineScope,
 ) {
 
+  /**
+   * A flow that emits `null` when [coroutineScope] is canceled, which happens when
+   * [com.google.firebase.dataconnect.FirebaseDataConnect.close] is called.
+   */
+  private val scopeCompletedFlow = coroutineScope.completedFlow().map { null }
+
   private val connectionFlow: Flow<SubscriptionEvent> = run {
     val connectionStateFlow =
       MutableStateFlow<SubscriptionEvent.Connection>(SubscriptionEvent.Disconnected)
@@ -107,9 +113,7 @@ internal class DataConnectBidiConnectStream(
           replay = 0,
         )
 
-    val scopeCompletedFlow = coroutineScope.completedFlow().map { SubscriptionEvent.ScopeCompleted }
-
-    merge(scopeCompletedFlow, connectionStateFlow, sharedFlow)
+    merge(connectionStateFlow, sharedFlow)
   }
 
   /**
@@ -147,41 +151,54 @@ internal class DataConnectBidiConnectStream(
       }
     }
 
-    return connectionFlow
-      .onCompletion {
-        state.update { currentState ->
-          if (currentState is SubscriptionState.Connected) {
-            currentState.cancelSubscribeOrResumeJob("all subscribers have unsubscribed")
+    val subscriptionFlow =
+      connectionFlow
+        .onCompletion {
+          state.update { currentState ->
+            if (currentState is SubscriptionState.Connected) {
+              currentState.cancelSubscribeOrResumeJob("all subscribers have unsubscribed")
+            }
+            SubscriptionState.Disconnected
           }
-          SubscriptionState.Disconnected
         }
-      }
-      .transformToMessage(requestId, operationName, variables, state)
-      .map<_, MessageOrSubscribe> { MessageOrSubscribe.Message(it) }
-      .buffer(capacity = Channel.UNLIMITED)
-      .shareIn(
-        coroutineScope,
-        started = SharingStarted.WhileSubscribed(replayExpirationMillis = 0),
-        replay = 0,
-      )
-      .onSubscription { emit(MessageOrSubscribe.Subscribed) }
-      .transform { messageOrSubscribe ->
-        when (messageOrSubscribe) {
-          MessageOrSubscribe.Subscribed -> sendSubscribeOrResume()
-          is MessageOrSubscribe.Message -> emit(messageOrSubscribe.message)
+        .transformToMessage(requestId, operationName, variables, state)
+        .map<_, MessageOrSubscribe> { MessageOrSubscribe.Message(it) }
+        .buffer(capacity = Channel.UNLIMITED)
+        .shareIn(
+          coroutineScope,
+          started = SharingStarted.WhileSubscribed(replayExpirationMillis = 0),
+          replay = 0,
+        )
+        .onSubscription { emit(MessageOrSubscribe.Subscribed) }
+        .transform { messageOrSubscribe ->
+          when (messageOrSubscribe) {
+            MessageOrSubscribe.Subscribed -> sendSubscribeOrResume()
+            is MessageOrSubscribe.Message -> emit(messageOrSubscribe.message)
+          }
         }
+        .filter { it.requestId == requestId }
+        .mapNotNull { it.toExecuteResponse() }
+
+    // Configure the returned flow to end gracefully when FirebaseDataConnect.close() is called.
+    return merge(subscriptionFlow, scopeCompletedFlow).transformWhile {
+      if (it !== null && coroutineScope.isActive) {
+        emit(it)
+        true
+      } else {
+        false
       }
-      .filter { it.requestId == requestId }
-      .mapNotNull { it.toExecuteResponse() }
+    }
   }
 
   private sealed interface MessageOrSubscribe {
 
-    object Subscribed : MessageOrSubscribe
+    object Subscribed : MessageOrSubscribe {
+      override fun toString() = "Subscribed"
+    }
 
     class Message(val message: StreamResponseProto) : MessageOrSubscribe {
       constructor(event: SubscriptionEvent.Message) : this(event.message)
-      override fun toString() = "Message(message=${message.toCompactString()}"
+      override fun toString() = "Message(message=${message.toCompactString()})"
     }
   }
 
@@ -245,13 +262,7 @@ internal class DataConnectBidiConnectStream(
 
   private sealed interface SubscriptionEvent {
 
-    object ScopeCompleted : SubscriptionEvent {
-      override fun toString() = "ScopeCompleted"
-    }
-
-    sealed interface ScopeNotCompleted : SubscriptionEvent
-
-    class Message(val connectionId: String, val message: StreamResponseProto) : ScopeNotCompleted {
+    class Message(val connectionId: String, val message: StreamResponseProto) : SubscriptionEvent {
       constructor(
         event: GrpcBidiFlow.Event.Message<StreamResponseProto>
       ) : this(event.connectionId, event.message)
@@ -259,7 +270,7 @@ internal class DataConnectBidiConnectStream(
         "Message(connectionId=$connectionId, message=${message.toCompactString()})"
     }
 
-    sealed interface Connection : ScopeNotCompleted
+    sealed interface Connection : SubscriptionEvent
 
     class Connected(
       val connectionId: String,
@@ -427,17 +438,12 @@ internal class DataConnectBidiConnectStream(
       }
     }
 
-    return transformWhile { event ->
-      if (!coroutineScope.isActive) {
-        return@transformWhile false
-      }
+    return transform { event ->
       when (event) {
-        is SubscriptionEvent.ScopeCompleted -> return@transformWhile false
         is SubscriptionEvent.Connected -> transitionToConnectedState(event)
         is SubscriptionEvent.Disconnected -> transitionToDisconnectedState(event)
         is SubscriptionEvent.Message -> emit(event)
       }
-      true
     }
   }
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -42,10 +42,7 @@ import kotlinx.coroutines.channels.onFailure
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
@@ -81,28 +78,20 @@ internal class DataConnectBidiConnectStream(
   private val coroutineScope: CoroutineScope,
 ) {
 
-  private val scopeCompletedFlow: Flow<SubscriptionEvent.ScopeCompleted> =
-    coroutineScope.completedFlow().map { SubscriptionEvent.ScopeCompleted }
-
-  private val sharedFlow: SharedFlow<SubscriptionEvent>
-
-  private val connectionState: StateFlow<SubscriptionEvent.Connection>
-
-  init {
-    val mutableConnectionState =
+  private val connectionFlow: Flow<SubscriptionEvent> = run {
+    val connectionStateFlow =
       MutableStateFlow<SubscriptionEvent.Connection>(SubscriptionEvent.Disconnected)
-    connectionState = mutableConnectionState.asStateFlow()
 
-    sharedFlow =
+    val sharedFlow =
       flow
         .onEach { event ->
           if (event is GrpcBidiFlow.Event.ConnectionInfo) {
-            mutableConnectionState.value = SubscriptionEvent.Connected(event)
+            connectionStateFlow.value = SubscriptionEvent.Connected(event)
           }
         }
         .filterIsInstance<GrpcBidiFlow.Event.Message<StreamResponseProto>>()
         .map(SubscriptionEvent::Message)
-        .onCompletion { mutableConnectionState.value = SubscriptionEvent.Disconnected }
+        .onCompletion { connectionStateFlow.value = SubscriptionEvent.Disconnected }
         .retryWhen { _, attempt ->
           if (attempt > 2) {
             false
@@ -117,6 +106,10 @@ internal class DataConnectBidiConnectStream(
           started = SharingStarted.WhileSubscribed(replayExpirationMillis = 0),
           replay = 0,
         )
+
+    val scopeCompletedFlow = coroutineScope.completedFlow().map { SubscriptionEvent.ScopeCompleted }
+
+    merge(scopeCompletedFlow, connectionStateFlow, sharedFlow)
   }
 
   /**
@@ -154,7 +147,7 @@ internal class DataConnectBidiConnectStream(
       }
     }
 
-    return merge(sharedFlow, connectionState, scopeCompletedFlow)
+    return connectionFlow
       .onCompletion {
         state.update { currentState ->
           if (currentState is SubscriptionState.Connected) {

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -29,6 +29,7 @@ import google.firebase.dataconnect.proto.GraphqlResponseExtensions.DataConnectPr
 import google.firebase.dataconnect.proto.ResumeRequest as ResumeRequestProto
 import google.firebase.dataconnect.proto.StreamRequest as StreamRequestProto
 import google.firebase.dataconnect.proto.StreamResponse as StreamResponseProto
+import java.io.IOException
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
@@ -97,7 +98,11 @@ internal class DataConnectBidiConnectStream(
         }
         .filterIsInstance<GrpcBidiFlow.Event.Message<StreamResponseProto>>()
         .map(SubscriptionEvent::Message)
-        .onCompletion { connectionStateFlow.value = SubscriptionEvent.Disconnected }
+        .onCompletion { throwable ->
+          connectionStateFlow.value = SubscriptionEvent.Disconnected
+          // Throw an exception to trigger the `retryWhen` logic.
+          throw throwable ?: IOException("server closed the stream gracefully? that's unexpected")
+        }
         .retryWhen { _, attempt ->
           if (attempt > 2) {
             false

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -44,10 +44,13 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
@@ -78,36 +81,36 @@ internal class DataConnectBidiConnectStream(
   private val coroutineScope: CoroutineScope,
 ) {
 
+  private val scopeCompletedFlow: Flow<SubscriptionEvent.ScopeCompleted> =
+    coroutineScope.completedFlow().map { SubscriptionEvent.ScopeCompleted }
+
   private val sharedFlow: SharedFlow<SubscriptionEvent>
 
+  private val connectionState: StateFlow<SubscriptionEvent.Connection>
+
   init {
-    val scopeCompletedFlow: Flow<SubscriptionEvent.ScopeCompleted> =
-      coroutineScope.completedFlow().map { SubscriptionEvent.ScopeCompleted }
-
-    val connectionState =
+    val mutableConnectionState =
       MutableStateFlow<SubscriptionEvent.Connection>(SubscriptionEvent.Disconnected)
+    connectionState = mutableConnectionState.asStateFlow()
 
-    val messageFlow: Flow<SubscriptionEvent.Message> =
+    sharedFlow =
       flow
         .onEach { event ->
           if (event is GrpcBidiFlow.Event.ConnectionInfo) {
-            connectionState.value = SubscriptionEvent.Connected(event)
+            mutableConnectionState.value = SubscriptionEvent.Connected(event)
           }
         }
         .filterIsInstance<GrpcBidiFlow.Event.Message<StreamResponseProto>>()
         .map(SubscriptionEvent::Message)
-        .onCompletion { connectionState.value = SubscriptionEvent.Disconnected }
+        .onCompletion { mutableConnectionState.value = SubscriptionEvent.Disconnected }
         .retryWhen { _, attempt ->
-          if (attempt < 2) {
+          if (attempt > 2) {
             false
           } else {
             delay(1.seconds)
             true
           }
         }
-
-    sharedFlow =
-      merge(scopeCompletedFlow, connectionState, messageFlow)
         .buffer(capacity = Channel.UNLIMITED)
         .shareIn(
           coroutineScope,
@@ -151,7 +154,7 @@ internal class DataConnectBidiConnectStream(
       }
     }
 
-    return sharedFlow
+    return merge(sharedFlow, connectionState, scopeCompletedFlow)
       .onCompletion {
         state.update { currentState ->
           if (currentState is SubscriptionState.Connected) {
@@ -172,14 +175,11 @@ internal class DataConnectBidiConnectStream(
       .transform { messageOrSubscribe ->
         when (messageOrSubscribe) {
           MessageOrSubscribe.Subscribed -> sendSubscribeOrResume()
-          is MessageOrSubscribe.Message -> {
-            val executeResponse = messageOrSubscribe.message.toExecuteResponse()
-            if (executeResponse !== null) {
-              emit(executeResponse)
-            }
-          }
+          is MessageOrSubscribe.Message -> emit(messageOrSubscribe.message)
         }
       }
+      .filter { it.requestId == requestId }
+      .mapNotNull { it.toExecuteResponse() }
   }
 
   private sealed interface MessageOrSubscribe {
@@ -275,7 +275,7 @@ internal class DataConnectBidiConnectStream(
     ) : Connection {
       constructor(
         event: GrpcBidiFlow.Event.ConnectionInfo<StreamRequestProto, String?>
-      ) : this(event.connectionId, event.connectionContext, event.outgoingRequests)
+      ) : this(event.connectionId, event.connectionCookie, event.outgoingRequests)
 
       override fun toString() = "Connected(connectionId=$connectionId)"
     }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -76,6 +76,7 @@ import kotlinx.coroutines.launch
 internal class DataConnectBidiConnectStream(
   flow: Flow<GrpcBidiFlow.Event<StreamRequestProto, StreamResponseProto, String?>>,
   private val coroutineScope: CoroutineScope,
+  private val logger: Logger,
 ) {
 
   /**

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -110,7 +110,7 @@ internal class DataConnectBidiConnectStream(
             true
           }
         }
-        .buffer(capacity = Channel.UNLIMITED)
+        .buffer(capacity = 64) // Use a finite buffer to activate gRPC flow control, when needed
         .shareIn(
           coroutineScope,
           started = SharingStarted.WhileSubscribed(replayExpirationMillis = 0),
@@ -168,7 +168,7 @@ internal class DataConnectBidiConnectStream(
         }
         .transformToMessage(requestId, operationName, variables, state)
         .map<_, MessageOrSubscribe> { MessageOrSubscribe.Message(it) }
-        .buffer(capacity = Channel.UNLIMITED)
+        .buffer(capacity = Channel.CONFLATED) // use CONFLATED to drop stale data
         .shareIn(
           coroutineScope,
           started = SharingStarted.WhileSubscribed(replayExpirationMillis = 0),

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -136,6 +136,7 @@ internal class DataConnectBidiConnectStream(
         when (val currentState = state.get()) {
           is SubscriptionState.Connected -> {
             currentState.enqueueSubscribeOrResume()
+            break
           }
           SubscriptionState.DisconnectedWithPendingSubscription -> break
           SubscriptionState.Disconnected ->

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -21,17 +21,10 @@ import com.google.firebase.dataconnect.util.CoroutineUtils.completedFlow
 import com.google.firebase.dataconnect.util.GrpcBidiFlow
 import com.google.firebase.dataconnect.util.ProtoUtil.toCompactString
 import com.google.protobuf.Struct
-import google.firebase.dataconnect.proto.ExecuteRequest
-import google.firebase.dataconnect.proto.GraphqlError as GraphqlErrorProto
-import google.firebase.dataconnect.proto.GraphqlResponseExtensions.DataConnectProperties as DataConnectPropertiesProto
-import google.firebase.dataconnect.proto.StreamRequest as StreamRequestProto
-import google.firebase.dataconnect.proto.StreamResponse as StreamResponseProto
-import java.util.concurrent.atomic.AtomicReference
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
@@ -42,15 +35,29 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.flow.transformWhile
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration.Companion.seconds
+import com.google.protobuf.Empty as EmptyProto
+import google.firebase.dataconnect.proto.ExecuteRequest as ExecuteRequestProto
+import google.firebase.dataconnect.proto.GraphqlError as GraphqlErrorProto
+import google.firebase.dataconnect.proto.GraphqlResponseExtensions.DataConnectProperties as DataConnectPropertiesProto
+import google.firebase.dataconnect.proto.ResumeRequest as ResumeRequestProto
+import google.firebase.dataconnect.proto.StreamRequest as StreamRequestProto
+import google.firebase.dataconnect.proto.StreamResponse as StreamResponseProto
 
 /**
  * Manages a bidirectional gRPC stream for Data Connect operations.
@@ -66,7 +73,7 @@ import kotlinx.coroutines.isActive
  */
 @ExperimentalRealtimeQueries
 internal class DataConnectBidiConnectStream(
-  flow: Flow<GrpcBidiFlow.Event<StreamRequestProto, StreamResponseProto>>,
+  flow: Flow<GrpcBidiFlow.Event<StreamRequestProto, StreamResponseProto, String?>>,
   private val coroutineScope: CoroutineScope,
 ) {
 
@@ -129,12 +136,47 @@ internal class DataConnectBidiConnectStream(
     val x =
       sharedFlow
         .transformToMessage(requestId, operationName, variables, state)
+        .map<_, MessageOrSubscribe> { MessageOrSubscribe.Message(it) }
         .buffer(capacity = Channel.UNLIMITED)
         .shareIn(
           coroutineScope,
           started = SharingStarted.WhileSubscribed(replayExpirationMillis = 0),
           replay = 0,
         )
+        .onSubscription { emit(MessageOrSubscribe.Subscribed) }
+        .transform { messageOrSubscribe ->
+          when (messageOrSubscribe) {
+            is MessageOrSubscribe.Message -> emit(messageOrSubscribe.message)
+            MessageOrSubscribe.Subscribed -> {
+              while (true) {
+                when (val currentState = state.get()) {
+                  is SubscriptionState.Disconnected ->
+                    if (currentState.pendingSubscription) {
+                      break
+                    } else if (state.compareAndSet(currentState, SubscriptionState.Disconnected(pendingSubscription = true))) {
+                      break
+                    }
+                  is SubscriptionState.Connected -> {
+                    currentState.enqueueSubscribeOrResume()
+                  }
+                }
+              }
+            }
+          }
+        }
+
+    TODO()
+  }
+
+  private sealed interface MessageOrSubscribe {
+
+    class Message(val message: StreamResponseProto) : MessageOrSubscribe {
+      constructor(event: SubscriptionEvent.Message) : this(event.message)
+      override fun toString() = "Message(message=${message.toCompactString()}"
+    }
+
+    object Subscribed : MessageOrSubscribe
+
   }
 
   private sealed interface SubscriptionState {
@@ -146,11 +188,26 @@ internal class DataConnectBidiConnectStream(
     class Connected(
       val outgoingRequests: SendChannel<StreamRequestProto>,
       val wasPendingSubscription: Boolean,
-      val subscribeJob: Job,
+      private val enqueuedSubscribeOrResume: MutableStateFlow<Boolean>,
+      private val subscribeOrResumeJob: Job,
     ) : SubscriptionState {
+
+      fun enqueueSubscribeOrResume() {
+        enqueuedSubscribeOrResume.value = true
+        subscribeOrResumeJob.start()
+      }
+
+      fun cancelSubscribeOrResumeJob(message: String) {
+        subscribeOrResumeJob.cancel(message)
+      }
+
       override fun toString(): String =
-        "Connected(subscribeJob={isActive=${subscribeJob.isActive}, " +
-          "isCompleted=${subscribeJob.isCompleted}})"
+        "Connected(" +
+            "wasPendingSubscription=$wasPendingSubscription " +
+            "enqueuedSubscribeOrResume=${enqueuedSubscribeOrResume.value} " +
+            "subscribeOrResumeJob={isActive=${subscribeOrResumeJob.isActive}, " +
+            "isCancelled=${subscribeOrResumeJob.isCancelled}, " +
+            "isCompleted=${subscribeOrResumeJob.isCompleted}})"
     }
   }
 
@@ -191,11 +248,12 @@ internal class DataConnectBidiConnectStream(
 
     class Connected(
       val connectionId: String,
+      val authUid: String?,
       val outgoingRequests: SendChannel<StreamRequestProto>,
     ) : Connection {
       constructor(
-        event: GrpcBidiFlow.Event.ConnectionInfo<StreamRequestProto>
-      ) : this(event.connectionId, event.outgoingRequests)
+        event: GrpcBidiFlow.Event.ConnectionInfo<StreamRequestProto, String?>
+      ) : this(event.connectionId, event.connectionContext, event.outgoingRequests)
 
       override fun toString() = "Connected(connectionId=$connectionId)"
     }
@@ -216,7 +274,7 @@ internal class DataConnectBidiConnectStream(
       StreamRequestProto.newBuilder().let { streamRequest ->
         streamRequest.setRequestId(requestId)
         streamRequest.setSubscribe(
-          ExecuteRequest.newBuilder().let { executeRequest ->
+          ExecuteRequestProto.newBuilder().let { executeRequest ->
             executeRequest.setOperationName(operationName)
             executeRequest.setVariables(variables)
             executeRequest.build()
@@ -225,16 +283,51 @@ internal class DataConnectBidiConnectStream(
         streamRequest.build()
       }
 
-    fun SendChannel<StreamRequestProto>.trySendSubscribeRequest() {
-      val sendResult = trySend(subscribeRequest)
-      sendResult.onFailure { exception ->
-        if (!sendResult.isClosed) {
-          throw exception
-            ?: error(
-              "internal error gt2ms5wwby: outgoingRequests.trySend(subscribeRequest) " +
-                "failed, but should have succeeded because outgoingRequests " +
-                "is created with capacity=UNLIMITED"
-            )
+    val resumeRequest =
+      StreamRequestProto.newBuilder().let { streamRequest ->
+        streamRequest.setRequestId(requestId)
+        streamRequest.setResume(ResumeRequestProto.getDefaultInstance())
+        streamRequest.build()
+      }
+
+    val cancelRequest =
+      StreamRequestProto.newBuilder().let { streamRequest ->
+        streamRequest.setRequestId(requestId)
+        streamRequest.setCancel(EmptyProto.getDefaultInstance())
+        streamRequest.build()
+      }
+
+    suspend fun SendChannel<StreamRequestProto>.subscribeOrResumeLoop(authUid: String?, enqueuedSubscribeOrResume: MutableStateFlow<Boolean>) {
+      fun sendRequest(request: StreamRequestProto) {
+        val sendResult = trySend(request)
+        sendResult.onFailure { exception ->
+          if (!sendResult.isClosed) {
+            throw exception
+              ?: error(
+                "internal error gt2ms5wwby: outgoingRequests.trySend() failed, " +
+                "but should have succeeded because outgoingRequests is created " +
+                    "with capacity=UNLIMITED (request=${request.toCompactString(authUid)})"
+              )
+          }
+        }
+      }
+
+      var subscribed = false
+      try {
+        enqueuedSubscribeOrResume.filter { it }.collect {
+          enqueuedSubscribeOrResume.value = false
+          if (! subscribed) {
+            sendRequest(subscribeRequest)
+            subscribed = true
+          } else {
+            sendRequest(resumeRequest)
+          }
+        }
+      } finally {
+        withContext(NonCancellable) {
+          if (subscribed) {
+            sendRequest(cancelRequest)
+          }
         }
       }
     }
@@ -248,17 +341,19 @@ internal class DataConnectBidiConnectStream(
                 "but state=$currentState (expected state=Disconnected)"
             )
           is SubscriptionState.Disconnected -> {
+            val enqueuedSubscribeOrResume = MutableStateFlow(currentState.pendingSubscription)
             val newState =
               SubscriptionState.Connected(
                 event.outgoingRequests,
                 wasPendingSubscription = currentState.pendingSubscription,
-                subscribeJob =
-                  coroutineScope.async(start = CoroutineStart.LAZY) {
-                    event.outgoingRequests.trySendSubscribeRequest()
+                enqueuedSubscribeOrResume = enqueuedSubscribeOrResume,
+                subscribeOrResumeJob =
+                  coroutineScope.launch(start = CoroutineStart.LAZY) {
+                    event.outgoingRequests.subscribeOrResumeLoop(event.authUid, enqueuedSubscribeOrResume)
                   }
               )
             if (state.compareAndSet(currentState, newState)) {
-              newState.subscribeJob.start()
+              newState.enqueueSubscribeOrResume()
               break
             }
           }
@@ -275,7 +370,7 @@ internal class DataConnectBidiConnectStream(
                 "but state=$currentState (expected state=Connected)"
             )
           is SubscriptionState.Connected -> {
-            currentState.subscribeJob.cancel("got Disconnected event")
+            currentState.cancelSubscribeOrResumeJob("got Disconnected event")
             val newState =
               SubscriptionState.Disconnected(
                 pendingSubscription = currentState.wasPendingSubscription

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -20,38 +20,37 @@ import com.google.firebase.dataconnect.ExperimentalRealtimeQueries
 import com.google.firebase.dataconnect.util.CoroutineUtils.completedFlow
 import com.google.firebase.dataconnect.util.GrpcBidiFlow
 import com.google.firebase.dataconnect.util.ProtoUtil.toCompactString
-import com.google.firebase.dataconnect.util.SequencedReference.Companion.nextSequenceNumber
-import com.google.protobuf.Empty
 import com.google.protobuf.Struct
 import google.firebase.dataconnect.proto.ExecuteRequest
 import google.firebase.dataconnect.proto.GraphqlError as GraphqlErrorProto
 import google.firebase.dataconnect.proto.GraphqlResponseExtensions.DataConnectProperties as DataConnectPropertiesProto
-import google.firebase.dataconnect.proto.ResumeRequest
 import google.firebase.dataconnect.proto.StreamRequest as StreamRequestProto
 import google.firebase.dataconnect.proto.StreamResponse as StreamResponseProto
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.onFailure
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.buffer
-import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.transformWhile
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.isActive
 
 /**
  * Manages a bidirectional gRPC stream for Data Connect operations.
@@ -122,54 +121,36 @@ internal class DataConnectBidiConnectStream(
     operationName: String,
     variables: Struct,
   ): Flow<ExecuteResponse> {
-    // Note: `subscriptionStateManager` is shared by _all_ collectors of the returned flow;
-    // however, each flow collector gets its own `Subscriber` object from the manager.
-    val subscriptionStateManager =
-      SubscriptionStateManager(
-        requestId = requestId,
-        operationName = operationName,
-        variables = variables,
+    val state =
+      AtomicReference<SubscriptionState>(
+        SubscriptionState.Disconnected(pendingSubscription = false)
       )
 
-    return flow {
-      val flowCollectorStartSequenceNumber = nextSequenceNumber()
-      val subscription = subscriptionStateManager.Subscriber()
+    val x =
+      sharedFlow
+        .transformToMessage(requestId, operationName, variables, state)
+        .buffer(capacity = Channel.UNLIMITED)
+        .shareIn(
+          coroutineScope,
+          started = SharingStarted.WhileSubscribed(replayExpirationMillis = 0),
+          replay = 0,
+        )
+  }
 
-      emitAll(
-        merge(sharedFlow.onSubscription { emit(Event.Subscribed) }, scopeCompletedFlow)
-          .transformWhile { event ->
-            when (event) {
-              is Event.Ready -> {
-                subscription.setOutgoingRequests(event.outgoingRequests)
-                true
-              }
-              is Event.Subscribed -> subscription.subscribe()
-              is Event.Message -> {
-                subscription.setOutgoingRequests(event.outgoingRequests)
-                if (event.sequenceNumber < flowCollectorStartSequenceNumber) {
-                  true
-                } else if (event.streamResponse.requestId != requestId) {
-                  true
-                } else {
-                  val executeResponse = event.streamResponse.toExecuteResponse()
-                  if (executeResponse !== null) {
-                    emit(executeResponse)
-                  }
-                  !event.streamResponse.cancelled
-                }
-              }
-              is Event.Completed -> {
-                event.throwable?.let {
-                  if (it !is CancellationException) {
-                    throw it
-                  }
-                }
-                false
-              }
-            }
-          }
-          .onCompletion { subscription.unsubscribe() }
-      )
+  private sealed interface SubscriptionState {
+
+    class Disconnected(val pendingSubscription: Boolean) : SubscriptionState {
+      override fun toString(): String = "Disconnected(pendingSubscription=$pendingSubscription)"
+    }
+
+    class Connected(
+      val outgoingRequests: SendChannel<StreamRequestProto>,
+      val wasPendingSubscription: Boolean,
+      val subscribeJob: Job,
+    ) : SubscriptionState {
+      override fun toString(): String =
+        "Connected(subscribeJob={isActive=${subscribeJob.isActive}, " +
+          "isCompleted=${subscribeJob.isCompleted}})"
     }
   }
 
@@ -192,7 +173,13 @@ internal class DataConnectBidiConnectStream(
 
   private sealed interface SubscriptionEvent {
 
-    class Message(val connectionId: String, val message: StreamResponseProto) : SubscriptionEvent {
+    object ScopeCompleted : SubscriptionEvent {
+      override fun toString() = "ScopeCompleted"
+    }
+
+    sealed interface ScopeNotCompleted : SubscriptionEvent
+
+    class Message(val connectionId: String, val message: StreamResponseProto) : ScopeNotCompleted {
       constructor(
         event: GrpcBidiFlow.Event.Message<StreamResponseProto>
       ) : this(event.connectionId, event.message)
@@ -200,11 +187,7 @@ internal class DataConnectBidiConnectStream(
         "Message(connectionId=$connectionId, message=${message.toCompactString()})"
     }
 
-    object ScopeCompleted : SubscriptionEvent {
-      override fun toString() = "ScopeCompleted"
-    }
-
-    sealed interface Connection : SubscriptionEvent
+    sealed interface Connection : ScopeNotCompleted
 
     class Connected(
       val connectionId: String,
@@ -222,128 +205,14 @@ internal class DataConnectBidiConnectStream(
     }
   }
 
-  /**
-   * NOTE: This class is **NOT** thread safe.
-   *
-   * Concurrent access to a [SubscriptionStateManager] and all [Subscriber] instances created from
-   * it **MUST** be serialized with **the same** [Mutex], or else the behavior is undefined. The
-   * likely observable effect of unserialized concurrent access would be things like missing, extra,
-   * or out-of-order "subscribe", "resume" or "cancel" requests, which defeats the entire purpose of
-   * this class.
-   */
-  private class SubscriptionStateManager(
+  private fun SharedFlow<SubscriptionEvent>.transformToMessage(
     requestId: String,
     operationName: String,
     variables: Struct,
-  ) {
+    state: AtomicReference<SubscriptionState>,
+  ): Flow<SubscriptionEvent.Message> {
 
-    private val mutex = Mutex()
-    private var subscriberCount = 0
-
-    inner class Subscriber {
-      private var state: State = State.NotReady(pendingSubscribe = false)
-
-      suspend fun setOutgoingRequests(outgoingRequests: SendChannel<StreamRequestProto>) {
-        when (val currentState = state) {
-          is State.NotReady -> {
-            val readyState = State.Ready(outgoingRequests)
-            state = readyState
-            if (currentState.pendingSubscribe) {
-              mutex.withLock { subscribe(readyState) }
-            }
-          }
-          is State.Ready ->
-            check(currentState.outgoingRequests === outgoingRequests) {
-              "internal error n99tc8qe2t: setOutgoingRequests() has already been called " +
-                "with a different object"
-            }
-        }
-      }
-
-      suspend fun subscribe(): Boolean {
-        return when (val currentState = state) {
-          is State.NotReady -> {
-            check(!currentState.pendingSubscribe) {
-              "internal error szx94f63tz: subscribe() called when already subscribed"
-            }
-            state = State.NotReady(pendingSubscribe = true)
-            true
-          }
-          is State.Ready ->
-            mutex.withLock {
-              return subscribe(currentState)
-            }
-        }
-      }
-
-      private fun subscribe(readyState: State.Ready): Boolean {
-        check(!readyState.subscribed) {
-          "internal error hkjgvhnk27: subscribe() called when already subscribed " +
-            "(is concurrent access to the SubscriptionStateManager properly serialized " +
-            "with a mutex?)"
-        }
-
-        val streamRequest =
-          if (subscriberCount == 0) {
-            subscribeStreamRequest
-          } else {
-            resumeStreamRequest
-          }
-
-        val sendResult = readyState.outgoingRequests.trySend(streamRequest)
-
-        return when {
-          sendResult.isSuccess -> {
-            readyState.subscribed = true
-            subscriberCount++
-            true
-          }
-          sendResult.isClosed -> false
-          else ->
-            error(
-              "internal error xw3zdzycfq: outgoingRequests.trySend(subscribe or resume) " +
-                "was unable to enqueue the streamRequest; this should never happen because " +
-                "outgoingRequests is created with capacity=UNLIMITED (sendResult=$sendResult)"
-            )
-        }
-      }
-
-      suspend fun unsubscribe() {
-        when (val currentState = state) {
-          is State.NotReady ->
-            if (currentState.pendingSubscribe) {
-              state = State.NotReady(pendingSubscribe = false)
-            }
-          is State.Ready -> mutex.withLock { unsubscribe(currentState) }
-        }
-      }
-
-      private fun unsubscribe(readyState: State.Ready) {
-        if (!readyState.subscribed) {
-          return
-        }
-
-        readyState.subscribed = false
-        subscriberCount--
-        check(subscriberCount >= 0) {
-          "internal error hpn3qsj746: subscriberCount should never be less than zero, " +
-            "but it is: $subscriberCount"
-        }
-
-        if (subscriberCount == 0) {
-          val sendResult = readyState.outgoingRequests.trySend(cancelStreamRequest)
-          if (sendResult.isFailure && !sendResult.isClosed) {
-            error(
-              "internal error mxcsq556tv: outgoingRequests.trySend(cancel) " +
-                "was unable to enqueue the streamRequest; this should never happen because " +
-                "outgoingRequests is created with capacity=UNLIMITED (sendResult=$sendResult)"
-            )
-          }
-        }
-      }
-    }
-
-    private val subscribeStreamRequest =
+    val subscribeRequest =
       StreamRequestProto.newBuilder().let { streamRequest ->
         streamRequest.setRequestId(requestId)
         streamRequest.setSubscribe(
@@ -356,32 +225,80 @@ internal class DataConnectBidiConnectStream(
         streamRequest.build()
       }
 
-    private val resumeStreamRequest =
-      StreamRequestProto.newBuilder().let { streamRequest ->
-        streamRequest.setRequestId(requestId)
-        streamRequest.setResume(ResumeRequest.getDefaultInstance())
-        streamRequest.build()
+    fun SendChannel<StreamRequestProto>.trySendSubscribeRequest() {
+      val sendResult = trySend(subscribeRequest)
+      sendResult.onFailure { exception ->
+        if (!sendResult.isClosed) {
+          throw exception
+            ?: error(
+              "internal error gt2ms5wwby: outgoingRequests.trySend(subscribeRequest) " +
+                "failed, but should have succeeded because outgoingRequests " +
+                "is created with capacity=UNLIMITED"
+            )
+        }
       }
+    }
 
-    private val cancelStreamRequest =
-      StreamRequestProto.newBuilder().let { streamRequest ->
-        streamRequest.setRequestId(requestId)
-        streamRequest.setCancel(Empty.getDefaultInstance())
-        streamRequest.build()
+    fun transitionToConnectedState(event: SubscriptionEvent.Connected) {
+      while (true) {
+        when (val currentState = state.get()) {
+          is SubscriptionState.Connected ->
+            error(
+              "internal error nqe9gre3ny: got event $event, " +
+                "but state=$currentState (expected state=Disconnected)"
+            )
+          is SubscriptionState.Disconnected -> {
+            val newState =
+              SubscriptionState.Connected(
+                event.outgoingRequests,
+                wasPendingSubscription = currentState.pendingSubscription,
+                subscribeJob =
+                  coroutineScope.async(start = CoroutineStart.LAZY) {
+                    event.outgoingRequests.trySendSubscribeRequest()
+                  }
+              )
+            if (state.compareAndSet(currentState, newState)) {
+              newState.subscribeJob.start()
+              break
+            }
+          }
+        }
       }
+    }
 
-    private sealed interface State {
-      data class NotReady(val pendingSubscribe: Boolean) : State {
-        override fun toString() = "NotReady(pendingSubscribe=$pendingSubscribe)"
+    fun transitionToDisconnectedState(@Suppress("unused") event: SubscriptionEvent.Disconnected) {
+      while (true) {
+        when (val currentState = state.get()) {
+          is SubscriptionState.Disconnected ->
+            error(
+              "internal error vv4verqchm: got Disconnected event, " +
+                "but state=$currentState (expected state=Connected)"
+            )
+          is SubscriptionState.Connected -> {
+            currentState.subscribeJob.cancel("got Disconnected event")
+            val newState =
+              SubscriptionState.Disconnected(
+                pendingSubscription = currentState.wasPendingSubscription
+              )
+            if (state.compareAndSet(currentState, newState)) {
+              break
+            }
+          }
+        }
       }
+    }
 
-      class Ready(
-        val outgoingRequests: SendChannel<StreamRequestProto>,
-        // NOTE: @Volatile is applied to `subscribed` so that toString() can safely read its value.
-        @Volatile var subscribed: Boolean = false,
-      ) : State {
-        override fun toString() = "Ready(subscribed=$subscribed)"
+    return transformWhile { event ->
+      if (!coroutineScope.isActive) {
+        return@transformWhile false
       }
+      when (event) {
+        is SubscriptionEvent.ScopeCompleted -> return@transformWhile false
+        is SubscriptionEvent.Connected -> transitionToConnectedState(event)
+        is SubscriptionEvent.Disconnected -> transitionToDisconnectedState(event)
+        is SubscriptionEvent.Message -> emit(event)
+      }
+      true
     }
   }
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -412,7 +412,7 @@ internal class DataConnectGrpcRPCs(
         grpcChannel = lazyGrpcChannel.get(),
         method = ConnectorStreamServiceGrpc.getConnectMethod(),
         callOptions = CallOptions.DEFAULT.withExecutor(blockingCoroutineDispatcher.asExecutor()),
-        headers = { Pair(metadata, authToken?.authUid) },
+        headers = { GrpcBidiFlow.HeadersResult(metadata, authToken?.authUid) },
         idStringGenerator = idStringGenerator,
         initRequests = listOf(initRequest),
         listener = grpcBidiFlowListener,
@@ -440,9 +440,9 @@ internal class DataConnectGrpcRPCs(
       override fun connectionStarting(
         method: MethodDescriptor<StreamRequest, StreamResponse>,
         callOptions: CallOptions,
-        headers: Metadata,
+        headers: Metadata?,
       ) {
-        this.headers = headers.copy()
+        this.headers = headers?.copy()
       }
 
       override fun sendingMessage(message: StreamRequest) {
@@ -509,8 +509,8 @@ internal class DataConnectGrpcRPCs(
   @Suppress("unused")
   private class ConnectGrpcBidiFlowListenerFormatter(private val authUid: String?) :
     GrpcBidiFlowListenerMessageFormatter.Formatter<StreamRequest, StreamResponse>() {
-    override fun connectionStartingHeaders(headers: Metadata): String =
-      headers.toStructProto(authUid).toCompactString()
+    override fun connectionStartingHeaders(headers: Metadata?): String =
+      headers?.toStructProto(authUid)?.toCompactString().toString()
 
     override fun onCloseTrailers(trailers: Metadata): String =
       trailers.toStructProto(authUid).toCompactString()

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -412,7 +412,7 @@ internal class DataConnectGrpcRPCs(
         grpcChannel = lazyGrpcChannel.get(),
         method = ConnectorStreamServiceGrpc.getConnectMethod(),
         callOptions = CallOptions.DEFAULT.withExecutor(blockingCoroutineDispatcher.asExecutor()),
-        headers = { metadata },
+        headers = { Pair(metadata, authToken?.authUid) },
         idStringGenerator = idStringGenerator,
         initRequests = listOf(initRequest),
         listener = grpcBidiFlowListener,

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -598,6 +598,7 @@ internal class DataConnectGrpcRPCs(
     val cacheDb = lazyCacheDb.initializedValueOrNull?.ref
 
     if (grpcChannel === null && cacheDb === null) {
+      connectCoroutineScope.coroutineContext.job.join()
       return
     }
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -418,7 +418,13 @@ internal class DataConnectGrpcRPCs(
         listener = grpcBidiFlowListener,
       )
 
-    return DataConnectBidiConnectStream(flow, connectCoroutineScope)
+    return DataConnectBidiConnectStream(
+      flow,
+      connectCoroutineScope,
+      Logger("DataConnectBidiConnectStream[sid=$streamId]").also {
+        it.debug { "created by ${logger.nameWithId}" }
+      }
+    )
   }
 
   private inner class ConnectGrpcBidiFlowListener(

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/querymgr/RealtimeQueryManager.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/querymgr/RealtimeQueryManager.kt
@@ -163,34 +163,46 @@ internal class RealtimeQueryManager(
     requestId: String,
     callerSdkType: CallerSdkType
   ): State.Connected? {
+    var connectionAttempted = false
+
     while (true) {
-      val currentState = state.get()
-
-      val newState =
-        when (currentState) {
-          State.Disconnected ->
-            State.Connecting(
-              coroutineScope.async(start = CoroutineStart.LAZY) {
-                grpcClient.connect(
-                  streamId = idStringGenerator.next("con"),
-                  requestId = requestId,
-                  callerSdkType = callerSdkType,
-                  idStringGenerator = idStringGenerator,
-                )
-              }
-            )
-          is State.Connecting -> {
-            val stream = currentState.job.await()
-            State.Connected(stream)
-          }
-          is State.Connected -> return currentState
-          State.Closing,
-          State.Closed -> return null
+      when (val currentState = state.get()) {
+        State.Disconnected -> {
+          val newState: State.Connecting = createConnectingState(requestId, callerSdkType)
+          state.compareAndSet(currentState, newState)
         }
-
-      state.compareAndSet(currentState, newState)
+        is State.Connecting -> {
+          val connectResult = currentState.job.runCatching { await() }
+          val newState = connectResult.map(State::Connected).getOrElse { State.Disconnected }
+          state.compareAndSet(currentState, newState)
+          connectResult.onFailure { exception ->
+            if (connectionAttempted) {
+              throw exception
+            }
+            connectionAttempted = true
+          }
+        }
+        is State.Connected -> return currentState
+        State.Closing,
+        State.Closed -> return null
+      }
     }
   }
+
+  private fun createConnectingState(
+    requestId: String,
+    callerSdkType: CallerSdkType,
+  ) =
+    State.Connecting(
+      coroutineScope.async(start = CoroutineStart.LAZY) {
+        grpcClient.connect(
+          streamId = idStringGenerator.next("con"),
+          requestId = requestId,
+          callerSdkType = callerSdkType,
+          idStringGenerator = idStringGenerator,
+        )
+      }
+    )
 
   private sealed interface State {
     object Disconnected : State {

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/AtomicReferenceExts.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/AtomicReferenceExts.kt
@@ -63,9 +63,9 @@ internal inline fun <T> AtomicReference<T>.update(block: (currentValue: T) -> T)
  * value, making this function slightly less performant than its [Unit]-returning counterpart due to
  * the allocation of the [AtomicReferenceUpdateResult] return value in the case of an update.
  */
-internal inline fun <T> AtomicReference<T>.updateWithResult(
-  block: (currentValue: T) -> T
-): AtomicReferenceUpdateResult<T> {
+internal inline fun <T, R : T> AtomicReference<T>.updateWithResult(
+  block: (currentValue: T) -> R
+): AtomicReferenceUpdateResult<T, R> {
   while (true) {
     val currentValue = get()
     val newValue = block(currentValue)
@@ -80,16 +80,17 @@ internal inline fun <T> AtomicReference<T>.updateWithResult(
   }
 }
 
-internal sealed interface AtomicReferenceUpdateResult<out T> {
+internal sealed interface AtomicReferenceUpdateResult<out T, out R> {
 
   val updated: Boolean
 
-  object NotUpdated : AtomicReferenceUpdateResult<Nothing> {
+  object NotUpdated : AtomicReferenceUpdateResult<Nothing, Nothing> {
     override val updated = false
     override fun toString() = "NoChange"
   }
 
-  class Updated<out T>(val oldValue: T, val newValue: T) : AtomicReferenceUpdateResult<T> {
+  class Updated<out T, out R>(val oldValue: T, val newValue: R) :
+    AtomicReferenceUpdateResult<T, R> {
     override val updated = true
     override fun toString() = "Updated"
   }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/CoroutineUtils.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/CoroutineUtils.kt
@@ -27,6 +27,10 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.emptyFlow
 
 internal object CoroutineUtils {
 
@@ -146,4 +150,40 @@ internal object CoroutineUtils {
    * Kotlin coroutines library.
    */
   class SendOnlySendChannel<in T>(delegate: SendChannel<T>) : SendChannel<T> by delegate
+
+  /**
+   * Returns a [Flow] that emits when the [Job] associated with the receiver [CoroutineScope]
+   * completes.
+   *
+   * This is a convenience extension function that delegates to [CoroutineContext.completedFlow]
+   * using this scope's [CoroutineScope.coroutineContext].
+   */
+  fun CoroutineScope.completedFlow(): Flow<Throwable?> = this.coroutineContext.completedFlow()
+
+  /**
+   * Returns a [Flow] that emits when the [Job] associated with the receiver [CoroutineContext]
+   * completes.
+   *
+   * If this context does not contain a [Job], the returned flow completes immediately without
+   * emitting any values.
+   *
+   * If this context contains a [Job], it delegates to [Job.completedFlow].
+   */
+  fun CoroutineContext.completedFlow(): Flow<Throwable?> = this[Job]?.completedFlow() ?: emptyFlow()
+
+  /**
+   * Returns a [Flow] that emits when the receiver [Job] completes.
+   *
+   * The returned flow will emit exactly one value when the job completes, and then close. The
+   * emitted value is the [Throwable] that caused the job to complete, or `null` if the job
+   * completed normally. Specifically, the emitted value is the argument passed to the
+   * [Job.invokeOnCompletion].
+   */
+  fun Job.completedFlow(): Flow<Throwable?> = callbackFlow {
+    val disposableHandle = invokeOnCompletion { throwable ->
+      trySend(throwable)
+      close()
+    }
+    awaitClose { disposableHandle.dispose() }
+  }
 }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/GrpcBidiFlow.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/GrpcBidiFlow.kt
@@ -267,7 +267,7 @@ internal object GrpcBidiFlow {
             readiness.onReady()
           }
         },
-        requestHeaders,
+        requestHeaders ?: GrpcMetadata(),
       )
 
       coroutineScope {

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/GrpcBidiFlow.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/GrpcBidiFlow.kt
@@ -71,7 +71,12 @@ import kotlinx.coroutines.withContext
  */
 internal object GrpcBidiFlow {
 
-  /** Represents events emitted by the [Flow] created by [GrpcBidiFlow.create]. */
+  /**
+   * Represents events emitted by the [Flow] created by [GrpcBidiFlow.create].
+   *
+   * @property connectionId The "connectionId" to uniquely identify a connection to the remote
+   * server, especially for correlation with invocations of [Listener.collectStarted].
+   */
   sealed class Event<in RequestT, out ResponseT>(val connectionId: String) {
     /**
      * Emitted once when the gRPC flow collection starts.
@@ -93,14 +98,11 @@ internal object GrpcBidiFlow {
      * Emitted when a response message is received from the server.
      *
      * @property message The response message received from the server.
-     * @property connectionInfo Information about the connection; it is included for convenience,
-     * such as in the case that subscribers of a [kotlinx.coroutines.flow.SharedFlow] join late and
-     * miss the [ConnectionInfo] event.
      */
-    class Message<in RequestT, out ResponseT>(
+    class Message<out ResponseT>(
+      connectionId: String,
       val message: ResponseT,
-      val connectionInfo: ConnectionInfo<RequestT>,
-    ) : Event<RequestT, ResponseT>(connectionInfo.connectionId) {
+    ) : Event<Any?, ResponseT>(connectionId) {
       override fun toString() = "Message(message=$message)"
     }
   }
@@ -206,8 +208,7 @@ internal object GrpcBidiFlow {
       }
 
       val requestHeaders = headers(connectionId).copy()
-      val connectionInfo = Event.ConnectionInfo(connectionId, requestChannel.asSendChannel())
-      emit(connectionInfo)
+      emit(Event.ConnectionInfo(connectionId, requestChannel.asSendChannel()))
 
       val clientCall: ClientCall<RequestT, ResponseT> = grpcChannel.newCall(method, callOptions)
       val readiness = Readiness(connectionId, clientCall)
@@ -294,7 +295,7 @@ internal object GrpcBidiFlow {
           clientCall.request(1)
           for (response in responses) {
             collectionListener?.receivedMessage(response)
-            emit(Event.Message(response, connectionInfo))
+            emit(Event.Message(connectionId, response))
             clientCall.request(1)
           }
           collectionListener?.receivingMessagesComplete()

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/GrpcBidiFlow.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/GrpcBidiFlow.kt
@@ -77,7 +77,7 @@ internal object GrpcBidiFlow {
    * @property connectionId The "connectionId" to uniquely identify a connection to the remote
    * server, especially for correlation with invocations of [Listener.collectStarted].
    */
-  sealed class Event<in RequestT, out ResponseT, out ConnectionContext>(val connectionId: String) {
+  sealed class Event<in RequestT, out ResponseT, out ConnectionCookie>(val connectionId: String) {
     /**
      * Emitted once when the gRPC flow collection starts.
      *
@@ -87,13 +87,13 @@ internal object GrpcBidiFlow {
      * @param connectionId The unique identifier associated with this particular flow collection.
      * @property outgoingRequests The channel to send requests to the server.
      */
-    class ConnectionInfo<in RequestT, out ConnectionContext>(
+    class ConnectionInfo<in RequestT, out ConnectionCookie>(
       connectionId: String,
-      val connectionContext: ConnectionContext,
+      val connectionCookie: ConnectionCookie,
       val outgoingRequests: SendChannel<RequestT>,
-    ) : Event<RequestT, Nothing, ConnectionContext>(connectionId) {
+    ) : Event<RequestT, Nothing, ConnectionCookie>(connectionId) {
       override fun toString() =
-        "ConnectionInfo(connectionId=$connectionId, connectionContext=$connectionContext)"
+        "ConnectionInfo(connectionId=$connectionId, connectionCookie=$connectionCookie)"
     }
 
     /**
@@ -137,7 +137,7 @@ internal object GrpcBidiFlow {
       fun connectionStarting(
         method: MethodDescriptor<RequestT, ResponseT>,
         callOptions: CallOptions,
-        headers: GrpcMetadata,
+        headers: GrpcMetadata?,
       )
 
       fun sendingMessage(message: RequestT)
@@ -153,6 +153,11 @@ internal object GrpcBidiFlow {
       fun onCallClose(status: Status, trailers: GrpcMetadata, calculatedCause: Throwable?)
     }
   }
+
+  data class HeadersResult<ConnectionCookie>(
+    val headers: GrpcMetadata?,
+    val connectionCookie: ConnectionCookie,
+  )
 
   /**
    * Creates a cold [Flow] that executes a bidirectional streaming gRPC method.
@@ -176,15 +181,15 @@ internal object GrpcBidiFlow {
    * @return A cold flow of [Event]s.
    * @throws IllegalArgumentException if [method] is not a bidirectional streaming RPC.
    */
-  fun <RequestT, ResponseT, ConnectionContext> create(
+  fun <RequestT, ResponseT, ConnectionCookie> create(
     grpcChannel: GrpcChannel,
     method: MethodDescriptor<RequestT, ResponseT>,
     callOptions: CallOptions,
-    headers: (connectionId: String) -> Pair<GrpcMetadata, ConnectionContext>,
+    headers: (connectionId: String) -> HeadersResult<ConnectionCookie>,
     idStringGenerator: IdStringGenerator,
     initRequests: Iterable<RequestT> = emptyList(),
     listener: Listener<RequestT, ResponseT>? = null,
-  ): Flow<Event<RequestT, ResponseT, ConnectionContext>> {
+  ): Flow<Event<RequestT, ResponseT, ConnectionCookie>> {
     require(method.type == MethodDescriptor.MethodType.BIDI_STREAMING) {
       "method.type is ${method.type} but BIDI_STREAMING is required"
     }
@@ -209,8 +214,13 @@ internal object GrpcBidiFlow {
         }
       }
 
-      val (requestHeaders, connectionContext) = headers(connectionId).copy()
-      emit(Event.ConnectionInfo(connectionId, connectionContext, requestChannel.asSendChannel()))
+      val requestHeaders: GrpcMetadata?
+      val connectionCookie: ConnectionCookie
+      headers(connectionId).let { result ->
+        requestHeaders = result.headers?.copy()
+        connectionCookie = result.connectionCookie
+      }
+      emit(Event.ConnectionInfo(connectionId, connectionCookie, requestChannel.asSendChannel()))
 
       val clientCall: ClientCall<RequestT, ResponseT> = grpcChannel.newCall(method, callOptions)
       val readiness = Readiness(connectionId, clientCall)
@@ -392,7 +402,7 @@ internal class LoggingGrpcBidiFlowListener<RequestT, ResponseT>(
     override fun connectionStarting(
       method: MethodDescriptor<RequestT, ResponseT>,
       callOptions: CallOptions,
-      headers: GrpcMetadata,
+      headers: GrpcMetadata?,
     ) {
       logger.debug { formatter.connectionStarting(connectionId, method, callOptions, headers) }
     }
@@ -474,7 +484,7 @@ internal class PrintlnGrpcBidiFlowListener<RequestT, ResponseT>(
     override fun connectionStarting(
       method: MethodDescriptor<RequestT, ResponseT>,
       callOptions: CallOptions,
-      headers: GrpcMetadata,
+      headers: GrpcMetadata?,
     ) {
       println(formatter.connectionStarting(connectionId, method, callOptions, headers))
     }
@@ -527,10 +537,10 @@ internal class GrpcBidiFlowListenerMessageFormatter<RequestT, ResponseT>(
 ) {
 
   open class Formatter<RequestT, ResponseT> {
-    open fun connectionStartingHeaders(headers: GrpcMetadata): String = headers.toString()
-    open fun onCloseTrailers(trailers: GrpcMetadata): String = trailers.toString()
-    open fun request(message: RequestT): String = message.toString()
-    open fun response(message: ResponseT): String = message.toString()
+    open fun connectionStartingHeaders(headers: GrpcMetadata?): Any? = headers
+    open fun onCloseTrailers(trailers: GrpcMetadata): Any? = trailers
+    open fun request(message: RequestT): Any? = message
+    open fun response(message: ResponseT): Any? = message
   }
 
   fun collectStarted(connectionId: String): String = "collectStarted(cid=$connectionId)"
@@ -542,7 +552,7 @@ internal class GrpcBidiFlowListenerMessageFormatter<RequestT, ResponseT>(
     connectionId: String,
     method: MethodDescriptor<RequestT, ResponseT>,
     callOptions: CallOptions,
-    headers: GrpcMetadata,
+    headers: GrpcMetadata?,
   ): String {
     val formattedHeaders = formatter?.connectionStartingHeaders(headers) ?: headers
     return "[cid=$connectionId] connectionStarting(method=${method.fullMethodName}, " +

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/GrpcBidiFlow.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/GrpcBidiFlow.kt
@@ -77,7 +77,7 @@ internal object GrpcBidiFlow {
    * @property connectionId The "connectionId" to uniquely identify a connection to the remote
    * server, especially for correlation with invocations of [Listener.collectStarted].
    */
-  sealed class Event<in RequestT, out ResponseT>(val connectionId: String) {
+  sealed class Event<in RequestT, out ResponseT, out ConnectionContext>(val connectionId: String) {
     /**
      * Emitted once when the gRPC flow collection starts.
      *
@@ -87,11 +87,13 @@ internal object GrpcBidiFlow {
      * @param connectionId The unique identifier associated with this particular flow collection.
      * @property outgoingRequests The channel to send requests to the server.
      */
-    class ConnectionInfo<in RequestT>(
+    class ConnectionInfo<in RequestT, out ConnectionContext>(
       connectionId: String,
+      val connectionContext: ConnectionContext,
       val outgoingRequests: SendChannel<RequestT>,
-    ) : Event<RequestT, Nothing>(connectionId) {
-      override fun toString() = "ConnectionInfo(connectionId=$connectionId)"
+    ) : Event<RequestT, Nothing, ConnectionContext>(connectionId) {
+      override fun toString() =
+        "ConnectionInfo(connectionId=$connectionId, connectionContext=$connectionContext)"
     }
 
     /**
@@ -102,7 +104,7 @@ internal object GrpcBidiFlow {
     class Message<out ResponseT>(
       connectionId: String,
       val message: ResponseT,
-    ) : Event<Any?, ResponseT>(connectionId) {
+    ) : Event<Any?, ResponseT, Nothing>(connectionId) {
       override fun toString() = "Message(message=$message)"
     }
   }
@@ -174,15 +176,15 @@ internal object GrpcBidiFlow {
    * @return A cold flow of [Event]s.
    * @throws IllegalArgumentException if [method] is not a bidirectional streaming RPC.
    */
-  fun <RequestT, ResponseT> create(
+  fun <RequestT, ResponseT, ConnectionContext> create(
     grpcChannel: GrpcChannel,
     method: MethodDescriptor<RequestT, ResponseT>,
     callOptions: CallOptions,
-    headers: (connectionId: String) -> GrpcMetadata,
+    headers: (connectionId: String) -> Pair<GrpcMetadata, ConnectionContext>,
     idStringGenerator: IdStringGenerator,
     initRequests: Iterable<RequestT> = emptyList(),
     listener: Listener<RequestT, ResponseT>? = null,
-  ): Flow<Event<RequestT, ResponseT>> {
+  ): Flow<Event<RequestT, ResponseT, ConnectionContext>> {
     require(method.type == MethodDescriptor.MethodType.BIDI_STREAMING) {
       "method.type is ${method.type} but BIDI_STREAMING is required"
     }
@@ -207,8 +209,8 @@ internal object GrpcBidiFlow {
         }
       }
 
-      val requestHeaders = headers(connectionId).copy()
-      emit(Event.ConnectionInfo(connectionId, requestChannel.asSendChannel()))
+      val (requestHeaders, connectionContext) = headers(connectionId).copy()
+      emit(Event.ConnectionInfo(connectionId, connectionContext, requestChannel.asSendChannel()))
 
       val clientCall: ClientCall<RequestT, ResponseT> = grpcChannel.newCall(method, callOptions)
       val readiness = Readiness(connectionId, clientCall)

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/GrpcBidiFlow.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/GrpcBidiFlow.kt
@@ -19,6 +19,7 @@ package com.google.firebase.dataconnect.util
 import com.google.firebase.dataconnect.core.Logger
 import com.google.firebase.dataconnect.core.LoggerGlobals.debug
 import com.google.firebase.dataconnect.util.CoroutineUtils.asSendChannel
+import com.google.firebase.dataconnect.util.coroutines.ConflatedSignal
 import io.grpc.CallOptions
 import io.grpc.Channel as GrpcChannel
 import io.grpc.ClientCall
@@ -31,7 +32,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.onFailure
@@ -223,10 +223,14 @@ internal object GrpcBidiFlow {
       emit(Event.ConnectionInfo(connectionId, connectionCookie, requestChannel.asSendChannel()))
 
       val clientCall: ClientCall<RequestT, ResponseT> = grpcChannel.newCall(method, callOptions)
-      val readiness = Readiness(connectionId, clientCall)
-      suspend fun ClientCall<*, *>.suspendUntilReady() {
-        check(this === clientCall)
-        readiness.suspendUntilReady()
+
+      val clientCallReadySignal = ConflatedSignal()
+      suspend fun suspendUntilClientCallReady() {
+        // Spurious "ready" signals are possible, so check clientCall.isReady to verify.
+        // See the documentation for ClientCall.Listener.onReady() for details.
+        while (!clientCall.isReady) {
+          clientCallReadySignal.await()
+        }
       }
 
       /*
@@ -264,7 +268,7 @@ internal object GrpcBidiFlow {
 
           override fun onReady() {
             collectionListener?.onCallReady()
-            readiness.onReady()
+            clientCallReadySignal.signal()
           }
         },
         requestHeaders ?: GrpcMetadata(),
@@ -280,11 +284,11 @@ internal object GrpcBidiFlow {
         val sendJob =
           launch(CoroutineName("SendMessage worker for ${method.fullMethodName}")) {
             val sendingResult = runCatching {
-              clientCall.suspendUntilReady()
+              suspendUntilClientCallReady()
               for (request in requestChannel) {
                 collectionListener?.sendingMessage(request)
                 clientCall.sendMessage(request)
-                clientCall.suspendUntilReady()
+                suspendUntilClientCallReady()
               }
 
               collectionListener?.sendingMessagesComplete()
@@ -340,31 +344,6 @@ internal object GrpcBidiFlow {
               "for connectionId=$connectionId"
           )
         }
-      }
-    }
-  }
-
-  private class Readiness(
-    private val connectionId: String,
-    private val clientCall: ClientCall<*, *>,
-  ) {
-    // A CONFLATED channel never suspends to send, and two notifications of readiness are equivalent
-    // to one
-    private val channel = Channel<Unit>(CONFLATED)
-
-    fun onReady() {
-      channel.trySend(Unit).onFailure { exception ->
-        throw exception
-          ?: error(
-            "internal error p8sv8ctgws: channel.trySend(Unit) should not have failed " +
-              "because `channel` was created with capacity=CONFLATED; connectionId=$connectionId"
-          )
-      }
-    }
-
-    suspend fun suspendUntilReady() {
-      while (!clientCall.isReady) {
-        channel.receive()
       }
     }
   }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignal.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignal.kt
@@ -134,4 +134,6 @@ internal class ConflatedSignal {
       channel.receive()
     }
   }
+
+  override fun toString() = "ConflatedSignal(hasPendingSignal=$hasPendingSignal)"
 }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignal.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignal.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.dataconnect.util.coroutines
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
+
+/**
+ * A coroutine-based signaling mechanism that allows a waiter to suspend until notified by a sender,
+ * conflating multiple signals into one signal.
+ *
+ * This class is designed to coordinate execution flow between asynchronous operations (such as a
+ * producer and a consumer). A consumer call to [await] will suspend if no signal is available, and
+ * will resume immediately once a producer calls [signal].
+ *
+ * **Intended Use & Example Workflow:**
+ * 1. A background worker (sender) performs tasks in a loop, and calls [signal] after each task is
+ * complete.
+ * 2. A consumer (waiter) calls [await] to block/suspend its execution until the worker signals that
+ * some work is done.
+ *
+ * ### Key Behavioral Characteristics
+ *
+ * * **Single Signal Delivery:** If multiple coroutines are suspended in [await] then exactly _one_
+ * of them will be resumed upon [signal] being called. This is *not* a broadcast event or a
+ * `signalAll` style primitive.
+ * * **Signal Conflation:** The signal is conflated and persistent until consumed. If [signal] is
+ * called multiple times before any coroutine awaits, only a single signal permit is retained. The
+ * first subsequent call to [await] will consume the signal and resume immediately, while any
+ * further calls to [await] will suspend.
+ *
+ * ### Prompt cancellation guarantee
+ *
+ * All suspending functions in this class provide **prompt cancellation guarantee**. If the job was
+ * canceled while [await] was suspended, it will not resume successfully, even if it already
+ * received a signal, but throws a [CancellationException]. See the documentation regarding "Prompt
+ * cancellation guarantee" in [Channel] for further details.
+ *
+ * ### Safe for concurrent use
+ *
+ * All methods and properties of [ConflatedSignal] are thread-safe and may be safely called and/or
+ * accessed concurrently from multiple threads and/or coroutines.
+ */
+internal class ConflatedSignal {
+
+  private val channel = Channel<Unit>(CONFLATED)
+
+  /**
+   * Emits a signal to resume a suspended waiter, if one is present, or buffers the signal for the
+   * next waiter if none are currently awaiting.
+   *
+   * Because this signal is conflated, multiple sequential calls to [signal] without intervening
+   * calls to [await] will be merged into a single signal. Only one [await] call will be resumed
+   * immediately, regardless of how many times [signal] was called.
+   *
+   * This method is non-blocking, thread-safe, and safe to call from any context (including outside
+   * of coroutines).
+   */
+  fun signal() {
+    channel.trySend(Unit)
+  }
+
+  /**
+   * Suspends the calling coroutine until a signal is received via [signal].
+   *
+   * If a signal has already been emitted and not yet consumed, this method returns immediately,
+   * consuming that signal.
+   *
+   * ### Prompt cancellation guarantee
+   *
+   * This function provides **prompt cancellation guarantee**. That is, if the job is canceled while
+   * [await] is suspended, it will not resume successfully, even if it consumed a signal, but throws
+   * a [CancellationException].
+   *
+   * ### Concurrent Waiters
+   *
+   * If multiple coroutines are concurrently suspended in [await], only one of them, chosen in an
+   * indeterminate manner, will be resumed when [signal] is called.
+   */
+  suspend fun await() {
+    channel.receive()
+  }
+}

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignal.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignal.kt
@@ -20,37 +20,37 @@ import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 
 /**
  * A coroutine-based signaling mechanism that allows a waiter to suspend until notified by a sender,
  * conflating multiple signals into one signal.
  *
  * This class is designed to coordinate execution flow between asynchronous operations (such as a
- * producer and a consumer). A consumer call to [await] will suspend if no signal is available, and
- * will resume immediately once a producer calls [signal].
- *
- * **Intended Use & Example Workflow:**
- * 1. A background worker (sender) performs tasks in a loop, and calls [signal] after each task is
- * complete.
- * 2. A consumer (waiter) calls [await] to block/suspend its execution until the worker signals that
- * some work is done.
+ * producer and a consumer). A consumer can wait for a signal either by calling the suspending
+ * method [await] or by collecting from the [signals] flow. In both cases, the consumer will resume
+ * immediately once a producer calls [signal].
  *
  * ### Key Behavioral Characteristics
  *
- * * **Single Signal Delivery:** If multiple coroutines are suspended in [await] then exactly _one_
- * of them will be resumed upon [signal] being called. This is *not* a broadcast event or a
- * `signalAll` style primitive.
+ * * **Single Signal Delivery / Competing Consumers:** If multiple coroutines are waiting for a
+ * signal, whether they are suspended in [await] or collecting from the [signals] flow, then exactly
+ * _one_ of them will be resumed/notified upon [signal] being called, chosen indeterminately. This
+ * is *not* a broadcast event or a `signalAll` style primitive. Waiters and flow collectors
+ * **compete** for signals.
  * * **Signal Conflation:** The signal is conflated and persistent until consumed. If [signal] is
- * called multiple times before any coroutine awaits, only a single signal permit is retained. The
- * first subsequent call to [await] will consume the signal and resume immediately, while any
- * further calls to [await] will suspend.
+ * called multiple times before any coroutine awaits, only a single signal is retained. The first
+ * subsequent waiter (either via [await] or [signals] collection) will consume the signal and resume
+ * immediately, while any further waiters will suspend.
  *
  * ### Prompt cancellation guarantee
  *
- * All suspending functions in this class provide **prompt cancellation guarantee**. If the job was
- * canceled while [await] was suspended, it will not resume successfully, even if it already
- * received a signal, but throws a [CancellationException]. See the documentation regarding "Prompt
- * cancellation guarantee" in [Channel] for further details.
+ * All suspending functions and flows in this class provide a **prompt cancellation guarantee**. If
+ * the job was canceled while suspended in [await] (or while collecting from [signals]), it will not
+ * resume successfully, even if it already received a signal, but will throw [CancellationException]
+ * . See the documentation regarding "Prompt cancellation guarantee" in [Channel] for further
+ * details.
  *
  * ### Safe for concurrent use
  *
@@ -63,8 +63,29 @@ internal class ConflatedSignal {
   private val channel = Channel<Unit>(CONFLATED)
 
   /**
+   * A cold [Flow] that emits [Unit] every time a signal is received.
+   *
+   * ### Important Concurrency & Competing-Consumer Semantics
+   *
+   * This is a **competing-consumer** flow. Because [ConflatedSignal] only resumes one waiter per
+   * signal, collectors of this flow **compete** for signals with each other and with direct callers
+   * of [await].
+   *
+   * Specifically, if multiple collectors are actively collecting this flow concurrently, or if some
+   * coroutines are suspended in [await], a single call to [signal] will notify exactly **one** of
+   * them (either resuming a direct [await] caller or emitting to a single flow collector). It will
+   * *not* broadcast the signal to all collectors.
+   */
+  val signals: Flow<Unit> = flow {
+    while (true) {
+      await()
+      emit(Unit)
+    }
+  }
+
+  /**
    * Whether there is a pending signal from a call to [signal] that has not yet been consumed by a
-   * call to [await].
+   * call to [await] or a collector of [signals].
    */
   val hasPendingSignal: Boolean
     get() = signalState.get()
@@ -74,8 +95,9 @@ internal class ConflatedSignal {
    * next waiter if none are currently awaiting.
    *
    * Because this signal is conflated, multiple sequential calls to [signal] without intervening
-   * calls to [await] will be merged into a single signal. Only one [await] call will be resumed
-   * immediately, regardless of how many times [signal] was called.
+   * calls to [await] (or collectors of [signal]) will be merged into a single signal. Only one
+   * [await] call (or [signals] collector) will be resumed immediately, regardless of how many times
+   * [signal] was called.
    *
    * This method is non-blocking, thread-safe, and safe to call from any context (including outside
    * of coroutines).
@@ -91,16 +113,18 @@ internal class ConflatedSignal {
    * If a signal has already been emitted and not yet consumed, this method returns immediately,
    * consuming that signal.
    *
+   * ### Important Concurrency & Competing-Consumer Semantics
+   *
+   * Direct callers of [await] **compete** for signals with each other and with active collectors of
+   * the [signals] flow. Specifically, if multiple coroutines are waiting (either suspended in
+   * [await] or collecting from [signals]), a single call to [signal] will resume/notify exactly
+   * **one** of them, chosen indeterminately. It will *not* broadcast the signal to all.
+   *
    * ### Prompt cancellation guarantee
    *
    * This function provides **prompt cancellation guarantee**. That is, if the job is canceled while
    * [await] is suspended, it will not resume successfully, even if it consumed a signal, but throws
    * a [CancellationException].
-   *
-   * ### Concurrent Waiters
-   *
-   * If multiple coroutines are concurrently suspended in [await], only one of them, chosen in an
-   * indeterminate manner, will be resumed when [signal] is called.
    */
   suspend fun await() {
     while (true) {

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignal.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignal.kt
@@ -16,6 +16,7 @@
 
 package com.google.firebase.dataconnect.util.coroutines
 
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
@@ -58,7 +59,15 @@ import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
  */
 internal class ConflatedSignal {
 
+  private val signalState = AtomicBoolean(false)
   private val channel = Channel<Unit>(CONFLATED)
+
+  /**
+   * Whether there is a pending signal from a call to [signal] that has not yet been consumed by a
+   * call to [await].
+   */
+  val hasPendingSignal: Boolean
+    get() = signalState.get()
 
   /**
    * Emits a signal to resume a suspended waiter, if one is present, or buffers the signal for the
@@ -72,6 +81,7 @@ internal class ConflatedSignal {
    * of coroutines).
    */
   fun signal() {
+    signalState.set(true)
     channel.trySend(Unit)
   }
 
@@ -93,6 +103,11 @@ internal class ConflatedSignal {
    * indeterminate manner, will be resumed when [signal] is called.
    */
   suspend fun await() {
-    channel.receive()
+    while (true) {
+      if (signalState.compareAndSet(true, false)) {
+        break
+      }
+      channel.receive()
+    }
   }
 }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RealtimeQuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RealtimeQuerySubscriptionImplUnitTest.kt
@@ -287,27 +287,47 @@ class RealtimeQuerySubscriptionImplUnitTest {
 
   @Test
   fun `cancel message is sent after last unsubscription for a query`() = runTest {
-    val operationName = Arb.dataConnect.operationName().sample()
-    val variables = testVariablesArb().sample()
+    val subscriptionParameters =
+      distinctOperationNameVariablesPairWithRepeatedComponentsArb().sampleList(10)
     val server = runningInProcessDataConnectServer()
     val dataConnect = dataConnect(server)
-    val subscriptions = List(10) { querySubscription(dataConnect, operationName, variables) }
+    val subscriptions =
+      subscriptionParameters.map { querySubscription(dataConnect, it.operationName, it.variables) }
 
     turbineScope {
       val serverCollector = server.events.testIn(backgroundScope, name = "serverCollector")
       val clientCollectors =
-        subscriptions.mapIndexed { index, subscription ->
-          subscription.flow.testIn(backgroundScope, name = "clientCollector$index")
+        List(2) {
+          subscriptions
+            .mapIndexed { index, subscription ->
+              subscription.flow.testIn(backgroundScope, name = "clientCollector$index")
+            }
+            .shuffled(rs.random)
+        }
+      val requestIds =
+        MutableList(subscriptions.size) {
+          serverCollector.awaitUntilSubscribeStreamRequest().streamRequest.requestId
         }
 
-      serverCollector.awaitUntilInitStreamRequest()
-      val subscribeRequest = serverCollector.awaitUntilSubscribeStreamRequest()
-      check(subscribeRequest.streamRequest.hasSubscribe())
+      clientCollectors[0].forEach { clientCollector ->
+        clientCollector.cancelAndIgnoreRemainingEvents()
+      }
+      while (true) {
+        yield()
+        val event = serverCollector.asChannel().tryReceive().getOrNull() ?: break
+        if (event is StreamRequestReceived) {
+          event.streamRequest.requestKindCase shouldNotBe RequestKindCase.CANCEL
+        }
+      }
 
-      clientCollectors.forEach { it.cancelAndIgnoreRemainingEvents() }
-
-      val cancelRequest = serverCollector.awaitUntilCancelStreamRequest()
-      cancelRequest.streamRequest.requestId shouldBe subscribeRequest.streamRequest.requestId
+      // Specify drop(1) so that we don't close the very last connection as that will shut down
+      // the entire connection, confusing the logic below.
+      clientCollectors[1].drop(1).forEach { clientCollector ->
+        clientCollector.cancelAndIgnoreRemainingEvents()
+        val requestId = serverCollector.awaitUntilCancelStreamRequest().streamRequest.requestId
+        requestId shouldBeIn requestIds
+        requestIds.removeAt(requestIds.indexOf(requestId))
+      }
 
       serverCollector.cancelAndIgnoreRemainingEvents()
     }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RealtimeQuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RealtimeQuerySubscriptionImplUnitTest.kt
@@ -80,11 +80,13 @@ import io.mockk.mockk
 import io.mockk.spyk
 import kotlin.random.Random
 import kotlinx.coroutines.asExecutor
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializer
 import org.junit.Assume.assumeTrue
@@ -246,24 +248,40 @@ class RealtimeQuerySubscriptionImplUnitTest {
 
     turbineScope {
       val serverCollector = server.events.testIn(backgroundScope, name = "serverCollector")
-      val clientCollectors =
-        subscriptions.mapIndexed { index, subscription ->
-          subscription.flow.testIn(backgroundScope, name = "clientCollector$index")
-        }
+      val clientCollector0 =
+        subscriptions[0].flow.testIn(backgroundScope, name = "clientCollector0")
 
-      serverCollector.awaitUntilInitStreamRequest()
+      val responseObserver = serverCollector.awaitConnectRpcStarted().responseObserver
       val subscribeRequest = serverCollector.awaitUntilSubscribeStreamRequest()
-      subscribeRequest.streamRequest.requestId shouldBeIn requestIds
-      subscribeRequest.streamRequest.requestKindCase shouldBe RequestKindCase.SUBSCRIBE
-      repeat(subscriptions.size - 1) {
-        val resumeRequest: StreamRequestReceived = serverCollector.awaitUntilItemIsInstance()
-        resumeRequest.connectionId shouldBe subscribeRequest.connectionId
-        resumeRequest.streamRequest.requestId shouldBe subscribeRequest.streamRequest.requestId
-        resumeRequest.streamRequest.requestKindCase shouldBe RequestKindCase.RESUME
+      val testData = testDataArb().let { arb -> List(requestIds.size) { arb.sample() } }
+      val respondJob = launch {
+        val requestId = subscribeRequest.streamRequest.requestId
+        val testDataIterator = testData.iterator()
+        while (true) {
+          responseObserver.onNext(requestId, testDataIterator.next())
+          val resumeRequest = serverCollector.awaitUntilResumeStreamRequest()
+          resumeRequest.connectionId shouldBe subscribeRequest.connectionId
+          resumeRequest.streamRequest.requestId shouldBe subscribeRequest.streamRequest.requestId
+          resumeRequest.streamRequest.requestKindCase shouldBe RequestKindCase.RESUME
+        }
       }
 
-      serverCollector.cancelAndIgnoreRemainingEvents()
+      subscribeRequest.streamRequest.requestId shouldBeIn requestIds
+      subscribeRequest.streamRequest.requestKindCase shouldBe RequestKindCase.SUBSCRIBE
+      clientCollector0.awaitItem()
+      val clientCollectors =
+        subscriptions.drop(1).mapIndexed { index, subscription ->
+          if (rs.random.nextBoolean()) yield() // let some of the resume requests coalesce
+          subscription.flow.testIn(backgroundScope, name = "clientCollector${index+1}")
+        }
+      clientCollectors.forEach { clientCollector ->
+        clientCollector.awaitItem().result.shouldBeSuccess().data shouldBeIn testData
+      }
+
       clientCollectors.forEach { it.cancelAndIgnoreRemainingEvents() }
+      respondJob.cancelAndJoin()
+      clientCollector0.cancelAndIgnoreRemainingEvents()
+      serverCollector.cancelAndIgnoreRemainingEvents()
     }
   }
 

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RealtimeQuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RealtimeQuerySubscriptionImplUnitTest.kt
@@ -507,19 +507,28 @@ class RealtimeQuerySubscriptionImplUnitTest {
   }
 
   @Test
-  fun `flow completes if server complete the RPC mid-stream`() = runTest {
+  fun `flow retries if server completes the RPC gracefully mid-stream`() = runTest {
     val server = runningInProcessDataConnectServer()
     val dataConnect = dataConnect(server)
     val subscription = querySubscription(dataConnect)
+    val testData = testDataArb().sample()
 
     turbineScope {
       val serverCollector = server.events.testIn(backgroundScope, name = "serverCollector")
       val clientCollector = subscription.flow.testIn(backgroundScope, name = "clientCollector1")
-      val responseSender = serverCollector.awaitResponseSender()
-      serverCollector.awaitUntilSubscribeStreamRequest()
-      responseSender.onCompleted()
+      serverCollector.awaitResponseSender().let { responseSender ->
+        serverCollector.awaitUntilSubscribeStreamRequest()
+        responseSender.onCompleted()
+      }
 
-      clientCollector.awaitComplete()
+      // Client should restart the connection since the closure was unprovoked and unexpected.
+      serverCollector.awaitResponseSender().let { responseSender ->
+        val requestId = serverCollector.awaitUntilSubscribeStreamRequest().streamRequest.requestId
+        responseSender.onNext(requestId, testData)
+        clientCollector.awaitItem().result.shouldBeSuccess().data shouldBe testData
+      }
+
+      clientCollector.cancelAndIgnoreRemainingEvents()
       serverCollector.cancelAndIgnoreRemainingEvents()
     }
   }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RealtimeQuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RealtimeQuerySubscriptionImplUnitTest.kt
@@ -41,10 +41,10 @@ import com.google.firebase.dataconnect.testutil.awaitConnectRpcStarted
 import com.google.firebase.dataconnect.testutil.awaitResponseSender
 import com.google.firebase.dataconnect.testutil.awaitUntilCancelStreamRequest
 import com.google.firebase.dataconnect.testutil.awaitUntilInitStreamRequest
-import com.google.firebase.dataconnect.testutil.awaitUntilItem
 import com.google.firebase.dataconnect.testutil.awaitUntilItemIsInstance
 import com.google.firebase.dataconnect.testutil.awaitUntilResumeStreamRequest
 import com.google.firebase.dataconnect.testutil.awaitUntilStatusExceptionReceived
+import com.google.firebase.dataconnect.testutil.awaitUntilStreamRequest
 import com.google.firebase.dataconnect.testutil.awaitUntilStreamRequestWithRequestId
 import com.google.firebase.dataconnect.testutil.awaitUntilSubscribeStreamRequest
 import com.google.firebase.dataconnect.testutil.property.arbitrary.dataConnect
@@ -74,6 +74,7 @@ import io.kotest.property.arbitrary.distinct
 import io.kotest.property.arbitrary.enum
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.next
 import io.kotest.property.arbitrary.string
 import io.mockk.every
 import io.mockk.mockk
@@ -254,17 +255,18 @@ class RealtimeQuerySubscriptionImplUnitTest {
       val responseObserver = serverCollector.awaitConnectRpcStarted().responseObserver
       val subscribeRequest = serverCollector.awaitUntilSubscribeStreamRequest()
       val testData = testDataArb().let { arb -> List(requestIds.size) { arb.sample() } }
-      val respondJob = launch {
-        val requestId = subscribeRequest.streamRequest.requestId
-        val testDataIterator = testData.iterator()
-        while (true) {
-          responseObserver.onNext(requestId, testDataIterator.next())
-          val resumeRequest = serverCollector.awaitUntilResumeStreamRequest()
-          resumeRequest.connectionId shouldBe subscribeRequest.connectionId
-          resumeRequest.streamRequest.requestId shouldBe subscribeRequest.streamRequest.requestId
-          resumeRequest.streamRequest.requestKindCase shouldBe RequestKindCase.RESUME
+      val respondJob =
+        backgroundScope.launch {
+          val requestId = subscribeRequest.streamRequest.requestId
+          val testDataIterator = testData.iterator()
+          while (true) {
+            responseObserver.onNext(requestId, testDataIterator.next())
+            val resumeRequest = serverCollector.awaitUntilResumeStreamRequest()
+            resumeRequest.connectionId shouldBe subscribeRequest.connectionId
+            resumeRequest.streamRequest.requestId shouldBe subscribeRequest.streamRequest.requestId
+            resumeRequest.streamRequest.requestKindCase shouldBe RequestKindCase.RESUME
+          }
         }
-      }
 
       subscribeRequest.streamRequest.requestId shouldBeIn requestIds
       subscribeRequest.streamRequest.requestKindCase shouldBe RequestKindCase.SUBSCRIBE
@@ -384,6 +386,7 @@ class RealtimeQuerySubscriptionImplUnitTest {
       repeat(size / 2) { add(get(it)) } // Add some duplicate subscriptions
       shuffle(rs.random)
     }
+    val testData = testDataArb().let { arb -> List(subscriptions.size) { arb.next(rs) } }
 
     turbineScope {
       val serverCollector = server.events.testIn(backgroundScope, name = "serverCollector")
@@ -392,14 +395,19 @@ class RealtimeQuerySubscriptionImplUnitTest {
           subscription.flow.testIn(backgroundScope, name = "clientCollector$index")
         }
 
-      repeat(subscriptions.size) {
-        serverCollector.awaitUntilItem {
-          it is StreamRequestReceived &&
-            it.streamRequest.let { streamRequest ->
-              streamRequest.hasSubscribe() || streamRequest.hasResume()
+      val respondJob =
+        backgroundScope.launch {
+          val responseObserver = serverCollector.awaitConnectRpcStarted().responseObserver
+          val testDataIterator = testData.iterator()
+          while (true) {
+            val streamRequest = serverCollector.awaitUntilStreamRequest().streamRequest
+            if (streamRequest.hasSubscribe() || streamRequest.hasResume()) {
+              responseObserver.onNext(streamRequest.requestId, testDataIterator.next())
             }
+          }
         }
-      }
+      clientCollectors.forEach { clientCollector -> clientCollector.awaitItem() }
+      respondJob.cancelAndJoin()
 
       clientCollectors.forEach { it.cancelAndIgnoreRemainingEvents() }
       serverCollector.awaitUntilClientClosesConnection()

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RealtimeQuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RealtimeQuerySubscriptionImplUnitTest.kt
@@ -509,42 +509,46 @@ class RealtimeQuerySubscriptionImplUnitTest {
   }
 
   @Test
-  fun `flow retries if server completes the RPC gracefully mid-stream`() =
-    testFlowReconnectsUponConnectionClosure {
-      it.onCompleted()
-    }
+  fun `flow retries if server completes the RPC gracefully mid-stream`() = runTest {
+    testFlowReconnectsUponConnectionClosure { it.onCompleted() }
+  }
 
   @Test
-  fun `flow retries if server aborts the RPC mid-stream with StatusException`() {
-    Status.Code.entries.forEach { code ->
-      withClue("code=$code") {
-        testFlowReconnectsUponConnectionClosure { it.onError(StatusException(code.toStatus())) }
-      }
+  fun `flow retries if server aborts the RPC mid-stream with StatusException`() = runTest {
+    testFlowReconnectsUponConnectionClosureWithGrpcFailureStatusCode {
+      StatusException(it.toStatus())
     }
   }
 
   @Test
-  fun `flow retries if server aborts the RPC mid-stream with StatusRuntimeException`() {
-    Status.Code.entries.forEach { code ->
-      withClue("code=$code") {
-        testFlowReconnectsUponConnectionClosure {
-          it.onError(StatusRuntimeException(code.toStatus()))
-        }
-      }
+  fun `flow retries if server aborts the RPC mid-stream with StatusRuntimeException`() = runTest {
+    testFlowReconnectsUponConnectionClosureWithGrpcFailureStatusCode {
+      StatusRuntimeException(it.toStatus())
     }
   }
 
   @Test
-  fun `flow retries if server aborts with a non-grpc Exception`() {
+  fun `flow retries if server aborts with a non-grpc Exception`() = runTest {
     class TestException(message: String) : Exception(message)
     testFlowReconnectsUponConnectionClosure {
       it.onError(TestException(Arb.dataConnect.string().sample()))
     }
   }
 
-  private fun testFlowReconnectsUponConnectionClosure(
+  private suspend fun TestScope.testFlowReconnectsUponConnectionClosureWithGrpcFailureStatusCode(
+    createException: (Status.Code) -> Throwable
+  ) {
+    failureGrpcStatusCodes.forEach { code ->
+      withClue("code=$code") {
+        val exception = createException(code)
+        testFlowReconnectsUponConnectionClosure { it.onError(exception) }
+      }
+    }
+  }
+
+  private suspend fun TestScope.testFlowReconnectsUponConnectionClosure(
     abort: (StreamObserver<StreamResponse>) -> Unit
-  ) = runTest {
+  ) {
     val server = runningInProcessDataConnectServer()
     val dataConnect = dataConnect(server)
     val subscription = querySubscription(dataConnect)
@@ -582,11 +586,10 @@ class RealtimeQuerySubscriptionImplUnitTest {
       val server1Collector = server1.events.testIn(backgroundScope, name = "server1Collector")
       val server2Collector = server2.events.testIn(backgroundScope, name = "server2Collector")
       val clientCollector = subscription.flow.testIn(backgroundScope, name = "clientCollector1")
-      server1Collector.awaitResponseSender().let { responseSender ->
-        server1Collector.awaitUntilSubscribeStreamRequest()
-        server1.close()
-        server2.open(server1.port)
-      }
+      server1Collector.awaitConnectRpcStarted()
+      server1Collector.awaitUntilSubscribeStreamRequest()
+      server1.close()
+      server2.open(server1.port)
 
       server2Collector.awaitResponseSender().let { responseSender ->
         val requestId = server2Collector.awaitUntilSubscribeStreamRequest().streamRequest.requestId
@@ -765,3 +768,6 @@ private fun distinctOperationNameVariablesPairWithRepeatedComponentsArb(
 private fun StreamObserver<StreamResponse>.onNext(requestId: String, data: TestData) {
   onNext(StreamResponse.newBuilder().setRequestId(requestId).setData(encodeToStruct(data)).build())
 }
+
+private val failureGrpcStatusCodes: List<Status.Code> =
+  Status.Code.entries.filterNot { it == Status.Code.OK }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RealtimeQuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RealtimeQuerySubscriptionImplUnitTest.kt
@@ -56,6 +56,8 @@ import google.firebase.dataconnect.proto.StreamRequest
 import google.firebase.dataconnect.proto.StreamRequest.RequestKindCase
 import google.firebase.dataconnect.proto.StreamResponse
 import io.grpc.Status
+import io.grpc.StatusException
+import io.grpc.StatusRuntimeException
 import io.grpc.stub.StreamObserver
 import io.kotest.assertions.print.print
 import io.kotest.assertions.withClue
@@ -507,7 +509,42 @@ class RealtimeQuerySubscriptionImplUnitTest {
   }
 
   @Test
-  fun `flow retries if server completes the RPC gracefully mid-stream`() = runTest {
+  fun `flow retries if server completes the RPC gracefully mid-stream`() =
+    testFlowReconnectsUponConnectionClosure {
+      it.onCompleted()
+    }
+
+  @Test
+  fun `flow retries if server aborts the RPC mid-stream with StatusException`() {
+    Status.Code.entries.forEach { code ->
+      withClue("code=$code") {
+        testFlowReconnectsUponConnectionClosure { it.onError(StatusException(code.toStatus())) }
+      }
+    }
+  }
+
+  @Test
+  fun `flow retries if server aborts the RPC mid-stream with StatusRuntimeException`() {
+    Status.Code.entries.forEach { code ->
+      withClue("code=$code") {
+        testFlowReconnectsUponConnectionClosure {
+          it.onError(StatusRuntimeException(code.toStatus()))
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `flow retries if server aborts with a non-grpc Exception`() {
+    class TestException(message: String) : Exception(message)
+    testFlowReconnectsUponConnectionClosure {
+      it.onError(TestException(Arb.dataConnect.string().sample()))
+    }
+  }
+
+  private fun testFlowReconnectsUponConnectionClosure(
+    abort: (StreamObserver<StreamResponse>) -> Unit
+  ) = runTest {
     val server = runningInProcessDataConnectServer()
     val dataConnect = dataConnect(server)
     val subscription = querySubscription(dataConnect)
@@ -518,10 +555,9 @@ class RealtimeQuerySubscriptionImplUnitTest {
       val clientCollector = subscription.flow.testIn(backgroundScope, name = "clientCollector1")
       serverCollector.awaitResponseSender().let { responseSender ->
         serverCollector.awaitUntilSubscribeStreamRequest()
-        responseSender.onCompleted()
+        abort(responseSender)
       }
 
-      // Client should restart the connection since the closure was unprovoked and unexpected.
       serverCollector.awaitResponseSender().let { responseSender ->
         val requestId = serverCollector.awaitUntilSubscribeStreamRequest().streamRequest.requestId
         responseSender.onNext(requestId, testData)
@@ -530,6 +566,37 @@ class RealtimeQuerySubscriptionImplUnitTest {
 
       clientCollector.cancelAndIgnoreRemainingEvents()
       serverCollector.cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun `flow retries if server connection is lost`() = runTest {
+    val server1 = runningInProcessDataConnectServer()
+    val server2 = InProcessDataConnectGrpcStreamingServer()
+    cleanups.register(server2)
+    val dataConnect = dataConnect(server1)
+    val subscription = querySubscription(dataConnect)
+    val testData = testDataArb().sample()
+
+    turbineScope {
+      val server1Collector = server1.events.testIn(backgroundScope, name = "server1Collector")
+      val server2Collector = server2.events.testIn(backgroundScope, name = "server2Collector")
+      val clientCollector = subscription.flow.testIn(backgroundScope, name = "clientCollector1")
+      server1Collector.awaitResponseSender().let { responseSender ->
+        server1Collector.awaitUntilSubscribeStreamRequest()
+        server1.close()
+        server2.open(server1.port)
+      }
+
+      server2Collector.awaitResponseSender().let { responseSender ->
+        val requestId = server2Collector.awaitUntilSubscribeStreamRequest().streamRequest.requestId
+        responseSender.onNext(requestId, testData)
+        clientCollector.awaitItem().result.shouldBeSuccess().data shouldBe testData
+      }
+
+      clientCollector.cancelAndIgnoreRemainingEvents()
+      server2Collector.cancelAndIgnoreRemainingEvents()
+      server1Collector.cancelAndIgnoreRemainingEvents()
     }
   }
 

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/querymgr/RealtimeQueryManagerUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/querymgr/RealtimeQueryManagerUnitTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.dataconnect.querymgr
+
+import com.google.firebase.dataconnect.ExperimentalRealtimeQueries
+import com.google.firebase.dataconnect.FirebaseDataConnect.CallerSdkType
+import com.google.firebase.dataconnect.core.DataConnectGrpcClient
+import com.google.firebase.dataconnect.core.DataConnectSerialization
+import com.google.firebase.dataconnect.testutil.RandomSeedTestRule
+import com.google.firebase.dataconnect.testutil.SuspendingCountDownLatch
+import com.google.firebase.dataconnect.testutil.newMockLogger
+import com.google.firebase.dataconnect.testutil.property.arbitrary.dataConnect
+import com.google.firebase.dataconnect.util.IdStringGenerator
+import com.google.firebase.dataconnect.util.SequencedReference.Companion.nextSequenceNumber
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldBeUnique
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.property.Arb
+import io.kotest.property.RandomSource
+import io.kotest.property.arbitrary.Codepoint
+import io.kotest.property.arbitrary.az
+import io.kotest.property.arbitrary.enum
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.string
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.serializer
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalRealtimeQueries::class)
+class RealtimeQueryManagerUnitTest {
+
+  @get:Rule(order = Int.MIN_VALUE) val randomSeedTestRule = RandomSeedTestRule()
+  private val rs: RandomSource by randomSeedTestRule.rs
+
+  @Serializable private data class TestVariables(val string: String)
+
+  private val stringArb: Arb<String> = Arb.string(size = 4, Codepoint.az())
+  private val testVariablesArb: Arb<TestVariables> = stringArb.map(::TestVariables)
+
+  private fun <T> Arb<T>.sample(): T = sample(rs).value
+
+  @Test
+  fun `subscribe() should allow subsequent calls to re-try the connection`() = runTest {
+    val grpcClient: DataConnectGrpcClient = mockk()
+    val realtimeQueryManager =
+      RealtimeQueryManager(
+        grpcClient = grpcClient,
+        coroutineScope = backgroundScope,
+        idStringGenerator = IdStringGenerator(rs.random),
+        serialization = DataConnectSerialization(StandardTestDispatcher(testScheduler)),
+        logger = newMockLogger("s78hgm6fff")
+      )
+
+    class TestException(message: String) : Exception(message)
+    coEvery { grpcClient.connect(any(), any(), any(), any()) } answers
+      {
+        throw TestException("simulated connection failure ${nextSequenceNumber()} mxrceswed8")
+      }
+
+    val exceptions =
+      List(5) {
+        shouldThrow<TestException> {
+          realtimeQueryManager.subscribe(
+            operationName = "operationName-${stringArb.sample()}",
+            variables = testVariablesArb.sample(),
+            dataDeserializer = serializer<Unit>(),
+            variablesSerializer = serializer<TestVariables>(),
+            callerSdkType = Arb.enum<CallerSdkType>().sample(),
+            dataSerializersModule = Arb.dataConnect.serializersModule().sample(),
+            variablesSerializersModule = Arb.dataConnect.serializersModule().sample(),
+          )
+        }
+      }
+
+    exceptions.map { it.message }.shouldBeUnique()
+  }
+
+  @Test
+  fun `subscribe() should conflate concurrent failing calls`() = runTest {
+    val grpcClient: DataConnectGrpcClient = mockk()
+    val realtimeQueryManager =
+      RealtimeQueryManager(
+        grpcClient = grpcClient,
+        coroutineScope = backgroundScope,
+        idStringGenerator = IdStringGenerator(rs.random),
+        serialization = DataConnectSerialization(StandardTestDispatcher(testScheduler)),
+        logger = newMockLogger("yzrpk2m6tt")
+      )
+
+    class TestException(message: String) : Exception(message)
+    coEvery { grpcClient.connect(any(), any(), any(), any()) } answers
+      {
+        throw TestException("simulated connection failure ${nextSequenceNumber()} ddx8543vf9")
+      }
+
+    val latch = SuspendingCountDownLatch(50)
+    val jobs =
+      List(latch.count) {
+        backgroundScope.async(Dispatchers.Default) {
+          latch.countDown().await()
+          shouldThrow<TestException> {
+            realtimeQueryManager.subscribe(
+              operationName = "operationName-${stringArb.sample()}",
+              variables = testVariablesArb.sample(),
+              dataDeserializer = serializer<Unit>(),
+              variablesSerializer = serializer<TestVariables>(),
+              callerSdkType = Arb.enum<CallerSdkType>().sample(),
+              dataSerializersModule = Arb.dataConnect.serializersModule().sample(),
+              variablesSerializersModule = Arb.dataConnect.serializersModule().sample(),
+            )
+          }
+        }
+      }
+
+    // There should be fewer distinct exception messages than the number of jobs because some of
+    // the subscribe() requests should conflate/share their calls to subscribe().
+    val distinctExceptionMessages = jobs.awaitAll().map { it.message }.distinct()
+    distinctExceptionMessages.size shouldBeLessThan jobs.size
+  }
+}

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/testutil/InProcessDataConnectGrpcStreamingServer.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/testutil/InProcessDataConnectGrpcStreamingServer.kt
@@ -172,17 +172,20 @@ class InProcessDataConnectGrpcStreamingServer : AutoCloseable {
    * Opens and starts the gRPC server. If the server is already opened, it blocks until it is fully
    * started and returns the instance.
    *
+   * @param port The TCP port to which to bind; a value of 0 (the default) picks a random available
+   * port, whose value can be retrieved from the [port] property of this object after this method
+   * returns, or the [Server.getPort] method of the returned server.
    * @return The started gRPC [Server] instance.
    * @throws IllegalStateException if [close] has been called.
    */
-  fun open(): Server {
+  fun open(port: Int = 0): Server {
     while (true) {
       when (val currentState = state.get()) {
         is State.Unopened -> {
           val future = CompletableFuture<Unit>()
           val eventHandler = EventHandler(_events, listener)
           val server =
-            OkHttpServerBuilder.forPort(0, InsecureServerCredentials.create())
+            OkHttpServerBuilder.forPort(port, InsecureServerCredentials.create())
               .addService(ConnectorStreamingServiceImpl(eventHandler))
               .intercept(ServerInterceptorImpl(eventHandler))
               .build()

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignalUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignalUnitTest.kt
@@ -16,6 +16,8 @@
 
 package com.google.firebase.dataconnect.util.coroutines
 
+import app.cash.turbine.test
+import app.cash.turbine.turbineScope
 import com.google.firebase.dataconnect.testutil.RandomSeedTestRule
 import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldHaveSize
@@ -148,6 +150,89 @@ class ConflatedSignalUnitTest {
     repeat(100) {
       signal.hasPendingSignal shouldBe false
       yield()
+    }
+  }
+
+  @Test
+  fun `signals flow emits immediately if there is a pending signal`() = runTest {
+    val signal = ConflatedSignal()
+    signal.signal()
+
+    signal.signals.test {
+      awaitItem() shouldBe Unit
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun `signals flow collection suspends if there is NO pending signal`() = runTest {
+    val signal = ConflatedSignal()
+
+    val job =
+      backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { signal.signals.collect {} }
+
+    job.isCompleted shouldBe false
+  }
+
+  @Test
+  fun `signals flow emits when signal is called`() = runTest {
+    val signal = ConflatedSignal()
+
+    signal.signals.test {
+      signal.signal()
+      awaitItem() shouldBe Unit
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun `multiple signals are conflated in the signals flow`() = runTest {
+    val signal = ConflatedSignal()
+    repeat(10) { signal.signal() }
+
+    signal.signals.test {
+      awaitItem() shouldBe Unit
+      expectNoEvents()
+    }
+  }
+
+  @Test
+  fun `multiple collectors of signals flow compete for signals`() = runTest {
+    val signal = ConflatedSignal()
+
+    turbineScope {
+      val collector1 = signal.signals.testIn(backgroundScope, name = "collector1")
+      val collector2 = signal.signals.testIn(backgroundScope, name = "collector2")
+
+      signal.signal()
+      yield()
+
+      val events1 = collector1.cancelAndConsumeRemainingEvents()
+      val events2 = collector2.cancelAndConsumeRemainingEvents()
+
+      val itemsCount1 = events1.count { it is app.cash.turbine.Event.Item }
+      val itemsCount2 = events2.count { it is app.cash.turbine.Event.Item }
+      (itemsCount1 + itemsCount2) shouldBe 1
+    }
+  }
+
+  @Test
+  fun `signals flow collectors compete with direct awaiters`() = runTest {
+    val signal = ConflatedSignal()
+
+    turbineScope {
+      val collector = signal.signals.testIn(backgroundScope, name = "collector")
+      val awaitJob = backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { signal.await() }
+
+      signal.signal()
+      yield()
+
+      val flowEvents = collector.cancelAndConsumeRemainingEvents()
+      val awaitCompleted = awaitJob.isCompleted
+
+      val flowGotSignal = flowEvents.count { it is app.cash.turbine.Event.Item } == 1
+
+      (flowGotSignal xor awaitCompleted) shouldBe true
     }
   }
 }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignalUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignalUnitTest.kt
@@ -19,6 +19,9 @@ package com.google.firebase.dataconnect.util.coroutines
 import app.cash.turbine.test
 import app.cash.turbine.turbineScope
 import com.google.firebase.dataconnect.testutil.RandomSeedTestRule
+import com.google.firebase.dataconnect.testutil.shouldContainWithNonAbuttingText
+import com.google.firebase.dataconnect.testutil.shouldContainWithNonAbuttingTextIgnoringCase
+import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -233,6 +236,29 @@ class ConflatedSignalUnitTest {
       val flowGotSignal = flowEvents.count { it is app.cash.turbine.Event.Item } == 1
 
       (flowGotSignal xor awaitCompleted) shouldBe true
+    }
+  }
+
+  @Test
+  fun `toString contains hasPendingSignal=false initially`() {
+    val signal = ConflatedSignal()
+    check(!signal.hasPendingSignal)
+
+    assertSoftly {
+      signal.toString() shouldContainWithNonAbuttingText "ConflatedSignal"
+      signal.toString() shouldContainWithNonAbuttingTextIgnoringCase "hasPendingSignal=false"
+    }
+  }
+
+  @Test
+  fun `toString contains hasPendingSignal=true after signal`() {
+    val signal = ConflatedSignal()
+    signal.signal()
+    check(signal.hasPendingSignal)
+
+    assertSoftly {
+      signal.toString() shouldContainWithNonAbuttingText "ConflatedSignal"
+      signal.toString() shouldContainWithNonAbuttingTextIgnoringCase "hasPendingSignal=true"
     }
   }
 }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignalUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignalUnitTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.dataconnect.util.coroutines
+
+import com.google.firebase.dataconnect.testutil.RandomSeedTestRule
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.property.RandomSource
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.junit.Rule
+import org.junit.Test
+
+class ConflatedSignalUnitTest {
+
+  @get:Rule(order = Int.MIN_VALUE) val randomSeedTestRule = RandomSeedTestRule()
+
+  val rs: RandomSource by randomSeedTestRule.rs
+
+  @Test
+  fun `await returns immediately without suspending if there is a pending signal`() = runTest {
+    val signal = ConflatedSignal()
+    signal.signal()
+
+    val job = backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { signal.await() }
+
+    job.isCompleted shouldBe true
+  }
+
+  @Test
+  fun `await suspends if there is NO pending signal`() = runTest {
+    val signal = ConflatedSignal()
+
+    val job = backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { signal.await() }
+
+    job.isCompleted shouldBe false
+  }
+
+  @Test
+  fun `multiple signals are conflated into one`() = runTest {
+    val signal = ConflatedSignal()
+    repeat(10) { signal.signal() }
+
+    val job1 = backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { signal.await() }
+    job1.isCompleted shouldBe true
+    val job2 = backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { signal.await() }
+    job2.isCompleted shouldBe false
+  }
+
+  @Test
+  fun `each call to signal resumes one call to await, leaving the others suspended`() = runTest {
+    val signal = ConflatedSignal()
+    val jobs =
+      List(10) { backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { signal.await() } }
+    check(jobs.all { !it.isCompleted })
+
+    repeat(jobs.size) { iterationIndex ->
+      signal.signal()
+      yield()
+      val completedCount = jobs.count { it.isCompleted }
+      withClue("iterationIndex=$iterationIndex") { completedCount shouldBe iterationIndex + 1 }
+    }
+  }
+
+  @Test
+  fun `suspended await() calls are promptly canceled`() = runTest {
+    val signal = ConflatedSignal()
+    val job = backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { signal.await() }
+    job.cancel()
+    yield()
+    job.isCompleted shouldBe true
+  }
+
+  @Test
+  fun `canceling suspended await() calls do not disturb other awaiters`() = runTest {
+    val signal = ConflatedSignal()
+    val jobs =
+      List(10) { backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { signal.await() } }
+
+    val jobsRemaining = jobs.toMutableList()
+    jobsRemaining.shuffle(rs.random)
+    while (jobsRemaining.isNotEmpty()) {
+      withClue("jobsRemaining.size=${jobsRemaining.size}") {
+        val canceledJob = jobsRemaining.removeLast()
+        canceledJob.cancelAndJoin()
+        signal.signal()
+        yield()
+        val completedJobs = jobsRemaining.filter { it.isCompleted }
+        completedJobs shouldHaveSize 1
+        jobsRemaining.remove(completedJobs.single())
+      }
+    }
+  }
+}

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignalUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignalUnitTest.kt
@@ -109,4 +109,45 @@ class ConflatedSignalUnitTest {
       }
     }
   }
+
+  @Test
+  fun `hasPendingSignal is initially false`() {
+    val signal = ConflatedSignal()
+    signal.hasPendingSignal shouldBe false
+  }
+
+  @Test
+  fun `hasPendingSignal is true after signal is called`() {
+    val signal = ConflatedSignal()
+    signal.signal()
+    signal.hasPendingSignal shouldBe true
+  }
+
+  @Test
+  fun `hasPendingSignal transitions to false after await completes`() = runTest {
+    val signal = ConflatedSignal()
+    signal.signal()
+    signal.hasPendingSignal shouldBe true
+
+    signal.await()
+    signal.hasPendingSignal shouldBe false
+  }
+
+  @Test
+  fun `hasPendingSignal remains true after multiple signals`() {
+    val signal = ConflatedSignal()
+    repeat(5) { signal.signal() }
+    signal.hasPendingSignal shouldBe true
+  }
+
+  @Test
+  fun `hasPendingSignal remains false when multiple awaiters`() = runTest {
+    val signal = ConflatedSignal()
+    repeat(5) { backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { signal.await() } }
+
+    repeat(100) {
+      signal.hasPendingSignal shouldBe false
+      yield()
+    }
+  }
 }


### PR DESCRIPTION
This PR significantly refactors gRPC bidirectional stream handling and improves the reliability of Realtime Queries in Firebase Data Connect. It introduces a more robust mechanism for managing subscriptions, handles connection failures more gracefully, and updates several architectural design records (ADRs) to reflect the new implementation details.

### Highlights

*   **Refactored Bidirectional Stream Management**: Replaced the previous subscription state management with a cleaner, `SharedFlow`-based approach in `DataConnectBidiConnectStream`. This simplifies the logic for multiplexing multiple query subscriptions over a single gRPC stream.
*   **Introduced ConflatedSignal**: Added a new utility class, `ConflatedSignal`, to handle signal-based synchronization between coroutines without the overhead or race condition risks of `MutableStateFlow` for simple "event" signaling.
*   **Improved Error Handling and Reconnection**: Fixed critical bugs where `RealtimeQueryManager` could get stuck in a "Connecting" state or fail to detect broken connections. Realtime queries now properly re-try connections upon various gRPC failures and graceful server closures.
*   **Updated Architecture Documentation**: Significantly revised ADR-0002, ADR-0003, and ADR-0004, and added ADR-0005 to document the refined strategy for flow control, conflation, and subscription coordination.
*   **Enhanced Test Coverage**: Added comprehensive unit tests for `ConflatedSignal`, `RealtimeQueryManager` connection retries, and expanded existing tests for `DataConnectBidiConnectStream` to cover various failure and reconnection scenarios.

### Changelog

<details>
<summary>Modified Files</summary>

*   **RealtimeTodo.md**: Updated the TODO list, removing resolved critical issues related to connection monitoring and stuck states.
*   **README.md (docs)**: Updated documentation overview.
*   **adr-0002-use-replay-expiration-millis-0-in-while-subscribed.md**: Revised to clarify the usage of replay expiration in the context of `SharedFlow`.
*   **adr-0003-sequence-number-filtering-for-stale-replayed-data.md**: Updated details on sequence number filtering.
*   **adr-0004-coordinate-multiplexed-subscriptions-using-conflatedsignal-and-replay-0.md**: Significant re-write to document the coordination of subscriptions using `ConflatedSignal`.
*   **adr-0005-configure-flow-control-and-conflation-for-realtime-queries.md**: New ADR documenting the configuration of flow control and data conflation.
*   **test_execute.zsh**: Fixed a shell script warning by properly scoping the `IFS` variable.
*   **DataConnectBidiConnectStream.kt**: Major refactor of stream management, subscription handling, and logging. Reduced buffering and improved state transitions.
*   **DataConnectGrpcRPCs.kt**: Minor updates to gRPC RPC definitions.
*   **RealtimeQueryManager.kt**: Fixed bugs in connection lifecycle management, ensuring failures are properly propagated and re-tries are possible.
*   **AtomicReferenceExts.kt**: Relaxed type constraints for atomic updates to provide more flexibility.
*   **CoroutineUtils.kt**: Added `completedFlow()` utility.
*   **GrpcBidiFlow.kt**: Modified to use `ConflatedSignal` and improved metadata handling.
*   **ConflatedSignal.kt**: New utility class for conflated signaling between coroutines.
*   **RealtimeQuerySubscriptionImplUnitTest.kt**: Expanded and improved robustness of tests for various server error and reconnection scenarios.
*   **RealtimeQueryManagerUnitTest.kt**: Added tests for connection retry and conflation of concurrent subscription attempts.
*   **InProcessDataConnectGrpcStreamingServer.kt**: Updated to allow binding to specific ports in tests.
*   **ConflatedSignalUnitTest.kt**: New comprehensive unit tests for the `ConflatedSignal` utility.

</details>
