### PR TITLE
Hotfix/jrc  8103.bump.app.start.runnable.delay

### DIFF
--- a/firebase-perf/CHANGELOG.md
+++ b/firebase-perf/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+- [fixed] Fixed `_app_start` traces being suppressed on API 34+ devices for typical
+  real-world apps by widening the foreground/background-start timing window to account
+  for Android's main-thread vs Binder scheduling on physical devices. [#8103]
+
 # 22.0.5
 
 - [changed] Bumped internal dependencies.

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -76,8 +76,19 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, LifecycleObser
 
   // If the `mainThreadRunnableTime` was set within this duration, the assumption
   // is that it was called immediately before `onActivityCreated` in foreground starts on API 34+.
-  // See b/339891952.
-  private static final long MAX_BACKGROUND_RUNNABLE_DELAY = TimeUnit.MILLISECONDS.toMicros(50);
+  //
+  // On API 34+, Android may drain posted main-thread runnables before processing the
+  // Activity-launch Binder transaction even during a genuine cold foreground start. The
+  // resulting gap between `StartFromBackgroundRunnable` firing and the first
+  // `onActivityCreated` is dominated by system scheduling, not by app work, and has been
+  // measured at ~316ms on a minimal repro app and ~204ms on a large production app on
+  // physical Pixel devices. The threshold must therefore comfortably exceed these
+  // real-world gaps; 1000ms provides ~5x headroom over the worst measured cold-start gap
+  // while still being two orders of magnitude below `MAX_LATENCY_BEFORE_UI_INIT` so that
+  // genuine warm starts (where the process was forked for background work seconds-to-
+  // minutes before any activity launch) remain correctly suppressed.
+  // See b/339891952 and https://github.com/firebase/firebase-android-sdk/issues/8103.
+  private static final long MAX_BACKGROUND_RUNNABLE_DELAY = TimeUnit.MILLISECONDS.toMicros(1000);
 
   // Core pool size 0 allows threads to shut down if they're idle
   private static final int CORE_POOL_SIZE = 0;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -347,7 +347,25 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, LifecycleObser
    * before `onActivityCreated`, the
    * assumption is that it was called immediately before the activity lifecycle callbacks in a
    * foreground start.
-   * See b/339891952.
+   * See b/339891952 and https://github.com/firebase/firebase-android-sdk/issues/8103.
+   *
+   * <p>TODO(b/339891952): Replace this timing-window heuristic with a causal signal.
+   * The current approach infers "was the process forked to launch an Activity?" from the
+   * ordering of a posted runnable vs the first onActivityCreated callback, which is
+   * inherently fragile (its calibration depends on Android scheduling behavior that has
+   * already shifted once on API 34+ and could shift again). Better candidates:
+   * <ul>
+   *   <li>API 35+: use {@code ActivityManager.getHistoricalProcessStartReasons} /
+   *       {@code ApplicationStartInfo}, which authoritatively reports the start reason
+   *       ({@code START_REASON_LAUNCHER}, {@code START_REASON_SERVICE},
+   *       {@code START_REASON_CONTENT_PROVIDER}, etc.). This removes the heuristic
+   *       entirely on supported devices.
+   *   <li>API 34: capture {@code ActivityManager.RunningAppProcessInfo.importanceReasonCode}
+   *       and {@code .importance} once early in {@code FirebasePerfEarly} (before any of
+   *       our own ContentProvider work mutates the cause), and combine with the timing
+   *       window as a fallback for ambiguous cases.
+   * </ul>
+   * Adopting either of these would also let the API-34-vs-pre-34 branch below collapse.
    */
   private void resolveIsStartedFromBackground() {
     // If the mainThreadRunnableTime is null, either the runnable hasn't run, or this check has

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/AppStartTraceTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/AppStartTraceTest.java
@@ -239,7 +239,7 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void testStartFromBackground_within50ms() {
+  public void testStartFromBackground_within1000ms() {
     FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
     Timer fakeTimer = spy(new Timer(currentTime));
     AppStartTrace trace =
@@ -248,7 +248,7 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
     trace.setMainThreadRunnableTime(fakeTimer);
 
     // See AppStartTrace.MAX_BACKGROUND_RUNNABLE_DELAY.
-    when(fakeTimer.getDurationMicros()).thenReturn(TimeUnit.MILLISECONDS.toMicros(50) - 1);
+    when(fakeTimer.getDurationMicros()).thenReturn(TimeUnit.MILLISECONDS.toMicros(1000) - 1);
     trace.onActivityCreated(activity1, bundle);
     Assert.assertNotNull(trace.getOnCreateTime());
     ++currentTime;
@@ -267,7 +267,7 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void testStartFromBackground_moreThan50ms() {
+  public void testStartFromBackground_moreThan1000ms() {
     FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
     Timer fakeTimer = spy(new Timer(currentTime));
     AppStartTrace trace =
@@ -276,7 +276,7 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
     trace.setMainThreadRunnableTime(fakeTimer);
 
     // See AppStartTrace.MAX_BACKGROUND_RUNNABLE_DELAY.
-    when(fakeTimer.getDurationMicros()).thenReturn(TimeUnit.MILLISECONDS.toMicros(50) + 1);
+    when(fakeTimer.getDurationMicros()).thenReturn(TimeUnit.MILLISECONDS.toMicros(1000) + 1);
     trace.onActivityCreated(activity1, bundle);
     Assert.assertNull(trace.getOnCreateTime());
     ++currentTime;
@@ -286,6 +286,63 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
     trace.onActivityResumed(activity1);
     Assert.assertNull(trace.getOnResumeTime());
     // There should be no trace sent.
+    fakeExecutorService.runAll();
+    verify(transportManager, times(0))
+        .log(
+            traceArgumentCaptor.capture(),
+            ArgumentMatchers.nullable(ApplicationProcessState.class));
+  }
+
+  // Regression test for https://github.com/firebase/firebase-android-sdk/issues/8103.
+  // On API 34+ physical devices, the gap between StartFromBackgroundRunnable firing and the
+  // first onActivityCreated has been measured at ~204-316ms on real apps; the previous 50ms
+  // threshold misclassified these as background starts and suppressed _app_start traces.
+  @Test
+  public void testStartFromBackground_largeAppGap_isForegroundStart() {
+    FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
+    Timer fakeTimer = spy(new Timer(currentTime));
+    AppStartTrace trace =
+        new AppStartTrace(transportManager, clock, configResolver, fakeExecutorService);
+    trace.registerActivityLifecycleCallbacks(appContext);
+    trace.setMainThreadRunnableTime(fakeTimer);
+
+    // Simulates the API 34+ scheduling gap observed in real-world apps.
+    when(fakeTimer.getDurationMicros()).thenReturn(TimeUnit.MILLISECONDS.toMicros(300));
+    trace.onActivityCreated(activity1, bundle);
+    Assert.assertNotNull(trace.getOnCreateTime());
+    ++currentTime;
+    trace.onActivityStarted(activity1);
+    Assert.assertNotNull(trace.getOnStartTime());
+    ++currentTime;
+    trace.onActivityResumed(activity1);
+    Assert.assertNotNull(trace.getOnResumeTime());
+    fakeExecutorService.runAll();
+    verify(transportManager, times(1))
+        .log(
+            traceArgumentCaptor.capture(),
+            ArgumentMatchers.nullable(ApplicationProcessState.class));
+  }
+
+  // Genuine warm starts (process alive for background work, activity launched seconds later)
+  // must still be classified as background and suppressed.
+  @Test
+  public void testStartFromBackground_warmStart_stillSuppressed() {
+    FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
+    Timer fakeTimer = spy(new Timer(currentTime));
+    AppStartTrace trace =
+        new AppStartTrace(transportManager, clock, configResolver, fakeExecutorService);
+    trace.registerActivityLifecycleCallbacks(appContext);
+    trace.setMainThreadRunnableTime(fakeTimer);
+
+    when(fakeTimer.getDurationMicros()).thenReturn(TimeUnit.SECONDS.toMicros(10));
+    trace.onActivityCreated(activity1, bundle);
+    Assert.assertNull(trace.getOnCreateTime());
+    ++currentTime;
+    trace.onActivityStarted(activity1);
+    Assert.assertNull(trace.getOnStartTime());
+    ++currentTime;
+    trace.onActivityResumed(activity1);
+    Assert.assertNull(trace.getOnResumeTime());
     fakeExecutorService.runAll();
     verify(transportManager, times(0))
         .log(


### PR DESCRIPTION
# firebase-perf: shadow-capture process start cause (#8103 follow-up, PR 1)


`AppStartTrace`'s current "was this process forked to satisfy a foreground activity
launch?" heuristic relies on the relative ordering of a posted main-thread runnable vs
the first `Activity.onCreate()` Binder transaction. That ordering is undocumented,
already shifted once on API 34+ (originally fixed in PR #7281 / #5920, threshold-tightened
into a regression that #8103 reports, and shipping-patched to 1000 ms on the parent
commit of this PR), and could shift again.

This PR adds an OS-provided causal signal alongside the existing decision and emits both
as custom attributes on the existing `_experiment_app_start_ttid` trace, so we can
compare them in production telemetry before deciding (in a later PR) whether to flip the
authoritative classification.

## Background

We ran a standalone experiment app
(`api34-appstart-cause/`) (TODO: UPLOAD TEST APP) on emulators at API 33, 34, 35, and 36
to validate the causal-signal approach before introducing it to the SDK. The full
results are out of tree but the headline findings are:

| API | Race reproduces on emulator? | `ApplicationStartInfo` available? | `importance == FOREGROUND` on launcher tap? |
|---|---|---|---|
| 33 | No | No (API 35+ feature) | Yes |
| 34 | No (matches PhilGlass's 2024 note from `b/339891952`) | No | Yes |
| 35 | **Yes — 89 ms gap** | **Yes — reason=LAUNCHER from first checkpoint** | Yes |
| 36 | **Yes — 86 ms gap** | **Yes — reason=LAUNCHER from first checkpoint** | Yes |

So on API 35+, `ApplicationStartInfo.getReason()` is authoritative and available at the
first ContentProvider checkpoint. On API 34, `RunningAppProcessInfo.importance` at first
capture is a reliable foreground signal even when the timing-race itself doesn't
reproduce. Pre-API-34, the existing logic is correct and we don't try.

`importanceReasonCode` was tested and is **not** useful — always `UNKNOWN (0)` across
all runs.

## Implementation

#### New file: `ProcessStartCause.java`

OS-version-conditioned helper. One static factory `capture(@Nullable Context)`, immutable
fields, no held references:

```java
ProcessStartCause cause = ProcessStartCause.capture(appContext);
cause.cause;            // FOREGROUND / BACKGROUND / UNKNOWN
cause.reasonName;       // "LAUNCHER" / "BROADCAST" / ... on API 35+, "" otherwise
cause.startTypeName;    // "COLD" / "WARM" / "HOT" on API 35+, "" otherwise
cause.importance;       // RunningAppProcessInfo.importance, or -1 if unread
cause.apiLevel;         // Build.VERSION.SDK_INT at capture
```

- **API 35+**: `ActivityManager.getHistoricalProcessStartReasons(1)` via reflection. The
  repo's `compileSdkVersion` is 34, so `ApplicationStartInfo` can't be imported directly.
  Constants (`START_REASON_*` / `START_TYPE_*`) are redeclared as local `int` literals
  matching the public AOSP values; the helper logs the raw int as `UNKNOWN_<n>` if the
  values ever drift.
- **API 34**: `ActivityManager.getMyMemoryState(RunningAppProcessInfo)`.
  `IMPORTANCE_FOREGROUND` ⇒ `FOREGROUND`; anything else ⇒ `UNKNOWN` (we don't classify
  background here — caller falls back to the existing heuristic).
- **API < 34**: `Cause.UNKNOWN`. The pre-API-34 timing logic is correct on those
  versions; the helper still captures `importance` for telemetry continuity.

#### `AppStartTrace.java`

- One new field, captured once inside `registerActivityLifecycleCallbacks` (called from
  `FirebasePerfEarly` during the ContentProvider init chain — the experiment confirmed
  this is early enough that OS-set values reflect the original fork cause).
- One new private method `addProcessStartCauseExperimentAttributes(...)` that puts six
  custom attributes on the existing `_experiment_app_start_ttid` trace, alongside the
  existing `systemDeterminedForeground` attribute:

| Attribute | Values |
|---|---|
| `processStartCause` | `foreground` / `background` / `unknown` |
| `processStartReasonApi35Plus` | e.g. `LAUNCHER`, `BROADCAST`, `CONTENT_PROVIDER`, or `""` |
| `processStartTypeApi35Plus` | `COLD` / `WARM` / `HOT` or `""` |
| `processImportanceApi34` | raw int as string (only on API 34) or `""` |
| `timingWindowDecision` | `foreground` / `background` (mirrors the existing decision) |
| `decisionAgreed` | `true` / `false` / `unknown` |

- Two new `@VisibleForTesting` accessors for the cause field.
- **Unchanged:** `MAX_BACKGROUND_RUNNABLE_DELAY`, `mainThreadRunnableTime`,
  `StartFromBackgroundRunnable`, `resolveIsStartedFromBackground()`, and every
  `isStartedFromBackground`-gated early return in the lifecycle callbacks.

### Tests

- **New `ProcessStartCauseTest`** (7 cases) — covers null context, pre-API-34 path,
  API 34 with `FOREGROUND` / `SERVICE` / `CACHED` importance, constructor preservation,
  and the holder view. The API 35+ reflective branch is exercised end-to-end in the
  out-of-tree experiment app rather than under Robolectric 4.12, which doesn't support
  `@Config(sdk = 35)`.
- **`AppStartTraceTest`** gains `experimentTrace_includesProcessStartCauseAttributes`
  which injects a known `ProcessStartCause` and asserts all six attributes appear on the
  experiment trace with the expected values.


## Rollout intent (post-merge)

1. Wait for `_experiment_app_start_ttid` data to accumulate from the field. Compare
   `processStartCause` vs `timingWindowDecision`, grouped by `processStartReasonApi35Plus`
   and `processImportanceApi34`.
2. Confirm the experiment's emulator-derived expectations hold on physical hardware,
   especially the `processImportanceApi34 == 100 (FOREGROUND)` → cold-launcher-start
   correspondence.
3. PR 2 (separate PR): switch the actual classification to consult `ProcessStartCause`
   first, gated by a remote-config kill switch, with the timing window as fallback.
4. PR 3 (separate PR): once PR 2 is stable in production, delete the timing-window
   machinery for API 34+ entirely.

This PR ships none of those next steps — it only adds the telemetry that informs PR 2.

## Test plan

- [x] `./gradlew :firebase-perf:spotlessApply`
- [x] `./gradlew :firebase-perf:testReleaseUnitTest` — 12 test suites, 0 failures /
      0 errors. `AppStartTraceTest`: 9/9 (was 8/8). `ProcessStartCauseTest`: 7/7 (new).
- [x] Compile under `compileSdkVersion = 34` confirmed (`compileReleaseJavaWithJavac`
      passes; the API 35+ reference is reflective so no missing-class warnings).
- [ ] Manual: run the standalone experiment app at
      `~/AndroidStudioProjects/api34-appstart-cause/` against a physical API 34 Pixel
      device to confirm the importance signal matches the bug-reported environment.
      (Not gating this PR — PR 1 is observation-only and the emulator data already
      validates the signal collection.)
