### PR TITLE
dataconnect(chore): Create AuthUid value class to add some type safety compared to raw strings

### DIFF
--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAuth.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAuth.kt
@@ -57,8 +57,8 @@ internal class DataConnectAuth(
     }
 
   @JvmInline
-  value class AuthUid(val authUid: String) {
-    override fun toString() = "AuthUid($authUid)"
+  value class AuthUid(val string: String) {
+    override fun toString() = "AuthUid($string)"
   }
 
   data class GetAuthTokenResult(override val token: String?, val authUid: AuthUid?) :

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAuth.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAuth.kt
@@ -56,7 +56,13 @@ internal class DataConnectAuth(
       GetAuthTokenResult(it.token, it.getAuthUid())
     }
 
-  data class GetAuthTokenResult(override val token: String?, val authUid: String?) : GetTokenResult
+  @JvmInline
+  value class AuthUid(val authUid: String) {
+    override fun toString() = "AuthUid($authUid)"
+  }
+
+  data class GetAuthTokenResult(override val token: String?, val authUid: AuthUid?) :
+    GetTokenResult
 
   private class IdTokenListenerImpl(private val logger: Logger) : IdTokenListener {
     override fun onIdTokenChanged(tokenResult: InternalTokenResult) {
@@ -68,6 +74,9 @@ internal class DataConnectAuth(
 
     // The "sub" claim is documented to be "a non-empty string and must be the uid of the user or
     // device". See http://goo.gle/4oGjEQt for the relevant Firebase documentation.
-    fun com.google.firebase.auth.GetTokenResult.getAuthUid(): String? = claims["sub"] as? String
+    fun com.google.firebase.auth.GetTokenResult.getAuthUid(): AuthUid? {
+      val sub = claims["sub"] as? String
+      return if (sub === null) null else AuthUid(sub)
+    }
   }
 }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -16,6 +16,7 @@
 
 package com.google.firebase.dataconnect.core
 
+import com.google.firebase.dataconnect.core.DataConnectAuth.AuthUid
 import com.google.firebase.dataconnect.core.LoggerGlobals.debug
 import com.google.firebase.dataconnect.util.CoroutineUtils.completedFlow
 import com.google.firebase.dataconnect.util.GrpcBidiFlow
@@ -72,7 +73,7 @@ import kotlinx.coroutines.launch
  * @param coroutineScope The [CoroutineScope] to whose lifetime this object belongs.
  */
 internal class DataConnectBidiConnectStream(
-  flow: Flow<GrpcBidiFlow.Event<StreamRequestProto, StreamResponseProto, String?>>,
+  flow: Flow<GrpcBidiFlow.Event<StreamRequestProto, StreamResponseProto, AuthUid?>>,
   private val coroutineScope: CoroutineScope,
   private val logger: Logger,
 ) {
@@ -278,11 +279,11 @@ internal class DataConnectBidiConnectStream(
 
     class Connected(
       val connectionId: String,
-      val authUid: String?,
+      val authUid: AuthUid?,
       val outgoingRequests: SendChannel<StreamRequestProto>,
     ) : Connection {
       constructor(
-        event: GrpcBidiFlow.Event.ConnectionInfo<StreamRequestProto, String?>
+        event: GrpcBidiFlow.Event.ConnectionInfo<StreamRequestProto, AuthUid?>
       ) : this(event.connectionId, event.connectionCookie, event.outgoingRequests)
 
       override fun toString() = "Connected(connectionId=$connectionId)"
@@ -342,7 +343,7 @@ internal class DataConnectBidiConnectStream(
   ): Flow<SubscriptionEvent.Message> {
 
     fun SendChannel<StreamRequestProto>.trySendOrThrow(
-      authUid: String?,
+      authUid: AuthUid?,
       request: StreamRequestProto
     ) {
       val sendResult = trySend(request)
@@ -359,7 +360,7 @@ internal class DataConnectBidiConnectStream(
     }
 
     suspend fun SendChannel<StreamRequestProto>.subscribeOrResumeLoop(
-      authUid: String?,
+      authUid: AuthUid?,
       subscribeOrResumeSignal: ConflatedSignal,
     ) {
       var subscribed = false

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadata.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadata.kt
@@ -118,7 +118,7 @@ internal class DataConnectGrpcMetadata(
             values.map {
               when (key.name()) {
                 firebaseAuthTokenHeader.name() ->
-                  it.toScrubbedAccessToken() + " (authUid=${authUid?.authUid})"
+                  it.toScrubbedAccessToken() + " (authUid=${authUid?.string})"
                 firebaseAppCheckTokenHeader.name() -> it.toScrubbedAccessToken()
                 else -> it
               }
@@ -155,7 +155,7 @@ internal class DataConnectGrpcMetadata(
             value?.let {
               when (key) {
                 firebaseAuthTokenHeader.name() ->
-                  it.toScrubbedAccessToken() + " (authUid=${authUid?.authUid})"
+                  it.toScrubbedAccessToken() + " (authUid=${authUid?.string})"
                 firebaseAppCheckTokenHeader.name() -> it.toScrubbedAccessToken()
                 else -> it
               }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadata.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadata.kt
@@ -20,6 +20,7 @@ import android.os.Build
 import com.google.firebase.FirebaseApp
 import com.google.firebase.dataconnect.BuildConfig
 import com.google.firebase.dataconnect.FirebaseDataConnect
+import com.google.firebase.dataconnect.core.DataConnectAuth.AuthUid
 import com.google.firebase.dataconnect.core.Globals.toScrubbedAccessToken
 import com.google.firebase.dataconnect.core.LoggerGlobals.Logger
 import com.google.firebase.dataconnect.core.LoggerGlobals.debug
@@ -100,7 +101,7 @@ internal class DataConnectGrpcMetadata(
   companion object {
     // TODO: Move this to ProtoUtil.kt where it would live alongside other related methods.
     // NOTE: Keep the implementation of this method in parity with StructProtoBuilder.putHeaders().
-    fun Metadata.toStructProto(authUid: String?): Struct = buildStructProto {
+    fun Metadata.toStructProto(authUid: AuthUid?): Struct = buildStructProto {
       val keys: List<Metadata.Key<String>> = run {
         val keySet: MutableSet<String> = keys().toMutableSet()
         // Always explicitly include the auth header in the returned string, even if it is absent.
@@ -116,7 +117,8 @@ internal class DataConnectGrpcMetadata(
           else {
             values.map {
               when (key.name()) {
-                firebaseAuthTokenHeader.name() -> it.toScrubbedAccessToken() + " (authUid=$authUid)"
+                firebaseAuthTokenHeader.name() ->
+                  it.toScrubbedAccessToken() + " (authUid=${authUid?.authUid})"
                 firebaseAppCheckTokenHeader.name() -> it.toScrubbedAccessToken()
                 else -> it
               }
@@ -131,7 +133,11 @@ internal class DataConnectGrpcMetadata(
 
     // TODO: Move this to ProtoUtil.kt where it would live alongside other related methods.
     // NOTE: Keep the implementation of this method in parity with Metadata.toStructProto().
-    fun StructProtoBuilder.putHeaders(authUid: String?, key: String, headers: Map<String, String>) {
+    fun StructProtoBuilder.putHeaders(
+      authUid: AuthUid?,
+      key: String,
+      headers: Map<String, String>
+    ) {
       putStruct(key) {
         val keys: List<String> =
           buildSet {
@@ -148,7 +154,8 @@ internal class DataConnectGrpcMetadata(
           val scrubbedValue =
             value?.let {
               when (key) {
-                firebaseAuthTokenHeader.name() -> it.toScrubbedAccessToken() + " (authUid=$authUid)"
+                firebaseAuthTokenHeader.name() ->
+                  it.toScrubbedAccessToken() + " (authUid=${authUid?.authUid})"
                 firebaseAppCheckTokenHeader.name() -> it.toScrubbedAccessToken()
                 else -> it
               }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -24,6 +24,7 @@ import com.google.firebase.dataconnect.DataConnectPath
 import com.google.firebase.dataconnect.DataConnectPathSegment
 import com.google.firebase.dataconnect.FirebaseDataConnect
 import com.google.firebase.dataconnect.QueryRef.FetchPolicy
+import com.google.firebase.dataconnect.core.DataConnectAuth.AuthUid
 import com.google.firebase.dataconnect.core.DataConnectGrpcMetadata.Companion.toStructProto
 import com.google.firebase.dataconnect.core.LoggerGlobals.Logger
 import com.google.firebase.dataconnect.core.LoggerGlobals.debug
@@ -240,7 +241,7 @@ internal class DataConnectGrpcRPCs(
 
   private class QueryCacheInfo(
     val cacheDb: DataConnectCacheDatabase,
-    val authUid: String?,
+    val authUid: AuthUid?,
     val queryId: ImmutableByteArray,
     val maxAge: DurationProto,
   )
@@ -427,7 +428,7 @@ internal class DataConnectGrpcRPCs(
 
   private inner class ConnectGrpcBidiFlowListener(
     private val streamId: String,
-    private val authUid: String?,
+    private val authUid: AuthUid?,
     private val initRequest: StreamRequest,
     private val kotlinMethodName: String,
   ) : GrpcBidiFlow.Listener<StreamRequest, StreamResponse> {
@@ -511,7 +512,7 @@ internal class DataConnectGrpcRPCs(
   }
 
   @Suppress("unused")
-  private class ConnectGrpcBidiFlowListenerFormatter(private val authUid: String?) :
+  private class ConnectGrpcBidiFlowListenerFormatter(private val authUid: AuthUid?) :
     GrpcBidiFlowListenerMessageFormatter.Formatter<StreamRequest, StreamResponse>() {
     override fun connectionStartingHeaders(headers: Metadata?): String =
       headers?.toStructProto(authUid)?.toCompactString().toString()
@@ -682,7 +683,7 @@ internal class DataConnectGrpcRPCs(
       metadata: Metadata?,
       request: () -> Struct,
       requestTypeName: String,
-      authUid: String?,
+      authUid: AuthUid?,
     ) = debug {
       val requestStruct = request()
       val struct = buildStructProto {

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/sqlite/DataConnectCacheDatabase.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/sqlite/DataConnectCacheDatabase.kt
@@ -18,6 +18,7 @@ package com.google.firebase.dataconnect.sqlite
 
 import android.annotation.SuppressLint
 import android.database.sqlite.SQLiteDatabase
+import com.google.firebase.dataconnect.core.DataConnectAuth.AuthUid
 import com.google.firebase.dataconnect.core.Logger
 import com.google.firebase.dataconnect.core.LoggerGlobals.warn
 import com.google.firebase.dataconnect.sqlite.DataConnectCacheDatabase.GetQueryResultResult
@@ -198,7 +199,7 @@ internal class DataConnectCacheDatabase(
 
   @JvmInline private value class SqliteEntityId(val sqliteRowId: Long)
 
-  private fun SQLiteDatabase.getOrInsertAuthUid(authUid: String?): SqliteUserId {
+  private fun SQLiteDatabase.getOrInsertAuthUid(authUid: AuthUid?): SqliteUserId {
     execSQL(logger, "INSERT OR IGNORE INTO users (auth_uid) VALUES (?)", arrayOf(authUid))
     return rawQuery(
       logger,
@@ -451,7 +452,7 @@ internal class DataConnectCacheDatabase(
   }
 
   suspend fun getQueryResult(
-    authUid: String?,
+    authUid: AuthUid?,
     queryId: ImmutableByteArray,
     currentTimeMillis: Long,
     staleResult: KClass<out GetQueryResultResult>,
@@ -524,7 +525,7 @@ internal class DataConnectCacheDatabase(
   }
 
   suspend fun insertQueryResult(
-    authUid: String?,
+    authUid: AuthUid?,
     queryId: ImmutableByteArray,
     queryData: Struct,
     maxAge: DurationProto,

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/sqlite/DataConnectCacheDatabase.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/sqlite/DataConnectCacheDatabase.kt
@@ -200,16 +200,16 @@ internal class DataConnectCacheDatabase(
   @JvmInline private value class SqliteEntityId(val sqliteRowId: Long)
 
   private fun SQLiteDatabase.getOrInsertAuthUid(authUid: AuthUid?): SqliteUserId {
-    execSQL(logger, "INSERT OR IGNORE INTO users (auth_uid) VALUES (?)", arrayOf(authUid?.authUid))
+    execSQL(logger, "INSERT OR IGNORE INTO users (auth_uid) VALUES (?)", arrayOf(authUid?.string))
     return rawQuery(
       logger,
       "SELECT id FROM users WHERE auth_uid ${if (authUid === null) "IS NULL" else "= ?"}",
-      if (authUid === null) emptyArray() else arrayOf(authUid.authUid),
+      if (authUid === null) emptyArray() else arrayOf(authUid.string),
     ) { cursor ->
       if (cursor.moveToNext()) {
         SqliteUserId(cursor.getLong(0))
       } else {
-        throw AuthUidNotFoundException("authUid=${authUid?.authUid} (internal error m5m52ahrxz)")
+        throw AuthUidNotFoundException("authUid=${authUid?.string} (internal error m5m52ahrxz)")
       }
     }
   }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/sqlite/DataConnectCacheDatabase.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/sqlite/DataConnectCacheDatabase.kt
@@ -200,16 +200,16 @@ internal class DataConnectCacheDatabase(
   @JvmInline private value class SqliteEntityId(val sqliteRowId: Long)
 
   private fun SQLiteDatabase.getOrInsertAuthUid(authUid: AuthUid?): SqliteUserId {
-    execSQL(logger, "INSERT OR IGNORE INTO users (auth_uid) VALUES (?)", arrayOf(authUid))
+    execSQL(logger, "INSERT OR IGNORE INTO users (auth_uid) VALUES (?)", arrayOf(authUid?.authUid))
     return rawQuery(
       logger,
       "SELECT id FROM users WHERE auth_uid ${if (authUid === null) "IS NULL" else "= ?"}",
-      if (authUid === null) emptyArray() else arrayOf(authUid),
+      if (authUid === null) emptyArray() else arrayOf(authUid.authUid),
     ) { cursor ->
       if (cursor.moveToNext()) {
         SqliteUserId(cursor.getLong(0))
       } else {
-        throw AuthUidNotFoundException("authUid=$authUid (internal error m5m52ahrxz)")
+        throw AuthUidNotFoundException("authUid=${authUid?.authUid} (internal error m5m52ahrxz)")
       }
     }
   }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/ProtoUtil.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/ProtoUtil.kt
@@ -18,6 +18,7 @@ package com.google.firebase.dataconnect.util
 
 import com.google.firebase.dataconnect.DataConnectPath
 import com.google.firebase.dataconnect.DataConnectPathSegment
+import com.google.firebase.dataconnect.core.DataConnectAuth.AuthUid
 import com.google.firebase.dataconnect.core.DataConnectGrpcMetadata.Companion.putHeaders
 import com.google.firebase.dataconnect.core.DataConnectSerialization.Companion.toErrorInfoImpl
 import com.google.firebase.dataconnect.toPathString
@@ -297,11 +298,11 @@ internal object ProtoUtil {
     }
 
   fun StreamRequest.toCompactString(
-    authUid: String?,
+    authUid: AuthUid?,
     keySortSelector: ((String) -> String)? = ::streamRequestKeySortSelector,
   ): String = toStructProto(authUid).toCompactString(keySortSelector)
 
-  fun StreamRequest.toStructProto(authUid: String?): Struct = buildStructProto {
+  fun StreamRequest.toStructProto(authUid: AuthUid?): Struct = buildStructProto {
     name.takeIf { it.isNotEmpty() }?.let { put("name", it) }
     requestId.takeIf { it.isNotEmpty() }?.let { put("requestId", it) }
     dataEtag.takeIf { it.isNotEmpty() }?.let { put("data_etag", it) }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
@@ -23,6 +23,7 @@ import com.google.firebase.auth.GetTokenResult
 import com.google.firebase.auth.internal.IdTokenListener
 import com.google.firebase.auth.internal.InternalAuthProvider
 import com.google.firebase.dataconnect.DataConnectException
+import com.google.firebase.dataconnect.core.DataConnectAuth.AuthUid
 import com.google.firebase.dataconnect.core.Globals.toScrubbedAccessToken
 import com.google.firebase.dataconnect.testutil.DataConnectLogLevelRule
 import com.google.firebase.dataconnect.testutil.DelayedDeferred
@@ -326,7 +327,7 @@ class DataConnectAuthUnitTest {
 
     val result = dataConnectAuth.getToken(requestId)
 
-    result.shouldNotBeNull().authUid shouldBe uid
+    result.shouldNotBeNull().authUid shouldBe AuthUid(uid)
   }
 
   @Test

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/sqlite/DataConnectCacheDatabaseUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/sqlite/DataConnectCacheDatabaseUnitTest.kt
@@ -17,6 +17,7 @@
 package com.google.firebase.dataconnect.sqlite
 
 import android.database.sqlite.SQLiteDatabase
+import com.google.firebase.dataconnect.core.DataConnectAuth.AuthUid
 import com.google.firebase.dataconnect.core.Logger
 import com.google.firebase.dataconnect.sqlite.DataConnectCacheDatabase.GetQueryResultResult
 import com.google.firebase.dataconnect.sqlite.DataConnectCacheDatabase.GetQueryResultResult.Found
@@ -276,7 +277,7 @@ class DataConnectCacheDatabaseUnitTest {
       Arb.proto.struct()
     ) { authUid, queryId, maxAge, structSample ->
       dataConnectCacheDatabase.insertQueryResult(
-        authUid.string,
+        authUid.authUid,
         queryId.bytes,
         structSample.struct,
         maxAge = maxAge,
@@ -286,7 +287,7 @@ class DataConnectCacheDatabaseUnitTest {
 
       val result =
         dataConnectCacheDatabase.getQueryResult(
-          authUid.string,
+          authUid.authUid,
           queryId.bytes,
           currentTimeMillis = 0L,
           staleResult = Stale::class,
@@ -309,7 +310,7 @@ class DataConnectCacheDatabaseUnitTest {
     ) { authUid, queryId, maxAge, structSamples ->
       structSamples.forEach {
         dataConnectCacheDatabase.insertQueryResult(
-          authUid.string,
+          authUid.authUid,
           queryId.bytes,
           it.struct,
           maxAge = maxAge,
@@ -320,7 +321,7 @@ class DataConnectCacheDatabaseUnitTest {
 
       val result =
         dataConnectCacheDatabase.getQueryResult(
-          authUid.string,
+          authUid.authUid,
           queryId.bytes,
           currentTimeMillis = 0L,
           staleResult = Stale::class,
@@ -342,7 +343,7 @@ class DataConnectCacheDatabaseUnitTest {
       Arb.twoValues(Arb.proto.struct())
     ) { (authUid1, authUid2), queryId, maxAge, (structSample1, structSample2) ->
       dataConnectCacheDatabase.insertQueryResult(
-        authUid1.string,
+        authUid1.authUid,
         queryId.bytes,
         structSample1.struct,
         maxAge = maxAge,
@@ -350,7 +351,7 @@ class DataConnectCacheDatabaseUnitTest {
         getEntityIdForPath = null,
       )
       dataConnectCacheDatabase.insertQueryResult(
-        authUid2.string,
+        authUid2.authUid,
         queryId.bytes,
         structSample2.struct,
         maxAge = maxAge,
@@ -360,7 +361,7 @@ class DataConnectCacheDatabaseUnitTest {
 
       val result1 =
         dataConnectCacheDatabase.getQueryResult(
-          authUid1.string,
+          authUid1.authUid,
           queryId.bytes,
           currentTimeMillis = 0L,
           staleResult = Stale::class,
@@ -368,7 +369,7 @@ class DataConnectCacheDatabaseUnitTest {
       val struct1FromDb = result1.shouldBeInstanceOf<Found>().struct
       val result2 =
         dataConnectCacheDatabase.getQueryResult(
-          authUid2.string,
+          authUid2.authUid,
           queryId.bytes,
           currentTimeMillis = 0L,
           staleResult = Stale::class,
@@ -393,7 +394,7 @@ class DataConnectCacheDatabaseUnitTest {
       Arb.twoValues(Arb.proto.struct())
     ) { authUid, (queryId1, queryId2), maxAge, (structSample1, structSample2) ->
       dataConnectCacheDatabase.insertQueryResult(
-        authUid.string,
+        authUid.authUid,
         queryId1.bytes,
         structSample1.struct,
         maxAge = maxAge,
@@ -401,7 +402,7 @@ class DataConnectCacheDatabaseUnitTest {
         getEntityIdForPath = null,
       )
       dataConnectCacheDatabase.insertQueryResult(
-        authUid.string,
+        authUid.authUid,
         queryId2.bytes,
         structSample2.struct,
         maxAge = maxAge,
@@ -411,7 +412,7 @@ class DataConnectCacheDatabaseUnitTest {
 
       val result1 =
         dataConnectCacheDatabase.getQueryResult(
-          authUid.string,
+          authUid.authUid,
           queryId1.bytes,
           currentTimeMillis = 0L,
           staleResult = Stale::class,
@@ -419,7 +420,7 @@ class DataConnectCacheDatabaseUnitTest {
       val struct1FromDb = result1.shouldBeInstanceOf<Found>().struct
       val result2 =
         dataConnectCacheDatabase.getQueryResult(
-          authUid.string,
+          authUid.authUid,
           queryId2.bytes,
           currentTimeMillis = 0L,
           staleResult = Stale::class,
@@ -444,7 +445,7 @@ class DataConnectCacheDatabaseUnitTest {
       QueryResultArb(entityCountRange = 1..5),
     ) { authUid, queryId, maxAge, queryResult ->
       dataConnectCacheDatabase.insertQueryResult(
-        authUid.string,
+        authUid.authUid,
         queryId.bytes,
         queryResult.hydratedStruct,
         maxAge = maxAge,
@@ -454,7 +455,7 @@ class DataConnectCacheDatabaseUnitTest {
 
       val result =
         dataConnectCacheDatabase.getQueryResult(
-          authUid.string,
+          authUid.authUid,
           queryId.bytes,
           currentTimeMillis = 0L,
           staleResult = Stale::class,
@@ -497,7 +498,7 @@ class DataConnectCacheDatabaseUnitTest {
       queryResultsByAuthUid.forEach { (authUid, queryResults) ->
         queryIds.zip(queryResults).forEach { (queryId, queryResult) ->
           dataConnectCacheDatabase.insertQueryResult(
-            authUid.string,
+            authUid.authUid,
             queryId.bytes,
             queryResult.hydratedStruct,
             maxAge = maxAge,
@@ -512,7 +513,7 @@ class DataConnectCacheDatabaseUnitTest {
           queryIds.zip(queryResults).forEachIndexed { queryIdIndex, (queryId, queryResult) ->
             val result =
               dataConnectCacheDatabase.getQueryResult(
-                authUid.string,
+                authUid.authUid,
                 queryId.bytes,
                 currentTimeMillis = 0L,
                 staleResult = Stale::class,
@@ -548,7 +549,7 @@ class DataConnectCacheDatabaseUnitTest {
 
       queryIds.zip(queryResults).forEach { (queryId, queryResult) ->
         dataConnectCacheDatabase.insertQueryResult(
-          authUid.string,
+          authUid.authUid,
           queryId.bytes,
           queryResult.hydratedStruct,
           maxAge = maxAge,
@@ -560,7 +561,7 @@ class DataConnectCacheDatabaseUnitTest {
       queryIds.zip(queryResults).forEachIndexed { index, (queryId, queryResult) ->
         val result =
           dataConnectCacheDatabase.getQueryResult(
-            authUid.string,
+            authUid.authUid,
             queryId.bytes,
             currentTimeMillis = 0L,
             staleResult = Stale::class,
@@ -592,7 +593,7 @@ class DataConnectCacheDatabaseUnitTest {
       val queryResult2 = queryResultArb.bind()
 
       dataConnectCacheDatabase.insertQueryResult(
-        authUid.string,
+        authUid.authUid,
         queryId1.bytes,
         queryResult1.hydratedStruct,
         maxAge = maxAge,
@@ -600,7 +601,7 @@ class DataConnectCacheDatabaseUnitTest {
         getEntityIdForPath = queryResult1::getEntityIdForPath,
       )
       dataConnectCacheDatabase.insertQueryResult(
-        authUid.string,
+        authUid.authUid,
         queryId2.bytes,
         queryResult2.hydratedStruct,
         maxAge = maxAge,
@@ -611,7 +612,7 @@ class DataConnectCacheDatabaseUnitTest {
       withClue("query2") {
         val result =
           dataConnectCacheDatabase.getQueryResult(
-            authUid.string,
+            authUid.authUid,
             queryId2.bytes,
             currentTimeMillis = 0L,
             staleResult = Stale::class,
@@ -622,7 +623,7 @@ class DataConnectCacheDatabaseUnitTest {
       withClue("query1") {
         val result =
           dataConnectCacheDatabase.getQueryResult(
-            authUid.string,
+            authUid.authUid,
             queryId1.bytes,
             currentTimeMillis = 0L,
             staleResult = Stale::class,
@@ -858,7 +859,7 @@ class DataConnectCacheDatabaseUnitTest {
     verifyResult: (GetQueryResultResult) -> Unit,
   ) {
     dataConnectCacheDatabase.insertQueryResult(
-      authUid.string,
+      authUid.authUid,
       queryId.bytes,
       queryResultData,
       maxAge = maxAge,
@@ -868,7 +869,7 @@ class DataConnectCacheDatabaseUnitTest {
 
     val result =
       dataConnectCacheDatabase.getQueryResult(
-        authUid.string,
+        authUid.authUid,
         queryId.bytes,
         currentTimeMillis = time2,
         staleResult,
@@ -886,10 +887,12 @@ private val propTestConfig =
     shrinkingMode = ShrinkingMode.Off
   )
 
-private data class AuthUidSample(val string: String?)
+private data class AuthUidSample(val authUid: AuthUid?)
 
 private fun authUidArb(): Arb<AuthUidSample> =
-  Arb.proto.structKey().orNull(nullProbability = 0.33).map(::AuthUidSample)
+  Arb.proto.structKey().orNull(nullProbability = 0.33).map {
+    AuthUidSample(if (it !== null) AuthUid(it) else null)
+  }
 
 private data class QueryIdSample(val bytes: ImmutableByteArray) {
   override fun toString() = "QueryIdSample(bytes=${bytes.to0xHexString()})"

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/testutil/KotestPrinters.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/testutil/KotestPrinters.kt
@@ -20,6 +20,7 @@ package com.google.firebase.dataconnect.testutil
 
 import com.google.firebase.dataconnect.DataConnectPathComparator
 import com.google.firebase.dataconnect.DataConnectPathSegment
+import com.google.firebase.dataconnect.core.DataConnectAuth
 import com.google.firebase.dataconnect.core.DataConnectSerialization.Companion.toErrorInfoImpl
 import com.google.firebase.dataconnect.sqlite.DehydratedQueryResult
 import com.google.firebase.dataconnect.toPathString
@@ -237,7 +238,7 @@ private object StreamRequestProtoPrint : Print<StreamRequestProto> {
 
   @Suppress("OVERRIDE_DEPRECATION")
   override fun print(a: StreamRequestProto): Printed =
-    a.toCompactString(authUid = "<unknown>").printed()
+    a.toCompactString(authUid = DataConnectAuth.AuthUid("<unknown>")).printed()
 }
 
 private object StreamResponseProtoPrint : Print<StreamResponseProto> {

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/arbs.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/arbs.kt
@@ -23,6 +23,7 @@ import com.google.firebase.dataconnect.DataSource
 import com.google.firebase.dataconnect.FirebaseDataConnect.CallerSdkType
 import com.google.firebase.dataconnect.OperationRef
 import com.google.firebase.dataconnect.core.DataConnectAppCheck.GetAppCheckTokenResult
+import com.google.firebase.dataconnect.core.DataConnectAuth.AuthUid
 import com.google.firebase.dataconnect.core.DataConnectAuth.GetAuthTokenResult
 import com.google.firebase.dataconnect.core.DataConnectGrpcClient
 import com.google.firebase.dataconnect.core.DataConnectGrpcMetadata
@@ -48,6 +49,7 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.Codepoint
 import io.kotest.property.arbitrary.alphanumeric
 import io.kotest.property.arbitrary.arbitrary
+import io.kotest.property.arbitrary.az
 import io.kotest.property.arbitrary.bind
 import io.kotest.property.arbitrary.choice
 import io.kotest.property.arbitrary.enum
@@ -366,9 +368,13 @@ internal inline fun <Data, reified Variables> DataConnectArb.operationRefConstru
   )
 }
 
+internal fun DataConnectArb.authUid(
+  string: Arb<String> = Arb.string(size = 8, Codepoint.az())
+): Arb<AuthUid> = string.map { AuthUid("authUid_${it.lowercase()}") }
+
 internal fun DataConnectArb.authTokenResult(
   accessToken: Arb<String?> = authToken().orNull(nullProbability = 0.33),
-  authUid: Arb<String?> = authUid().orNull(nullProbability = 0.33),
+  authUid: Arb<AuthUid?> = authUid().orNull(nullProbability = 0.33),
 ): Arb<GetAuthTokenResult> = Arb.bind(accessToken, authUid, ::GetAuthTokenResult)
 
 internal fun DataConnectArb.appCheckTokenResult(

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/arbs.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/arbs.kt
@@ -146,9 +146,6 @@ object DataConnectArb {
     }
   }
 
-  fun authUid(string: Arb<String> = Arb.string(size = 8, Codepoint.alphanumeric())): Arb<String> =
-    string.map { "authUid_${it.lowercase()}" }
-
   fun authToken(string: Arb<String> = Arb.string(size = 8, Codepoint.alphanumeric())): Arb<String> =
     string.map { "authToken_${it.lowercase()}" }
 


### PR DESCRIPTION
This PR improves the internals of the data connect sdk by introducing a dedicated `@JvmInline value class AuthUid` inside `DataConnectAuth` to replace raw strings for representing Auth UIDs across the `firebase-dataconnect` module. This change enhances compile-time type safety throughout the module's core code—including authentication, GRPC network stream layers, SQLite offline cache persistence, and their associated testing suites.

This is an internal-only change with no customer-visible side effects.

### Highlights

* **Core Type Safety Wrapper**: Defined a type-safe wrapper `@JvmInline value class AuthUid` to encapsulate Auth UIDs instead of representing them as raw strings.
* **Network and RPC Layer Integration**: Updated GRPC connection metadata, RPC handlers, and bidirectional streaming structures (`DataConnectBidiConnectStream`, `DataConnectGrpcMetadata`, and `DataConnectGrpcRPCs`) to strictly accept and propagate the new `AuthUid` wrapper type.
* **Database Caching Plumbing**: Adjusted the SQLite offline cache persistence layer (`DataConnectCacheDatabase`) to use the type-safe `AuthUid`, extracting the raw string field dynamically for SQL bind parameters and query variables.
* **Test Utility & Assertion Refactoring**: Migrated Kotest property testing random generators, JUnit unit assertions, custom print utilities, and test data structures (`DataConnectAuthUnitTest`, `DataConnectCacheDatabaseUnitTest`, `KotestPrinters`, and arbitrary generators) to utilize and validate `AuthUid` instances correctly.

<details>

<summary><b>Changelog</b></summary>

* **DataConnectAuth.kt**
  * Defined the `@JvmInline value class AuthUid` wrapper class.
  * Modified `GetAuthTokenResult` to wrap the `authUid` field in the new `AuthUid` type.
  * Updated the `GetTokenResult.getAuthUid()` extension helper to return an optional `AuthUid` instead of a raw `String?`.
* **DataConnectBidiConnectStream.kt**
  * Swapped type declarations of the GRPC bidirectional event channels and subscription state objects to accept and propagate the type-safe `AuthUid?` in place of `String?`.
* **DataConnectGrpcMetadata.kt**
  * Refactored `Metadata.toStructProto` and `StructProtoBuilder.putHeaders` to accept `AuthUid?` and to extract the raw string representation for network header serialization.
* **DataConnectGrpcRPCs.kt**
  * Updated the `QueryCacheInfo` structural cache, stream listeners, and internal logging formattings to handle the structured `AuthUid` wrapper class instead of raw strings.
* **DataConnectCacheDatabase.kt**
  * Refactored database operations `getOrInsertAuthUid`, `getQueryResult`, and `insertQueryResult` to accept `AuthUid` instances, projecting the enclosed string values to SQLite database queries.
* **ProtoUtil.kt**
  * Refactored `StreamRequest.toCompactString` and `StreamRequest.toStructProto` to use the wrapped `AuthUid` type signature.
* **DataConnectAuthUnitTest.kt**
  * Adjusted the authentication fetch result assertions to match on `AuthUid` instances.
* **DataConnectCacheDatabaseUnitTest.kt**
  * Ported cache database tests to construct and serialize mock `AuthUid` sample entities.
* **KotestPrinters.kt**
  * Adjusted test custom `StreamRequestProtoPrint` output assertion helper to instantiate custom type-safe `AuthUid` mocks.
* **src/test/.../arbs.kt**
  * Defined `DataConnectArb.authUid` arbitrary generator helper and adjusted the `authTokenResult` generator function to produce mock `AuthUid` objects instead of strings.
* **testutil/.../arbs.kt**
  * Removed the obsolete alphanumeric raw string `authUid` generator extension.
</details>
