### PR TITLE
[AppCheck] Add getLimitedUseToken support to AppCheckProvider

### DIFF
--- a/appcheck/firebase-appcheck-debug-testing/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-debug-testing/CHANGELOG.md
@@ -86,3 +86,4 @@
 # 16.0.0-beta01
 
 - [feature] Initial beta release of the [app_check] Debug Testing SDK with abuse reduction features.
+

--- a/appcheck/firebase-appcheck-debug-testing/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-debug-testing/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [unchanged] Updated to keep [app_check] SDK versions aligned.
+
 # 19.0.2
 
 - [unchanged] Updated to keep [app_check] SDK versions aligned.
@@ -84,4 +86,3 @@
 # 16.0.0-beta01
 
 - [feature] Initial beta release of the [app_check] Debug Testing SDK with abuse reduction features.
-

--- a/appcheck/firebase-appcheck-debug-testing/gradle.properties
+++ b/appcheck/firebase-appcheck-debug-testing/gradle.properties
@@ -1,2 +1,2 @@
-version=19.0.3
+version=19.1.0
 latestReleasedVersion=19.0.2

--- a/appcheck/firebase-appcheck-debug/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-debug/CHANGELOG.md
@@ -91,3 +91,4 @@
 # 16.0.0-beta01
 
 - [feature] Initial beta release of the [app_check] Debug SDK with abuse reduction features.
+

--- a/appcheck/firebase-appcheck-debug/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-debug/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [fixed] Fixed issue preventing limited use tokens from being correctly generated. (#8204)
+
 # 19.0.2
 
 - [unchanged] Updated to keep [app_check] SDK versions aligned.
@@ -89,4 +91,3 @@
 # 16.0.0-beta01
 
 - [feature] Initial beta release of the [app_check] Debug SDK with abuse reduction features.
-

--- a/appcheck/firebase-appcheck-debug/gradle.properties
+++ b/appcheck/firebase-appcheck-debug/gradle.properties
@@ -1,2 +1,2 @@
-version=19.0.3
+version=19.1.0
 latestReleasedVersion=19.0.2

--- a/appcheck/firebase-appcheck-debug/src/main/java/com/google/firebase/appcheck/debug/internal/DebugAppCheckProvider.java
+++ b/appcheck/firebase-appcheck-debug/src/main/java/com/google/firebase/appcheck/debug/internal/DebugAppCheckProvider.java
@@ -110,13 +110,13 @@ public class DebugAppCheckProvider implements AppCheckProvider {
   @NonNull
   @Override
   public Task<AppCheckToken> getToken() {
-    return getToken(false);
+    return getToken(/* isLimitedUseToken= */ false);
   }
 
   @NonNull
   @Override
   public Task<AppCheckToken> getLimitedUseToken() {
-    return getToken(true);
+    return getToken(/* isLimitedUseToken= */ true);
   }
 
   private Task<AppCheckToken> getToken(boolean isLimitedUseToken) {

--- a/appcheck/firebase-appcheck-debug/src/main/java/com/google/firebase/appcheck/debug/internal/DebugAppCheckProvider.java
+++ b/appcheck/firebase-appcheck-debug/src/main/java/com/google/firebase/appcheck/debug/internal/DebugAppCheckProvider.java
@@ -110,11 +110,22 @@ public class DebugAppCheckProvider implements AppCheckProvider {
   @NonNull
   @Override
   public Task<AppCheckToken> getToken() {
+    return getToken(false);
+  }
+
+  @NonNull
+  @Override
+  public Task<AppCheckToken> getLimitedUseToken() {
+    return getToken(true);
+  }
+
+  private Task<AppCheckToken> getToken(boolean isLimitedUseToken) {
     return debugSecretTask
         .onSuccessTask(
             liteExecutor,
             debugSecret -> {
-              ExchangeDebugTokenRequest request = new ExchangeDebugTokenRequest(debugSecret);
+              ExchangeDebugTokenRequest request =
+                  new ExchangeDebugTokenRequest(debugSecret, isLimitedUseToken);
               return Tasks.call(
                   blockingExecutor,
                   () ->

--- a/appcheck/firebase-appcheck-debug/src/main/java/com/google/firebase/appcheck/debug/internal/ExchangeDebugTokenRequest.java
+++ b/appcheck/firebase-appcheck-debug/src/main/java/com/google/firebase/appcheck/debug/internal/ExchangeDebugTokenRequest.java
@@ -25,18 +25,23 @@ import org.json.JSONObject;
  */
 public class ExchangeDebugTokenRequest {
   @VisibleForTesting static final String DEBUG_TOKEN_KEY = "debugToken";
+  @VisibleForTesting static final String LIMITED_USE_TOKEN_KEY = "limited_use";
 
   private final String debugToken;
+  private final boolean isLimitedUseToken;
 
-  public ExchangeDebugTokenRequest(@NonNull String debugToken) {
+  public ExchangeDebugTokenRequest(@NonNull String debugToken, boolean isLimitedUseToken) {
     this.debugToken = debugToken;
+    this.isLimitedUseToken = isLimitedUseToken;
   }
 
   @NonNull
   public String toJsonString() throws JSONException {
     JSONObject jsonObject = new JSONObject();
     jsonObject.put(DEBUG_TOKEN_KEY, debugToken);
-
+    if (isLimitedUseToken) {
+      jsonObject.put(LIMITED_USE_TOKEN_KEY, true);
+    }
     return jsonObject.toString();
   }
 }

--- a/appcheck/firebase-appcheck-debug/src/test/java/com/google/firebase/appcheck/debug/internal/DebugAppCheckProviderTest.java
+++ b/appcheck/firebase-appcheck-debug/src/test/java/com/google/firebase/appcheck/debug/internal/DebugAppCheckProviderTest.java
@@ -36,10 +36,13 @@ import com.google.firebase.appcheck.internal.RetryManager;
 import com.google.firebase.concurrent.TestOnlyExecutors;
 import java.io.IOException;
 import java.util.concurrent.Executor;
+import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
@@ -70,6 +73,7 @@ public class DebugAppCheckProviderTest {
   @Mock NetworkClient mockNetworkClient;
   @Mock RetryManager mockRetryManager;
   @Mock AppCheckTokenResponse mockAppCheckTokenResponse;
+  @Captor ArgumentCaptor<byte[]> requestBytesCaptor;
 
   private StorageHelper storageHelper;
   private SharedPreferences sharedPreferences;
@@ -172,5 +176,32 @@ public class DebugAppCheckProviderTest {
     assertThat(task.isSuccessful()).isFalse();
     Exception exception = task.getException();
     assertThat(exception).isInstanceOf(IOException.class);
+  }
+
+  @Test
+  public void getLimitedUseToken_onSuccess_setsTaskResult() throws Exception {
+    when(mockNetworkClient.exchangeAttestationForAppCheckToken(
+            any(), eq(NetworkClient.DEBUG), eq(mockRetryManager)))
+        .thenReturn(mockAppCheckTokenResponse);
+    when(mockAppCheckTokenResponse.getToken()).thenReturn(APP_CHECK_TOKEN);
+    when(mockAppCheckTokenResponse.getTimeToLive()).thenReturn(TIME_TO_LIVE);
+
+    DebugAppCheckProvider provider =
+        new DebugAppCheckProvider(
+            DEBUG_SECRET, mockNetworkClient, liteExecutor, blockingExecutor, mockRetryManager);
+    Task<AppCheckToken> task = provider.getLimitedUseToken();
+
+    verify(mockNetworkClient)
+        .exchangeAttestationForAppCheckToken(
+            requestBytesCaptor.capture(), eq(NetworkClient.DEBUG), eq(mockRetryManager));
+
+    byte[] capturedBytes = requestBytesCaptor.getValue();
+    JSONObject jsonObject = new JSONObject(new String(capturedBytes, "UTF-8"));
+    assertThat(jsonObject.opt(ExchangeDebugTokenRequest.DEBUG_TOKEN_KEY)).isEqualTo(DEBUG_SECRET);
+    assertThat(jsonObject.opt(ExchangeDebugTokenRequest.LIMITED_USE_TOKEN_KEY)).isEqualTo(true);
+
+    AppCheckToken token = task.getResult();
+    assertThat(token).isInstanceOf(DefaultAppCheckToken.class);
+    assertThat(token.getToken()).isEqualTo(APP_CHECK_TOKEN);
   }
 }

--- a/appcheck/firebase-appcheck-debug/src/test/java/com/google/firebase/appcheck/debug/internal/ExchangeDebugTokenRequestTest.java
+++ b/appcheck/firebase-appcheck-debug/src/test/java/com/google/firebase/appcheck/debug/internal/ExchangeDebugTokenRequestTest.java
@@ -16,7 +16,6 @@ package com.google.firebase.appcheck.debug.internal;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,9 +36,6 @@ public class ExchangeDebugTokenRequestTest {
 
     assertThat(jsonObject.getString(ExchangeDebugTokenRequest.DEBUG_TOKEN_KEY))
         .isEqualTo(DEBUG_TOKEN);
-
-    assertThat(jsonObject.getString(ExchangeDebugTokenRequest.DEBUG_TOKEN_KEY))
-        .isEqualTo(DEBUG_TOKEN);
     assertThat(jsonObject.opt(ExchangePlayIntegrityTokenRequest.LIMITED_USE_TOKEN_KEY)).isNull();
   }
 
@@ -53,7 +49,6 @@ public class ExchangeDebugTokenRequestTest {
 
     assertThat(jsonObject.getString(ExchangeDebugTokenRequest.DEBUG_TOKEN_KEY))
         .isEqualTo(DEBUG_TOKEN);
-    assertThat(jsonObject.getBoolean(ExchangeDebugTokenRequest.LIMITED_USE_TOKEN_KEY))
-        .isEqualTo(true);
+    assertThat(jsonObject.getBoolean(ExchangeDebugTokenRequest.LIMITED_USE_TOKEN_KEY)).isTrue();
   }
 }

--- a/appcheck/firebase-appcheck-debug/src/test/java/com/google/firebase/appcheck/debug/internal/ExchangeDebugTokenRequestTest.java
+++ b/appcheck/firebase-appcheck-debug/src/test/java/com/google/firebase/appcheck/debug/internal/ExchangeDebugTokenRequestTest.java
@@ -16,6 +16,7 @@ package com.google.firebase.appcheck.debug.internal;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,12 +30,30 @@ public class ExchangeDebugTokenRequestTest {
   @Test
   public void toJsonString_expectSerialized() throws Exception {
     ExchangeDebugTokenRequest exchangeDebugTokenRequest =
-        new ExchangeDebugTokenRequest(DEBUG_TOKEN);
+        new ExchangeDebugTokenRequest(DEBUG_TOKEN, false);
 
     String jsonString = exchangeDebugTokenRequest.toJsonString();
     JSONObject jsonObject = new JSONObject(jsonString);
 
     assertThat(jsonObject.getString(ExchangeDebugTokenRequest.DEBUG_TOKEN_KEY))
         .isEqualTo(DEBUG_TOKEN);
+
+    assertThat(jsonObject.getString(ExchangeDebugTokenRequest.DEBUG_TOKEN_KEY))
+        .isEqualTo(DEBUG_TOKEN);
+    assertThat(jsonObject.opt(ExchangePlayIntegrityTokenRequest.LIMITED_USE_TOKEN_KEY)).isNull();
+  }
+
+  @Test
+  public void toJsonString_limitedUse_expectSerialized() throws Exception {
+    ExchangeDebugTokenRequest exchangeDebugTokenRequest =
+        new ExchangeDebugTokenRequest(DEBUG_TOKEN, true);
+
+    String jsonString = exchangeDebugTokenRequest.toJsonString();
+    JSONObject jsonObject = new JSONObject(jsonString);
+
+    assertThat(jsonObject.getString(ExchangeDebugTokenRequest.DEBUG_TOKEN_KEY))
+        .isEqualTo(DEBUG_TOKEN);
+    assertThat(jsonObject.getBoolean(ExchangeDebugTokenRequest.LIMITED_USE_TOKEN_KEY))
+        .isEqualTo(true);
   }
 }

--- a/appcheck/firebase-appcheck-debug/src/test/java/com/google/firebase/appcheck/debug/internal/ExchangeDebugTokenRequestTest.java
+++ b/appcheck/firebase-appcheck-debug/src/test/java/com/google/firebase/appcheck/debug/internal/ExchangeDebugTokenRequestTest.java
@@ -36,7 +36,7 @@ public class ExchangeDebugTokenRequestTest {
 
     assertThat(jsonObject.getString(ExchangeDebugTokenRequest.DEBUG_TOKEN_KEY))
         .isEqualTo(DEBUG_TOKEN);
-    assertThat(jsonObject.opt(ExchangePlayIntegrityTokenRequest.LIMITED_USE_TOKEN_KEY)).isNull();
+    assertThat(jsonObject.opt(ExchangeDebugTokenRequest.LIMITED_USE_TOKEN_KEY)).isNull();
   }
 
   @Test

--- a/appcheck/firebase-appcheck-playintegrity/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-playintegrity/CHANGELOG.md
@@ -62,3 +62,4 @@
 
 - [feature] Added support for [Play Integrity](https://developer.android.com/google/play/integrity)
   as an attestation provider.
+

--- a/appcheck/firebase-appcheck-playintegrity/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-playintegrity/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [fixed] Fixed issue preventing limited use tokens from being correctly generated. (#8204)
+
 # 19.0.2
 
 - [unchanged] Updated to keep [app_check] SDK versions aligned.
@@ -60,4 +62,3 @@
 
 - [feature] Added support for [Play Integrity](https://developer.android.com/google/play/integrity)
   as an attestation provider.
-

--- a/appcheck/firebase-appcheck-playintegrity/gradle.properties
+++ b/appcheck/firebase-appcheck-playintegrity/gradle.properties
@@ -1,2 +1,2 @@
-version=19.0.3
+version=19.1.0
 latestReleasedVersion=19.0.2

--- a/appcheck/firebase-appcheck-playintegrity/src/main/java/com/google/firebase/appcheck/playintegrity/internal/ExchangePlayIntegrityTokenRequest.java
+++ b/appcheck/firebase-appcheck-playintegrity/src/main/java/com/google/firebase/appcheck/playintegrity/internal/ExchangePlayIntegrityTokenRequest.java
@@ -26,17 +26,24 @@ import org.json.JSONObject;
 class ExchangePlayIntegrityTokenRequest {
 
   @VisibleForTesting static final String PLAY_INTEGRITY_TOKEN_KEY = "playIntegrityToken";
+  @VisibleForTesting static final String LIMITED_USE_TOKEN_KEY = "limited_use";
 
   private final String playIntegrityToken;
+  private final boolean isLimitedUseToken;
 
-  public ExchangePlayIntegrityTokenRequest(@NonNull String playIntegrityToken) {
+  public ExchangePlayIntegrityTokenRequest(
+      @NonNull String playIntegrityToken, boolean isLimitedUseToken) {
     this.playIntegrityToken = playIntegrityToken;
+    this.isLimitedUseToken = isLimitedUseToken;
   }
 
   @NonNull
   public String toJsonString() throws JSONException {
     JSONObject jsonObject = new JSONObject();
     jsonObject.put(PLAY_INTEGRITY_TOKEN_KEY, playIntegrityToken);
+    if (isLimitedUseToken) {
+      jsonObject.put(LIMITED_USE_TOKEN_KEY, true);
+    }
 
     return jsonObject.toString();
   }

--- a/appcheck/firebase-appcheck-playintegrity/src/main/java/com/google/firebase/appcheck/playintegrity/internal/PlayIntegrityAppCheckProvider.java
+++ b/appcheck/firebase-appcheck-playintegrity/src/main/java/com/google/firebase/appcheck/playintegrity/internal/PlayIntegrityAppCheckProvider.java
@@ -75,12 +75,23 @@ public class PlayIntegrityAppCheckProvider implements AppCheckProvider {
   @NonNull
   @Override
   public Task<AppCheckToken> getToken() {
+    return getToken(/* isLimitedUseToken= */ false);
+  }
+
+  @NonNull
+  @Override
+  public Task<AppCheckToken> getLimitedUseToken() {
+    return getToken(/* isLimitedUseToken= */ true);
+  }
+
+  private Task<AppCheckToken> getToken(boolean isLimitedUseToken) {
     return getPlayIntegrityAttestation()
         .onSuccessTask(
             liteExecutor,
             integrityTokenResponse -> {
               ExchangePlayIntegrityTokenRequest request =
-                  new ExchangePlayIntegrityTokenRequest(integrityTokenResponse.token());
+                  new ExchangePlayIntegrityTokenRequest(
+                      integrityTokenResponse.token(), isLimitedUseToken);
               return Tasks.call(
                   blockingExecutor,
                   () ->

--- a/appcheck/firebase-appcheck-playintegrity/src/test/java/com/google/firebase/appcheck/playintegrity/internal/ExchangePlayIntegrityTokenRequestTest.java
+++ b/appcheck/firebase-appcheck-playintegrity/src/test/java/com/google/firebase/appcheck/playintegrity/internal/ExchangePlayIntegrityTokenRequestTest.java
@@ -31,12 +31,27 @@ public class ExchangePlayIntegrityTokenRequestTest {
   @Test
   public void toJsonString_expectSerialized() throws Exception {
     ExchangePlayIntegrityTokenRequest exchangePlayIntegrityTokenRequest =
-        new ExchangePlayIntegrityTokenRequest(PLAY_INTEGRITY_TOKEN);
+        new ExchangePlayIntegrityTokenRequest(PLAY_INTEGRITY_TOKEN, /* isLimitedUseToken= */ false);
 
     String jsonString = exchangePlayIntegrityTokenRequest.toJsonString();
     JSONObject jsonObject = new JSONObject(jsonString);
 
     assertThat(jsonObject.getString(ExchangePlayIntegrityTokenRequest.PLAY_INTEGRITY_TOKEN_KEY))
         .isEqualTo(PLAY_INTEGRITY_TOKEN);
+    assertThat(jsonObject.opt(ExchangePlayIntegrityTokenRequest.LIMITED_USE_TOKEN_KEY)).isNull();
+  }
+
+  @Test
+  public void toJsonString_limitedUse_expectSerialized() throws Exception {
+    ExchangePlayIntegrityTokenRequest exchangePlayIntegrityTokenRequest =
+        new ExchangePlayIntegrityTokenRequest(PLAY_INTEGRITY_TOKEN, /* isLimitedUseToken= */ true);
+
+    String jsonString = exchangePlayIntegrityTokenRequest.toJsonString();
+    JSONObject jsonObject = new JSONObject(jsonString);
+
+    assertThat(jsonObject.getString(ExchangePlayIntegrityTokenRequest.PLAY_INTEGRITY_TOKEN_KEY))
+        .isEqualTo(PLAY_INTEGRITY_TOKEN);
+    assertThat(jsonObject.optBoolean(ExchangePlayIntegrityTokenRequest.LIMITED_USE_TOKEN_KEY))
+        .isTrue();
   }
 }

--- a/appcheck/firebase-appcheck-playintegrity/src/test/java/com/google/firebase/appcheck/playintegrity/internal/PlayIntegrityAppCheckProviderTest.java
+++ b/appcheck/firebase-appcheck-playintegrity/src/test/java/com/google/firebase/appcheck/playintegrity/internal/PlayIntegrityAppCheckProviderTest.java
@@ -132,6 +132,8 @@ public class PlayIntegrityAppCheckProviderTest {
     String exchangePlayIntegrityTokenRequestJsonString =
         new String(exchangePlayIntegrityTokenRequestCaptor.getValue());
     assertThat(exchangePlayIntegrityTokenRequestJsonString).contains(INTEGRITY_TOKEN);
+    JSONObject jsonObject = new JSONObject(exchangePlayIntegrityTokenRequestJsonString);
+    assertThat(jsonObject.opt(ExchangePlayIntegrityTokenRequest.LIMITED_USE_TOKEN_KEY)).isNull();
   }
 
   @Test
@@ -224,6 +226,50 @@ public class PlayIntegrityAppCheckProviderTest {
     String exchangePlayIntegrityTokenRequestJsonString =
         new String(exchangePlayIntegrityTokenRequestCaptor.getValue());
     assertThat(exchangePlayIntegrityTokenRequestJsonString).contains(INTEGRITY_TOKEN);
+  }
+
+  @Test
+  public void getLimitedUseToken_onSuccess_setsTaskResult() throws Exception {
+    when(mockNetworkClient.generatePlayIntegrityChallenge(any(), eq(mockRetryManager)))
+        .thenReturn(createGeneratePlayIntegrityChallengeResponse());
+    when(mockIntegrityManager.requestIntegrityToken(any()))
+        .thenReturn(Tasks.forResult(mockIntegrityTokenResponse));
+    when(mockNetworkClient.exchangeAttestationForAppCheckToken(
+            any(), eq(NetworkClient.PLAY_INTEGRITY), eq(mockRetryManager)))
+        .thenReturn(mockAppCheckTokenResponse);
+
+    PlayIntegrityAppCheckProvider provider =
+        new PlayIntegrityAppCheckProvider(
+            PROJECT_NUMBER,
+            mockIntegrityManager,
+            mockNetworkClient,
+            liteExecutor,
+            blockingExecutor,
+            mockRetryManager);
+    Task<AppCheckToken> task = provider.getLimitedUseToken();
+
+    AppCheckToken token = task.getResult();
+    assertThat(token).isInstanceOf(DefaultAppCheckToken.class);
+    assertThat(token.getToken()).isEqualTo(APP_CHECK_TOKEN);
+
+    verify(mockNetworkClient).generatePlayIntegrityChallenge(any(), eq(mockRetryManager));
+
+    verify(mockIntegrityManager).requestIntegrityToken(integrityTokenRequestCaptor.capture());
+    assertThat(integrityTokenRequestCaptor.getValue().cloudProjectNumber())
+        .isEqualTo(Long.parseLong(PROJECT_NUMBER));
+    assertThat(integrityTokenRequestCaptor.getValue().nonce()).isEqualTo(CHALLENGE);
+
+    verify(mockNetworkClient)
+        .exchangeAttestationForAppCheckToken(
+            exchangePlayIntegrityTokenRequestCaptor.capture(),
+            eq(NetworkClient.PLAY_INTEGRITY),
+            eq(mockRetryManager));
+    String exchangePlayIntegrityTokenRequestJsonString =
+        new String(exchangePlayIntegrityTokenRequestCaptor.getValue());
+    assertThat(exchangePlayIntegrityTokenRequestJsonString).contains(INTEGRITY_TOKEN);
+    JSONObject jsonObject = new JSONObject(exchangePlayIntegrityTokenRequestJsonString);
+    assertThat(jsonObject.opt(ExchangePlayIntegrityTokenRequest.LIMITED_USE_TOKEN_KEY))
+        .isEqualTo(true);
   }
 
   private static String createGeneratePlayIntegrityChallengeResponse() throws Exception {

--- a/appcheck/firebase-appcheck-recaptchaenterprise/src/main/java/com/google/firebase/appcheck/recaptchaenterprise/internal/ExchangeRecaptchaEnterpriseTokenRequest.java
+++ b/appcheck/firebase-appcheck-recaptchaenterprise/src/main/java/com/google/firebase/appcheck/recaptchaenterprise/internal/ExchangeRecaptchaEnterpriseTokenRequest.java
@@ -28,16 +28,24 @@ public class ExchangeRecaptchaEnterpriseTokenRequest {
   @VisibleForTesting
   static final String RECAPTCHA_ENTERPRISE_TOKEN_KEY = "recaptchaEnterpriseToken";
 
-  private final String recaptchaEnterpriseToken;
+  @VisibleForTesting static final String LIMITED_USE_TOKEN_KEY = "limited_use";
 
-  public ExchangeRecaptchaEnterpriseTokenRequest(@NonNull String recaptchaEnterpriseToken) {
+  private final String recaptchaEnterpriseToken;
+  private final boolean isLimitedUseToken;
+
+  public ExchangeRecaptchaEnterpriseTokenRequest(
+      @NonNull String recaptchaEnterpriseToken, boolean isLimitedUseToken) {
     this.recaptchaEnterpriseToken = recaptchaEnterpriseToken;
+    this.isLimitedUseToken = isLimitedUseToken;
   }
 
   @NonNull
   public String toJsonString() throws JSONException {
     JSONObject jsonObject = new JSONObject();
     jsonObject.put(RECAPTCHA_ENTERPRISE_TOKEN_KEY, recaptchaEnterpriseToken);
+    if (isLimitedUseToken) {
+      jsonObject.put(LIMITED_USE_TOKEN_KEY, true);
+    }
 
     return jsonObject.toString();
   }

--- a/appcheck/firebase-appcheck-recaptchaenterprise/src/main/java/com/google/firebase/appcheck/recaptchaenterprise/internal/RecaptchaEnterpriseAppCheckProvider.java
+++ b/appcheck/firebase-appcheck-recaptchaenterprise/src/main/java/com/google/firebase/appcheck/recaptchaenterprise/internal/RecaptchaEnterpriseAppCheckProvider.java
@@ -103,12 +103,23 @@ public class RecaptchaEnterpriseAppCheckProvider implements AppCheckProvider {
   @NonNull
   @Override
   public Task<AppCheckToken> getToken() {
+    return getToken(/* isLimitedUseToken= */ false);
+  }
+
+  @NonNull
+  @Override
+  public Task<AppCheckToken> getLimitedUseToken() {
+    return getToken(/* isLimitedUseToken= */ true);
+  }
+
+  private Task<AppCheckToken> getToken(boolean isLimitedUseToken) {
     return getRecaptchaEnterpriseAttestation()
         .onSuccessTask(
             liteExecutor,
             recaptchaEnterpriseToken -> {
               ExchangeRecaptchaEnterpriseTokenRequest request =
-                  new ExchangeRecaptchaEnterpriseTokenRequest(recaptchaEnterpriseToken);
+                  new ExchangeRecaptchaEnterpriseTokenRequest(
+                      recaptchaEnterpriseToken, isLimitedUseToken);
               return Tasks.call(
                   blockingExecutor,
                   () ->

--- a/appcheck/firebase-appcheck-recaptchaenterprise/src/test/java/com/google/firebase/appcheck/recaptchaenterprise/internal/ExchangeRecaptchaEnterpriseTokenRequestTest.java
+++ b/appcheck/firebase-appcheck-recaptchaenterprise/src/test/java/com/google/firebase/appcheck/recaptchaenterprise/internal/ExchangeRecaptchaEnterpriseTokenRequestTest.java
@@ -26,7 +26,8 @@ public class ExchangeRecaptchaEnterpriseTokenRequestTest {
   @Test
   public void toJsonString_expectSerialized() throws Exception {
     ExchangeRecaptchaEnterpriseTokenRequest exchangeRecaptchaEnterpriseTokenRequest =
-        new ExchangeRecaptchaEnterpriseTokenRequest(RECAPTCHA_ENTERPRISE_TOKEN);
+        new ExchangeRecaptchaEnterpriseTokenRequest(
+            RECAPTCHA_ENTERPRISE_TOKEN, /* isLimitedUseToken= */ false);
 
     String jsonString = exchangeRecaptchaEnterpriseTokenRequest.toJsonString();
     JSONObject jsonObject = new JSONObject(jsonString);
@@ -35,5 +36,24 @@ public class ExchangeRecaptchaEnterpriseTokenRequestTest {
             jsonObject.getString(
                 ExchangeRecaptchaEnterpriseTokenRequest.RECAPTCHA_ENTERPRISE_TOKEN_KEY))
         .isEqualTo(RECAPTCHA_ENTERPRISE_TOKEN);
+    assertThat(jsonObject.opt(ExchangeRecaptchaEnterpriseTokenRequest.LIMITED_USE_TOKEN_KEY))
+        .isNull();
+  }
+
+  @Test
+  public void toJsonString_limitedUse_expectSerialized() throws Exception {
+    ExchangeRecaptchaEnterpriseTokenRequest exchangeRecaptchaEnterpriseTokenRequest =
+        new ExchangeRecaptchaEnterpriseTokenRequest(
+            RECAPTCHA_ENTERPRISE_TOKEN, /* isLimitedUseToken= */ true);
+
+    String jsonString = exchangeRecaptchaEnterpriseTokenRequest.toJsonString();
+    JSONObject jsonObject = new JSONObject(jsonString);
+
+    assertThat(
+            jsonObject.getString(
+                ExchangeRecaptchaEnterpriseTokenRequest.RECAPTCHA_ENTERPRISE_TOKEN_KEY))
+        .isEqualTo(RECAPTCHA_ENTERPRISE_TOKEN);
+    assertThat(jsonObject.optBoolean(ExchangeRecaptchaEnterpriseTokenRequest.LIMITED_USE_TOKEN_KEY))
+        .isTrue();
   }
 }

--- a/appcheck/firebase-appcheck-recaptchaenterprise/src/test/java/com/google/firebase/appcheck/recaptchaenterprise/internal/RecaptchaEnterpriseAppCheckProviderTest.java
+++ b/appcheck/firebase-appcheck-recaptchaenterprise/src/test/java/com/google/firebase/appcheck/recaptchaenterprise/internal/RecaptchaEnterpriseAppCheckProviderTest.java
@@ -120,6 +120,9 @@ public class RecaptchaEnterpriseAppCheckProviderTest {
     verify(mockNetworkClient)
         .exchangeAttestationForAppCheckToken(
             requestCaptor.capture(), eq(NetworkClient.RECAPTCHA_ENTERPRISE), eq(mockRetryManager));
+    JSONObject jsonObject = new JSONObject(new String(requestCaptor.getValue(), "UTF-8"));
+    assertThat(jsonObject.opt(ExchangeRecaptchaEnterpriseTokenRequest.LIMITED_USE_TOKEN_KEY))
+        .isNull();
   }
 
   @Test
@@ -160,5 +163,39 @@ public class RecaptchaEnterpriseAppCheckProviderTest {
     Task<AppCheckToken> task = provider.getToken();
     assertThat(task.isSuccessful()).isFalse();
     assertThat(task.getException()).isEqualTo(exception);
+  }
+
+  @Test
+  public void getLimitedUseToken_onSuccess_setsTaskResult() throws Exception {
+    when(mockRecaptchaTasksClient.executeTask(any(RecaptchaAction.class)))
+        .thenReturn(Tasks.forResult(RECAPTCHA_ENTERPRISE_TOKEN));
+    String jsonResponse =
+        new JSONObject().put("token", APP_CHECK_TOKEN).put("ttl", 3600).toString();
+    when(mockNetworkClient.exchangeAttestationForAppCheckToken(
+            any(byte[].class), eq(NetworkClient.RECAPTCHA_ENTERPRISE), eq(mockRetryManager)))
+        .thenReturn(AppCheckTokenResponse.fromJsonString(jsonResponse));
+
+    RecaptchaEnterpriseAppCheckProvider provider =
+        new RecaptchaEnterpriseAppCheckProvider(
+            liteExecutor,
+            blockingExecutor,
+            mockRetryManager,
+            mockNetworkClient,
+            mockRecaptchaTasksClient);
+    Task<AppCheckToken> task = provider.getLimitedUseToken();
+
+    assertThat(task.isSuccessful()).isTrue();
+    AppCheckToken token = task.getResult();
+    assertThat(token).isInstanceOf(DefaultAppCheckToken.class);
+    assertThat(token.getToken()).isEqualTo(APP_CHECK_TOKEN);
+
+    verify(mockRecaptchaTasksClient).executeTask(recaptchaActionCaptor.capture());
+    assertThat(recaptchaActionCaptor.getValue().getAction()).isEqualTo("fire_app_check");
+    verify(mockNetworkClient)
+        .exchangeAttestationForAppCheckToken(
+            requestCaptor.capture(), eq(NetworkClient.RECAPTCHA_ENTERPRISE), eq(mockRetryManager));
+    JSONObject jsonObject = new JSONObject(new String(requestCaptor.getValue(), "UTF-8"));
+    assertThat(jsonObject.opt(ExchangeRecaptchaEnterpriseTokenRequest.LIMITED_USE_TOKEN_KEY))
+        .isEqualTo(true);
   }
 }

--- a/appcheck/firebase-appcheck/CHANGELOG.md
+++ b/appcheck/firebase-appcheck/CHANGELOG.md
@@ -159,3 +159,4 @@ Kotlin extensions library has the following additional updates:
 # 16.0.0-beta01
 
 - [feature] Initial beta release of the [app_check] SDK with abuse reduction features.
+

--- a/appcheck/firebase-appcheck/CHANGELOG.md
+++ b/appcheck/firebase-appcheck/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [fixed] Fixed issue preventing limited use tokens from being correctly generated. (#8204)
+
 # 19.0.2
 
 - [fixed] Fixed a bug causing custom `AppCheckProvider` returning errors without a message to throw an exception.
@@ -157,4 +159,3 @@ Kotlin extensions library has the following additional updates:
 # 16.0.0-beta01
 
 - [feature] Initial beta release of the [app_check] SDK with abuse reduction features.
-

--- a/appcheck/firebase-appcheck/CHANGELOG.md
+++ b/appcheck/firebase-appcheck/CHANGELOG.md
@@ -161,3 +161,4 @@ Kotlin extensions library has the following additional updates:
 # 16.0.0-beta01
 
 - [feature] Initial beta release of the [app_check] SDK with abuse reduction features.
+

--- a/appcheck/firebase-appcheck/CHANGELOG.md
+++ b/appcheck/firebase-appcheck/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 - [fixed] Fixed issue preventing limited use tokens from being correctly generated. (#8204)
+- [changed] Added new `getLimitedUseToken` to `AppCheckProvider` interface, that default to
+  calling `getToken`. (#8204)
 
 # 19.0.2
 
@@ -159,4 +161,3 @@ Kotlin extensions library has the following additional updates:
 # 16.0.0-beta01
 
 - [feature] Initial beta release of the [app_check] SDK with abuse reduction features.
-

--- a/appcheck/firebase-appcheck/api.txt
+++ b/appcheck/firebase-appcheck/api.txt
@@ -2,7 +2,7 @@
 package com.google.firebase.appcheck {
 
   public interface AppCheckProvider {
-    method public com.google.android.gms.tasks.Task<com.google.firebase.appcheck.AppCheckToken!> getLimitedUseToken();
+    method public default com.google.android.gms.tasks.Task<com.google.firebase.appcheck.AppCheckToken!> getLimitedUseToken();
     method public com.google.android.gms.tasks.Task<com.google.firebase.appcheck.AppCheckToken!> getToken();
   }
 

--- a/appcheck/firebase-appcheck/api.txt
+++ b/appcheck/firebase-appcheck/api.txt
@@ -2,6 +2,7 @@
 package com.google.firebase.appcheck {
 
   public interface AppCheckProvider {
+    method public com.google.android.gms.tasks.Task<com.google.firebase.appcheck.AppCheckToken!> getLimitedUseToken();
     method public com.google.android.gms.tasks.Task<com.google.firebase.appcheck.AppCheckToken!> getToken();
   }
 

--- a/appcheck/firebase-appcheck/gradle.properties
+++ b/appcheck/firebase-appcheck/gradle.properties
@@ -1,2 +1,2 @@
-version=19.0.3
+version=19.1.0
 latestReleasedVersion=19.0.2

--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/AppCheckProvider.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/AppCheckProvider.java
@@ -31,4 +31,11 @@ public interface AppCheckProvider {
    */
   @NonNull
   Task<AppCheckToken> getToken();
+
+  /**
+   * Returns a {@link Task} which resolves to a valid, limited-use {@link AppCheckToken} or an
+   * {@link Exception} in the case that an unexpected failure occurred while getting the token.
+   */
+  @NonNull
+  Task<AppCheckToken> getLimitedUseToken();
 }

--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/AppCheckProvider.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/AppCheckProvider.java
@@ -37,5 +37,5 @@ public interface AppCheckProvider {
    * {@link Exception} in the case that an unexpected failure occurred while getting the token.
    */
   @NonNull
-  Task<AppCheckToken> getLimitedUseToken();
+  default Task<AppCheckToken> getLimitedUseToken() { return getToken(); }
 }

--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/AppCheckProvider.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/AppCheckProvider.java
@@ -37,5 +37,7 @@ public interface AppCheckProvider {
    * {@link Exception} in the case that an unexpected failure occurred while getting the token.
    */
   @NonNull
-  default Task<AppCheckToken> getLimitedUseToken() { return getToken(); }
+  default Task<AppCheckToken> getLimitedUseToken() {
+    return getToken();
+  }
 }

--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck.java
@@ -274,7 +274,7 @@ public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
     // We explicitly do not call the fetchTokenFromProvider helper method, as that method includes
     // side effects such as notifying listeners, updating the cached token, and scheduling token
     // refresh.
-    return appCheckProvider.getToken();
+    return appCheckProvider.getLimitedUseToken();
   }
 
   /** Fetches an {@link AppCheckToken} via the installed {@link AppCheckProvider}. */

--- a/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheckTest.java
+++ b/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheckTest.java
@@ -76,6 +76,8 @@ public class DefaultFirebaseAppCheckTest {
     when(mockFirebaseApp.getPersistenceKey()).thenReturn(PERSISTENCE_KEY);
     when(mockAppCheckProviderFactory.create(any())).thenReturn(mockAppCheckProvider);
     when(mockAppCheckProvider.getToken()).thenReturn(Tasks.forResult(validDefaultAppCheckToken));
+    when(mockAppCheckProvider.getLimitedUseToken())
+        .thenReturn(Tasks.forResult(validDefaultAppCheckToken));
 
     // TODO(b/258273630): Use TestOnlyExecutors instead of MoreExecutors.directExecutor().
     defaultFirebaseAppCheck =
@@ -419,7 +421,7 @@ public class DefaultFirebaseAppCheckTest {
 
     defaultFirebaseAppCheck.getLimitedUseAppCheckToken();
 
-    verify(mockAppCheckProvider).getToken();
+    verify(mockAppCheckProvider).getLimitedUseToken();
   }
 
   @Test
@@ -429,7 +431,7 @@ public class DefaultFirebaseAppCheckTest {
 
     defaultFirebaseAppCheck.getLimitedUseAppCheckToken();
 
-    verify(mockAppCheckProvider).getToken();
+    verify(mockAppCheckProvider).getLimitedUseToken();
   }
 
   @Test
@@ -438,7 +440,7 @@ public class DefaultFirebaseAppCheckTest {
 
     defaultFirebaseAppCheck.getLimitedUseToken();
 
-    verify(mockAppCheckProvider).getToken();
+    verify(mockAppCheckProvider).getLimitedUseToken();
   }
 
   @Test
@@ -448,7 +450,7 @@ public class DefaultFirebaseAppCheckTest {
 
     defaultFirebaseAppCheck.getLimitedUseToken();
 
-    verify(mockAppCheckProvider).getToken();
+    verify(mockAppCheckProvider).getLimitedUseToken();
   }
 
   @Test
@@ -472,9 +474,9 @@ public class DefaultFirebaseAppCheckTest {
   public void getLimitedUseToken_providerThrowsExceptionWithNullMessage_returnsResultWithError()
       throws Exception {
     defaultFirebaseAppCheck.installAppCheckProviderFactory(mockAppCheckProviderFactory);
-    when(mockAppCheckProvider.getToken())
+    when(mockAppCheckProvider.getLimitedUseToken())
         .thenReturn(Tasks.forException(new Exception((String) null)));
-    when(mockAppCheckProvider.getToken())
+    when(mockAppCheckProvider.getLimitedUseToken())
         .thenReturn(Tasks.forException(new Exception((String) null)));
 
     Task<AppCheckTokenResult> tokenTask = defaultFirebaseAppCheck.getLimitedUseToken();

--- a/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheckTest.java
+++ b/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheckTest.java
@@ -476,8 +476,6 @@ public class DefaultFirebaseAppCheckTest {
     defaultFirebaseAppCheck.installAppCheckProviderFactory(mockAppCheckProviderFactory);
     when(mockAppCheckProvider.getLimitedUseToken())
         .thenReturn(Tasks.forException(new Exception((String) null)));
-    when(mockAppCheckProvider.getLimitedUseToken())
-        .thenReturn(Tasks.forException(new Exception((String) null)));
 
     Task<AppCheckTokenResult> tokenTask = defaultFirebaseAppCheck.getLimitedUseToken();
     assertThat(tokenTask.isComplete()).isTrue();


### PR DESCRIPTION
Introduced the getLimitedUseToken() method to the AppCheckProvider interface and implemented it across the debug, Play Integrity, and reCAPTCHA Enterprise providers. The implementation ensures that token exchange requests include a "limited_use" flag, allowing for the generation of short-lived, single-use App Check tokens.

Verified manually using debug provider