### PR TITLE
[Crashlytics] Fix release build cache invalidation

### DIFF
--- a/firebase-crashlytics-gradle/CHANGELOG.md
+++ b/firebase-crashlytics-gradle/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Unreleased
 
 - [fixed] Fixed an incompatibility between Crashlytics Gradle plugin and Gradle isolated projects when enabling nativeSymbolUploadEnabled. [#8037]
-- [fixed] Stopped regenerating the mapping file id on every minified release build. `injectCrashlyticsMappingFileId<Variant>` is now content-driven: the task stays `UP-TO-DATE` (and downstream `mergeResources`, `processResources`, R8, packaging tasks stay cached) while the variant's source files (`src/**/java`, `src/**/kotlin`, excluding tests) are unchanged. A new id is minted when those sources change — which is when R8 would produce a different `mapping.txt` — and on first build, after `clean`, or when `mappingFileUploadEnabled` is toggled. [#6770]
+- [fixed] Stopped regenerating the mapping file id on every minified release build. `injectCrashlyticsMappingFileId<Variant>` is now content-driven: the task stays `UP-TO-DATE` (and downstream `mergeResources`, `processResources`, R8, packaging tasks stay cached) while the inputs that determine the obfuscation mapping are unchanged — the variant's source files (`src/**/java`, `src/**/kotlin`, excluding tests), the runtime dependency classpath, the ProGuard/R8 configuration, and the AGP version. A new id is minted when any of those change — which is when R8 would produce a different `mapping.txt` — and on first build, after `clean`, or when `mappingFileUploadEnabled` is toggled. [#6770]
 
 ### Crashlytics Gradle plugin version 3.0.7
 

--- a/firebase-crashlytics-gradle/CHANGELOG.md
+++ b/firebase-crashlytics-gradle/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 - [fixed] Fixed an incompatibility between Crashlytics Gradle plugin and Gradle isolated projects when enabling nativeSymbolUploadEnabled. [#8037]
+- [fixed] Stopped regenerating the mapping file id on every minified release build. `injectCrashlyticsMappingFileId<Variant>` now reuses the on-disk id when valid for the current mode, so release builds can be `UP-TO-DATE` and downstream tasks (`mergeResources`, `processResources`, R8, packaging) are no longer invalidated on every build. A new id is still generated on the first build, after `clean`, or when `mappingFileUploadEnabled` is toggled. [#6770]
 
 ### Crashlytics Gradle plugin version 3.0.7
 

--- a/firebase-crashlytics-gradle/CHANGELOG.md
+++ b/firebase-crashlytics-gradle/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Unreleased
 
 - [fixed] Fixed an incompatibility between Crashlytics Gradle plugin and Gradle isolated projects when enabling nativeSymbolUploadEnabled. [#8037]
-- [fixed] Stopped regenerating the mapping file id on every minified release build. `injectCrashlyticsMappingFileId<Variant>` now reuses the on-disk id when valid for the current mode, so release builds can be `UP-TO-DATE` and downstream tasks (`mergeResources`, `processResources`, R8, packaging) are no longer invalidated on every build. A new id is still generated on the first build, after `clean`, or when `mappingFileUploadEnabled` is toggled. [#6770]
+- [fixed] Stopped regenerating the mapping file id on every minified release build. `injectCrashlyticsMappingFileId<Variant>` is now content-driven: the task stays `UP-TO-DATE` (and downstream `mergeResources`, `processResources`, R8, packaging tasks stay cached) while the variant's source files (`src/**/java`, `src/**/kotlin`, excluding tests) are unchanged. A new id is minted when those sources change — which is when R8 would produce a different `mapping.txt` — and on first build, after `clean`, or when `mappingFileUploadEnabled` is toggled. [#6770]
 
 ### Crashlytics Gradle plugin version 3.0.7
 

--- a/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/TypicalAppFunctionalTests.kt
+++ b/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/TypicalAppFunctionalTests.kt
@@ -355,6 +355,72 @@ class TypicalAppFunctionalTests {
     assertThat(afterEdit.task(":injectCrashlyticsMappingFileIdRelease")?.outcome).isEqualTo(SUCCESS)
   }
 
+  @Test
+  fun `release mapping file id task is invalidated when the runtime classpath changes`() {
+    val first = buildGradleRunner(projectDir, ":injectCrashlyticsMappingFileIdRelease")
+    assertThat(first.task(":injectCrashlyticsMappingFileIdRelease")?.outcome).isEqualTo(SUCCESS)
+
+    val noChange = buildGradleRunner(projectDir, ":injectCrashlyticsMappingFileIdRelease")
+    assertThat(noChange.task(":injectCrashlyticsMappingFileIdRelease")?.outcome)
+      .isEqualTo(UP_TO_DATE)
+
+    // Adding a dependency changes the obfuscated output (new code is bundled and renamed) with no
+    // source edit, so R8 produces a different mapping.txt. fileTree("src") would miss this; the
+    // @Classpath input must catch it.
+    buildFile.appendText(
+      """
+        dependencies {
+          implementation("org.jetbrains:annotations:23.0.0")
+        }
+      """
+    )
+    val afterDependency = buildGradleRunner(projectDir, ":injectCrashlyticsMappingFileIdRelease")
+    assertThat(afterDependency.task(":injectCrashlyticsMappingFileIdRelease")?.outcome)
+      .isEqualTo(SUCCESS)
+  }
+
+  @Test
+  fun `release mapping file id task is invalidated when proguard rules change`() {
+    val rulesFile = File(projectDir, "proguard-rules.pro")
+    rulesFile.writeText("-dontwarn com.google.firebase.testing.**")
+
+    buildFile.writeText(
+      """
+        plugins {
+          id("com.android.application") version "8.1.4"
+          id("com.google.gms.google-services") version "4.4.1"
+          id("com.google.firebase.crashlytics") version "$pluginVersion"
+        }
+
+        android {
+          compileSdk = 33
+          namespace = "com.google.firebase.testing.crashlytics"
+
+          buildTypes {
+            release {
+              isMinifyEnabled = true
+              proguardFiles("proguard-rules.pro")
+            }
+          }
+        }
+      """
+    )
+
+    val first = buildGradleRunner(projectDir, ":injectCrashlyticsMappingFileIdRelease")
+    assertThat(first.task(":injectCrashlyticsMappingFileIdRelease")?.outcome).isEqualTo(SUCCESS)
+
+    val noChange = buildGradleRunner(projectDir, ":injectCrashlyticsMappingFileIdRelease")
+    assertThat(noChange.task(":injectCrashlyticsMappingFileIdRelease")?.outcome)
+      .isEqualTo(UP_TO_DATE)
+
+    // Changing keep rules changes what R8 obfuscates, so the mapping.txt changes with no source
+    // edit. The proguard config files are an input so the id must regenerate.
+    rulesFile.appendText("\n-keep class com.google.firebase.testing.crashlytics.** { *; }\n")
+    val afterRuleChange = buildGradleRunner(projectDir, ":injectCrashlyticsMappingFileIdRelease")
+    assertThat(afterRuleChange.task(":injectCrashlyticsMappingFileIdRelease")?.outcome)
+      .isEqualTo(SUCCESS)
+  }
+
   @BeforeEach
   fun setup() {
     settingsFile = File(projectDir, "settings.gradle.kts")

--- a/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/TypicalAppFunctionalTests.kt
+++ b/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/TypicalAppFunctionalTests.kt
@@ -21,6 +21,7 @@ import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPluginTest.C
 import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPluginTest.Companion.pluginVersion
 import java.io.File
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -215,6 +216,132 @@ class TypicalAppFunctionalTests {
       .contains(
         "injectMappingFileIdIntoResource - com_google_firebase_crashlytics_mappingfileid.xml test321"
       )
+  }
+
+  @Test
+  fun `injectCrashlyticsMappingFileIdRelease is UP_TO_DATE on second invocation`() {
+    val first =
+      GradleRunner.create()
+        .withGradleVersion("8.1")
+        .withProjectDir(projectDir)
+        .withArguments(":injectCrashlyticsMappingFileIdRelease", "--configuration-cache")
+        .build()
+
+    assertThat(first.task(":injectCrashlyticsMappingFileIdRelease")?.outcome).isEqualTo(SUCCESS)
+
+    val second =
+      GradleRunner.create()
+        .withGradleVersion("8.1")
+        .withProjectDir(projectDir)
+        .withArguments(":injectCrashlyticsMappingFileIdRelease", "--configuration-cache")
+        .build()
+
+    assertThat(second.task(":injectCrashlyticsMappingFileIdRelease")?.outcome).isEqualTo(UP_TO_DATE)
+  }
+
+  @Test
+  fun `release mapping file id resource is preserved across rebuilds`() {
+    GradleRunner.create()
+      .withGradleVersion("8.1")
+      .withProjectDir(projectDir)
+      .withArguments(":injectCrashlyticsMappingFileIdRelease", "--configuration-cache")
+      .build()
+
+    val idFile = File(projectDir, "build/crashlytics/release/mappingFileId.txt")
+    val resourceFile =
+      File(
+        projectDir,
+        "build/generated/res/injectCrashlyticsMappingFileIdRelease/values/" +
+          "com_google_firebase_crashlytics_mappingfileid.xml",
+      )
+
+    val idBefore = idFile.readText()
+    val resourceBefore = resourceFile.readText()
+
+    GradleRunner.create()
+      .withGradleVersion("8.1")
+      .withProjectDir(projectDir)
+      .withArguments(":injectCrashlyticsMappingFileIdRelease", "--configuration-cache")
+      .build()
+
+    assertThat(idFile.readText()).isEqualTo(idBefore)
+    assertThat(resourceFile.readText()).isEqualTo(resourceBefore)
+  }
+
+  @Test
+  fun `task re-runs after clean`() {
+    GradleRunner.create()
+      .withGradleVersion("8.1")
+      .withProjectDir(projectDir)
+      .withArguments(":injectCrashlyticsMappingFileIdRelease", "--configuration-cache")
+      .build()
+
+    val idFile = File(projectDir, "build/crashlytics/release/mappingFileId.txt")
+
+    val rerun =
+      GradleRunner.create()
+        .withGradleVersion("8.1")
+        .withProjectDir(projectDir)
+        .withArguments(
+          ":clean",
+          ":injectCrashlyticsMappingFileIdRelease",
+          "--configuration-cache",
+        )
+        .build()
+
+    assertThat(rerun.task(":injectCrashlyticsMappingFileIdRelease")?.outcome).isEqualTo(SUCCESS)
+    assertThat(idFile.exists()).isTrue()
+    assertThat(idFile.readText()).isNotEmpty()
+  }
+
+  @Test
+  fun `toggling mappingFileUploadEnabled invalidates the task`() {
+    val first =
+      GradleRunner.create()
+        .withGradleVersion("8.1")
+        .withProjectDir(projectDir)
+        .withArguments(":injectCrashlyticsMappingFileIdRelease", "--configuration-cache")
+        .build()
+
+    assertThat(first.task(":injectCrashlyticsMappingFileIdRelease")?.outcome).isEqualTo(SUCCESS)
+    val idFile = File(projectDir, "build/crashlytics/release/mappingFileId.txt")
+    assertThat(idFile.readText()).isEqualTo("test321")
+
+    buildFile.writeText(
+      """
+        import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension
+
+        plugins {
+          id("com.android.application") version "8.1.4"
+          id("com.google.gms.google-services") version "4.4.1"
+          id("com.google.firebase.crashlytics") version "$pluginVersion"
+        }
+
+        android {
+          compileSdk = 33
+          namespace = "com.google.firebase.testing.crashlytics"
+
+          buildTypes {
+            release {
+              configure<CrashlyticsExtension> {
+                mappingFileUploadEnabled = false
+              }
+              isMinifyEnabled = true
+            }
+          }
+        }
+      """
+    )
+
+    val second =
+      GradleRunner.create()
+        .withGradleVersion("8.1")
+        .withProjectDir(projectDir)
+        .withArguments(":injectCrashlyticsMappingFileIdRelease", "--configuration-cache")
+        .build()
+
+    assertThat(second.task(":injectCrashlyticsMappingFileIdRelease")?.outcome).isEqualTo(SUCCESS)
+    assertThat(idFile.readText()).isEqualTo("00000000000000000000000000000000")
   }
 
   @BeforeEach

--- a/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/TypicalAppFunctionalTests.kt
+++ b/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/TypicalAppFunctionalTests.kt
@@ -221,73 +221,50 @@ class TypicalAppFunctionalTests {
   @Test
   fun `injectCrashlyticsMappingFileIdRelease is UP_TO_DATE on second invocation`() {
     val first =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(":injectCrashlyticsMappingFileIdRelease", "--configuration-cache")
-        .build()
+      buildGradleRunner(
+        projectDir,
+        ":injectCrashlyticsMappingFileIdRelease",
+        "--configuration-cache"
+      )
 
     assertThat(first.task(":injectCrashlyticsMappingFileIdRelease")?.outcome).isEqualTo(SUCCESS)
 
     val second =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(":injectCrashlyticsMappingFileIdRelease", "--configuration-cache")
-        .build()
+      buildGradleRunner(
+        projectDir,
+        ":injectCrashlyticsMappingFileIdRelease",
+        "--configuration-cache"
+      )
 
     assertThat(second.task(":injectCrashlyticsMappingFileIdRelease")?.outcome).isEqualTo(UP_TO_DATE)
   }
 
   @Test
-  fun `release mapping file id resource is preserved across rebuilds`() {
-    GradleRunner.create()
-      .withGradleVersion("8.1")
-      .withProjectDir(projectDir)
-      .withArguments(":injectCrashlyticsMappingFileIdRelease", "--configuration-cache")
-      .build()
+  fun `release mapping file id is preserved across rebuilds`() {
+    buildGradleRunner(projectDir, ":injectCrashlyticsMappingFileIdRelease", "--configuration-cache")
 
     val idFile = File(projectDir, "build/crashlytics/release/mappingFileId.txt")
-    val resourceFile =
-      File(
-        projectDir,
-        "build/generated/res/injectCrashlyticsMappingFileIdRelease/values/" +
-          "com_google_firebase_crashlytics_mappingfileid.xml",
-      )
-
     val idBefore = idFile.readText()
-    val resourceBefore = resourceFile.readText()
+    assertThat(idBefore).isNotEmpty()
 
-    GradleRunner.create()
-      .withGradleVersion("8.1")
-      .withProjectDir(projectDir)
-      .withArguments(":injectCrashlyticsMappingFileIdRelease", "--configuration-cache")
-      .build()
+    buildGradleRunner(projectDir, ":injectCrashlyticsMappingFileIdRelease", "--configuration-cache")
 
     assertThat(idFile.readText()).isEqualTo(idBefore)
-    assertThat(resourceFile.readText()).isEqualTo(resourceBefore)
   }
 
   @Test
   fun `task re-runs after clean`() {
-    GradleRunner.create()
-      .withGradleVersion("8.1")
-      .withProjectDir(projectDir)
-      .withArguments(":injectCrashlyticsMappingFileIdRelease", "--configuration-cache")
-      .build()
+    buildGradleRunner(projectDir, ":injectCrashlyticsMappingFileIdRelease", "--configuration-cache")
 
     val idFile = File(projectDir, "build/crashlytics/release/mappingFileId.txt")
 
     val rerun =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(
-          ":clean",
-          ":injectCrashlyticsMappingFileIdRelease",
-          "--configuration-cache",
-        )
-        .build()
+      buildGradleRunner(
+        projectDir,
+        ":clean",
+        ":injectCrashlyticsMappingFileIdRelease",
+        "--configuration-cache",
+      )
 
     assertThat(rerun.task(":injectCrashlyticsMappingFileIdRelease")?.outcome).isEqualTo(SUCCESS)
     assertThat(idFile.exists()).isTrue()
@@ -297,11 +274,11 @@ class TypicalAppFunctionalTests {
   @Test
   fun `toggling mappingFileUploadEnabled invalidates the task`() {
     val first =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(":injectCrashlyticsMappingFileIdRelease", "--configuration-cache")
-        .build()
+      buildGradleRunner(
+        projectDir,
+        ":injectCrashlyticsMappingFileIdRelease",
+        "--configuration-cache"
+      )
 
     assertThat(first.task(":injectCrashlyticsMappingFileIdRelease")?.outcome).isEqualTo(SUCCESS)
     val idFile = File(projectDir, "build/crashlytics/release/mappingFileId.txt")
@@ -334,14 +311,48 @@ class TypicalAppFunctionalTests {
     )
 
     val second =
-      GradleRunner.create()
-        .withGradleVersion("8.1")
-        .withProjectDir(projectDir)
-        .withArguments(":injectCrashlyticsMappingFileIdRelease", "--configuration-cache")
-        .build()
+      buildGradleRunner(
+        projectDir,
+        ":injectCrashlyticsMappingFileIdRelease",
+        "--configuration-cache"
+      )
 
     assertThat(second.task(":injectCrashlyticsMappingFileIdRelease")?.outcome).isEqualTo(SUCCESS)
     assertThat(idFile.readText()).isEqualTo("00000000000000000000000000000000")
+  }
+
+  @Test
+  fun `release mapping file id task is invalidated when source code changes`() {
+    val sourceFile =
+      File(projectDir, "src/main/kotlin/com/google/firebase/testing/crashlytics/Greeter.kt")
+    sourceFile.parentFile.mkdirs()
+    sourceFile.writeText(
+      """
+        package com.google.firebase.testing.crashlytics
+        class Greeter { fun hello() = "hello" }
+      """
+    )
+
+    val first = buildGradleRunner(projectDir, ":injectCrashlyticsMappingFileIdRelease")
+    assertThat(first.task(":injectCrashlyticsMappingFileIdRelease")?.outcome).isEqualTo(SUCCESS)
+
+    // Re-running without changing inputs must NOT regenerate the id (would invalidate downstream
+    // R8, packaging, etc. — the bug PR #8185 originally fixed).
+    val noChange = buildGradleRunner(projectDir, ":injectCrashlyticsMappingFileIdRelease")
+    assertThat(noChange.task(":injectCrashlyticsMappingFileIdRelease")?.outcome)
+      .isEqualTo(UP_TO_DATE)
+
+    // Editing the source MUST invalidate the task so a new id is minted: the on-device id is the
+    // handle Crashlytics uses to match crashes to the right uploaded mapping.txt, and R8 will
+    // produce a different mapping.txt after this edit.
+    sourceFile.writeText(
+      """
+        package com.google.firebase.testing.crashlytics
+        class Greeter { fun hello() = "hello world" }
+      """
+    )
+    val afterEdit = buildGradleRunner(projectDir, ":injectCrashlyticsMappingFileIdRelease")
+    assertThat(afterEdit.task(":injectCrashlyticsMappingFileIdRelease")?.outcome).isEqualTo(SUCCESS)
   }
 
   @BeforeEach

--- a/firebase-crashlytics-gradle/src/main/kotlin/com/google/firebase/crashlytics/buildtools/gradle/tasks/InjectMappingFileIdTask.kt
+++ b/firebase-crashlytics-gradle/src/main/kotlin/com/google/firebase/crashlytics/buildtools/gradle/tasks/InjectMappingFileIdTask.kt
@@ -56,7 +56,11 @@ abstract class InjectMappingFileIdTask : DefaultTask() {
       if (useBlankMappingFileId.get()) {
         CrashlyticsBuildtools.BLANK_MAPPING_FILE_ID
       } else {
-        CrashlyticsBuildtools.generateMappingFileId()
+        // Reuse the on-disk id when valid so release builds stay reproducible and don't invalidate
+        // downstream tasks (mergeResources, R8, packaging, bundling). A fresh UUID is only minted
+        // on the first build or after `clean`.
+        existingMappingFileId()?.takeUnless { it == CrashlyticsBuildtools.BLANK_MAPPING_FILE_ID }
+          ?: CrashlyticsBuildtools.generateMappingFileId()
       }
     mappingFileIdFile.get().asFile.writeText(mappingFileId)
 
@@ -67,12 +71,14 @@ abstract class InjectMappingFileIdTask : DefaultTask() {
   }
 
   /**
-   * Check if a mapping file id file already exists, and that the mapping file id is blank - meaning
-   * no obfuscation is enabled. The Crashlytics SDK always needs a mapping file id.
+   * Returns the mapping file id currently stored on disk, or null if the file is missing or empty.
+   * Used to keep the task up-to-date across builds and to avoid generating a new random id on
+   * every release build.
    */
-  private fun blankMappingFileIdExists(): Boolean {
+  private fun existingMappingFileId(): String? {
     val file: File = mappingFileIdFile.get().asFile
-    return file.exists() && file.readText() == CrashlyticsBuildtools.BLANK_MAPPING_FILE_ID
+    if (!file.exists()) return null
+    return file.readText().trim().ifEmpty { null }
   }
 
   internal companion object {
@@ -91,7 +97,14 @@ abstract class InjectMappingFileIdTask : DefaultTask() {
           )
           this.mappingFileIdFile.set(buildFile(project, variant, "mappingFileId.txt"))
 
-          outputs.upToDateWhen { useBlankMappingFileId.get() && blankMappingFileIdExists() }
+          outputs.upToDateWhen {
+            val existing = existingMappingFileId()
+            if (useBlankMappingFileId.get()) {
+              existing == CrashlyticsBuildtools.BLANK_MAPPING_FILE_ID
+            } else {
+              existing != null && existing != CrashlyticsBuildtools.BLANK_MAPPING_FILE_ID
+            }
+          }
         }
 
       // It is not possible to disable Android resources in the AGP app plugin.

--- a/firebase-crashlytics-gradle/src/main/kotlin/com/google/firebase/crashlytics/buildtools/gradle/tasks/InjectMappingFileIdTask.kt
+++ b/firebase-crashlytics-gradle/src/main/kotlin/com/google/firebase/crashlytics/buildtools/gradle/tasks/InjectMappingFileIdTask.kt
@@ -26,13 +26,17 @@ import com.google.firebase.crashlytics.buildtools.mappingfiles.MappingFileIdWrit
 import java.io.File
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
@@ -40,7 +44,14 @@ import org.gradle.kotlin.dsl.register
 /** Inject mapping file id task. */
 @CacheableTask
 abstract class InjectMappingFileIdTask : DefaultTask() {
-  @get:Internal abstract val useBlankMappingFileId: Property<Boolean>
+  @get:Input abstract val useBlankMappingFileId: Property<Boolean>
+
+  @get:[InputFiles PathSensitive(PathSensitivity.RELATIVE)]
+  abstract val obfuscatableSources: ConfigurableFileCollection
+
+  @get:[InputFiles PathSensitive(PathSensitivity.NONE)]
+  abstract val obfuscatableClasspath: ConfigurableFileCollection
+
   @get:OutputFile abstract val mappingFileIdFile: RegularFileProperty
   @get:OutputDirectory abstract val resourceDir: DirectoryProperty
 
@@ -56,11 +67,7 @@ abstract class InjectMappingFileIdTask : DefaultTask() {
       if (useBlankMappingFileId.get()) {
         CrashlyticsBuildtools.BLANK_MAPPING_FILE_ID
       } else {
-        // Reuse the on-disk id when valid so release builds stay reproducible and don't invalidate
-        // downstream tasks (mergeResources, R8, packaging, bundling). A fresh UUID is only minted
-        // on the first build or after `clean`.
-        existingMappingFileId()?.takeUnless { it == CrashlyticsBuildtools.BLANK_MAPPING_FILE_ID }
-          ?: CrashlyticsBuildtools.generateMappingFileId()
+        CrashlyticsBuildtools.generateMappingFileId()
       }
     mappingFileIdFile.get().asFile.writeText(mappingFileId)
 
@@ -70,40 +77,44 @@ abstract class InjectMappingFileIdTask : DefaultTask() {
     )
   }
 
-  /**
-   * Returns the mapping file id currently stored on disk, or null if the file is missing or empty.
-   * Used to keep the task up-to-date across builds and to avoid generating a new random id on every
-   * release build.
-   */
-  private fun existingMappingFileId(): String? {
-    val file: File = mappingFileIdFile.get().asFile
-    if (!file.exists()) return null
-    return file.readText().trim().ifEmpty { null }
-  }
-
   internal companion object {
-    @Suppress("UnstableApiUsage") // isMinifyEnabled
+    @Suppress("UnstableApiUsage") // isMinifyEnabled, compileClasspath
     fun register(
       project: Project,
       variant: ApplicationVariant,
       crashlyticsExtension: CrashlyticsVariantExtension,
     ): TaskProvider<InjectMappingFileIdTask> {
+      val useBlank =
+        !crashlyticsExtension.mappingFileUploadEnabled.getOrElse(variant.isMinifyEnabled)
+
       val injectMappingFileIdTaskProvider =
         project.tasks.register<InjectMappingFileIdTask>(
           "injectCrashlyticsMappingFileId${variant.name.capitalized()}"
         ) {
-          this.useBlankMappingFileId.set(
-            !crashlyticsExtension.mappingFileUploadEnabled.getOrElse(variant.isMinifyEnabled)
-          )
+          this.useBlankMappingFileId.set(useBlank)
           this.mappingFileIdFile.set(buildFile(project, variant, "mappingFileId.txt"))
 
-          outputs.upToDateWhen {
-            val existing = existingMappingFileId()
-            if (useBlankMappingFileId.get()) {
-              existing == CrashlyticsBuildtools.BLANK_MAPPING_FILE_ID
-            } else {
-              existing != null && existing != CrashlyticsBuildtools.BLANK_MAPPING_FILE_ID
-            }
+          // Only fingerprint inputs when obfuscation is on. In blank-id mode the id is constant
+          // and source/classpath changes are irrelevant to the mapping handle.
+          //
+          // Discover user source files via project.fileTree("src") rather than
+          // variant.sources.java/kotlin.all. AGP's accessor includes generated source dirs
+          // (R.java, deeplinks, view-binding, etc.) whose producer tasks depend on the same
+          // mergeResources pipeline that consumes THIS task's output, which would close a cycle.
+          // AGP 8.1.4 has no `static` getter (added in 8.6) that would expose the non-generated
+          // subset, so we hand-roll the discovery from on-disk source-set conventions.
+          if (!useBlank) {
+            this.obfuscatableSources.from(
+              project.fileTree("src").matching { patterns ->
+                patterns.include(
+                  "**/java/**/*.java",
+                  "**/java/**/*.kt",
+                  "**/kotlin/**/*.java",
+                  "**/kotlin/**/*.kt",
+                )
+                patterns.exclude("test/**", "androidTest/**", "test*/**", "androidTest*/**")
+              }
+            )
           }
         }
 

--- a/firebase-crashlytics-gradle/src/main/kotlin/com/google/firebase/crashlytics/buildtools/gradle/tasks/InjectMappingFileIdTask.kt
+++ b/firebase-crashlytics-gradle/src/main/kotlin/com/google/firebase/crashlytics/buildtools/gradle/tasks/InjectMappingFileIdTask.kt
@@ -72,8 +72,8 @@ abstract class InjectMappingFileIdTask : DefaultTask() {
 
   /**
    * Returns the mapping file id currently stored on disk, or null if the file is missing or empty.
-   * Used to keep the task up-to-date across builds and to avoid generating a new random id on
-   * every release build.
+   * Used to keep the task up-to-date across builds and to avoid generating a new random id on every
+   * release build.
    */
   private fun existingMappingFileId(): String? {
     val file: File = mappingFileIdFile.get().asFile

--- a/firebase-crashlytics-gradle/src/main/kotlin/com/google/firebase/crashlytics/buildtools/gradle/tasks/InjectMappingFileIdTask.kt
+++ b/firebase-crashlytics-gradle/src/main/kotlin/com/google/firebase/crashlytics/buildtools/gradle/tasks/InjectMappingFileIdTask.kt
@@ -49,9 +49,6 @@ abstract class InjectMappingFileIdTask : DefaultTask() {
   @get:[InputFiles PathSensitive(PathSensitivity.RELATIVE)]
   abstract val obfuscatableSources: ConfigurableFileCollection
 
-  @get:[InputFiles PathSensitive(PathSensitivity.NONE)]
-  abstract val obfuscatableClasspath: ConfigurableFileCollection
-
   @get:OutputFile abstract val mappingFileIdFile: RegularFileProperty
   @get:OutputDirectory abstract val resourceDir: DirectoryProperty
 
@@ -78,7 +75,7 @@ abstract class InjectMappingFileIdTask : DefaultTask() {
   }
 
   internal companion object {
-    @Suppress("UnstableApiUsage") // isMinifyEnabled, compileClasspath
+    @Suppress("UnstableApiUsage") // isMinifyEnabled
     fun register(
       project: Project,
       variant: ApplicationVariant,

--- a/firebase-crashlytics-gradle/src/main/kotlin/com/google/firebase/crashlytics/buildtools/gradle/tasks/InjectMappingFileIdTask.kt
+++ b/firebase-crashlytics-gradle/src/main/kotlin/com/google/firebase/crashlytics/buildtools/gradle/tasks/InjectMappingFileIdTask.kt
@@ -16,6 +16,7 @@
 
 package com.google.firebase.crashlytics.buildtools.gradle.tasks
 
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.ApplicationVariant
 import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsBuildtools
 import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPlugin
@@ -31,14 +32,17 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.register
 
 /** Inject mapping file id task. */
@@ -46,8 +50,29 @@ import org.gradle.kotlin.dsl.register
 abstract class InjectMappingFileIdTask : DefaultTask() {
   @get:Input abstract val useBlankMappingFileId: Property<Boolean>
 
+  // When obfuscation is on, the mapping id must change whenever the obfuscated output could change,
+  // and stay stable otherwise (so it doesn't invalidate the cached release pipeline on every
+  // build).
+  //
+  // We deliberately do NOT fingerprint the obfuscated classes directly (ScopedArtifact.CLASSES):
+  // this task contributes the id as a generated `res` dir, which feeds mergeResources, and the
+  // compiled classes are produced downstream of that (res -> mergeResources -> R.jar -> compile).
+  // Wiring CLASSES as an input therefore closes a task-dependency cycle on every app. Instead we
+  // fingerprint the cycle-free, upstream inputs that determine the mapping.
   @get:[InputFiles PathSensitive(PathSensitivity.RELATIVE)]
   abstract val obfuscatableSources: ConfigurableFileCollection
+
+  // External runtime classpath: changes here (dependency or toolchain version bumps) change the
+  // obfuscated output even when no source file changes.
+  @get:Classpath abstract val obfuscatableClasspath: ConfigurableFileCollection
+
+  // ProGuard/R8 configuration: rule changes change the mapping.
+  @get:[InputFiles PathSensitive(PathSensitivity.RELATIVE)]
+  abstract val proguardConfigFiles: ConfigurableFileCollection
+
+  // AGP version ships R8; a toolchain bump can change the mapping with no other input change.
+  @get:[Input Optional]
+  abstract val androidGradlePluginVersion: Property<String>
 
   @get:OutputFile abstract val mappingFileIdFile: RegularFileProperty
   @get:OutputDirectory abstract val resourceDir: DirectoryProperty
@@ -75,7 +100,9 @@ abstract class InjectMappingFileIdTask : DefaultTask() {
   }
 
   internal companion object {
-    @Suppress("UnstableApiUsage") // isMinifyEnabled
+    @Suppress(
+      "UnstableApiUsage"
+    ) // isMinifyEnabled, runtimeConfiguration, proguardFiles, pluginVersion
     fun register(
       project: Project,
       variant: ApplicationVariant,
@@ -84,6 +111,11 @@ abstract class InjectMappingFileIdTask : DefaultTask() {
       val useBlank =
         !crashlyticsExtension.mappingFileUploadEnabled.getOrElse(variant.isMinifyEnabled)
 
+      val agpVersion =
+        project.extensions.getByType<ApplicationAndroidComponentsExtension>().pluginVersion.let {
+          "${it.major}.${it.minor}.${it.micro}"
+        }
+
       val injectMappingFileIdTaskProvider =
         project.tasks.register<InjectMappingFileIdTask>(
           "injectCrashlyticsMappingFileId${variant.name.capitalized()}"
@@ -91,15 +123,16 @@ abstract class InjectMappingFileIdTask : DefaultTask() {
           this.useBlankMappingFileId.set(useBlank)
           this.mappingFileIdFile.set(buildFile(project, variant, "mappingFileId.txt"))
 
-          // Only fingerprint inputs when obfuscation is on. In blank-id mode the id is constant
-          // and source/classpath changes are irrelevant to the mapping handle.
+          // Only fingerprint inputs when obfuscation is on. In blank-id mode the id is constant, so
+          // source/classpath/rule changes are irrelevant to the mapping handle.
           //
-          // Discover user source files via project.fileTree("src") rather than
-          // variant.sources.java/kotlin.all. AGP's accessor includes generated source dirs
-          // (R.java, deeplinks, view-binding, etc.) whose producer tasks depend on the same
-          // mergeResources pipeline that consumes THIS task's output, which would close a cycle.
-          // AGP 8.1.4 has no `static` getter (added in 8.6) that would expose the non-generated
-          // subset, so we hand-roll the discovery from on-disk source-set conventions.
+          // User sources are discovered via project.fileTree("src") rather than
+          // variant.sources.java/kotlin.all: AGP's `all` accessor includes generated source dirs
+          // (view-binding, etc.) whose producer tasks depend on the same mergeResources pipeline
+          // that consumes THIS task's output, which would close a cycle. The `static` accessor that
+          // would expose only the non-generated subset was added in AGP 8.6, but this plugin
+          // compiles against the 8.1 API, so we hand-roll the discovery from source-set
+          // conventions.
           if (!useBlank) {
             this.obfuscatableSources.from(
               project.fileTree("src").matching { patterns ->
@@ -112,6 +145,9 @@ abstract class InjectMappingFileIdTask : DefaultTask() {
                 patterns.exclude("test/**", "androidTest/**", "test*/**", "androidTest*/**")
               }
             )
+            this.obfuscatableClasspath.from(variant.runtimeConfiguration)
+            this.proguardConfigFiles.from(variant.proguardFiles)
+            this.androidGradlePluginVersion.set(agpVersion)
           }
         }
 


### PR DESCRIPTION

# Crashlytics: content-driven mapping file id for release builds

Fixes #6770

`injectCrashlyticsMappingFileIdRelease` minted a new UUID on every release build, cascading through `mergeResources` → `processResources` → R8 → packaging and busting the build cache for every minified release.

This PR makes the task **content-driven**: Gradle's input snapshotting decides when to re-execute. The id stays byte-identical (and the downstream cascade `UP-TO-DATE`) while the inputs that determine R8's `mapping.txt` are unchanged, and regenerates whenever any of them changes.

## How

`useBlankMappingFileId` is promoted to `@Input` so mode flips invalidate natively. When obfuscation is on, the task fingerprints the cycle-free upstream inputs that determine R8's output: user sources (`fileTree("src")` over `**/java/**` + `**/kotlin/**`, tests excluded), the runtime dependency classpath (`@Classpath`), ProGuard/R8 config files, and the AGP version. Wiring `ScopedArtifact.CLASSES` directly would close a `res → mergeResources → R.jar → compile` cycle, so we fingerprint the upstream inputs that determine it instead. The custom `upToDateWhen` and on-disk reuse path are removed.

## Verification

- `:spotlessApply`, `:validatePlugins`, `:test`, `:functionalTest` — green. Functional suite covers source-change, dependency-change, rule-change, and blank-id-mode invalidation.
- **End-to-end manual repro:** [github.com/jrodiz/repro6770](https://github.com/jrodiz/repro6770) (AGP 9.1.0-alpha05, Gradle 9.2.1, `compileSdk` 36, Compose). Pre-fix `3.0.3` flips `mappingFileId.txt` every rebuild and re-runs the full cascade. With this branch (`mavenLocal()`) the id stays byte-identical across rebuilds, every downstream task is `UP-TO-DATE`, second `assembleRelease` finishes in ~3s. Editing any `.kt` file (`@Composable` bodies, new composables, `@Preview` bodies) regenerates the id; `clean` and `mappingFileUploadEnabled` toggle behave as expected.

## Risks

No SDK runtime change; configuration-cache compatibility preserved. The first build after this lands re-fires the inject task once (input fingerprint differs from prior runs) and the cascade settles to `UP-TO-DATE` from the next build on.
