### PR TITLE
dataconnect(fix): CACHE_ONLY was incorrectly ignored when cache was not enabled

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -9,6 +9,9 @@
   as the random numbers were not used in a security-sensitive context,
   thus the performance costs of secure random number generation were unnecessary.
   ([#8154](https://github.com/firebase/firebase-android-sdk/pull/8154))
+- [fixed] Queries executed with FetchPolicy.CACHE_ONLY now fail, as expected,
+  if local caching is not enabled, instead of behaving like SERVER_ONLY.
+  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
 
 # 17.2.2
 

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -11,7 +11,7 @@
   ([#8154](https://github.com/firebase/firebase-android-sdk/pull/8154))
 - [fixed] Queries executed with FetchPolicy.CACHE_ONLY now fail, as expected,
   if local caching is not enabled, instead of behaving like SERVER_ONLY.
-  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
+  ([#8214](https://github.com/firebase/firebase-android-sdk/pull/8214))
 
 # 17.2.2
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -279,6 +279,15 @@ internal class DataConnectGrpcRPCs(
         it.build()
       }
 
+    val cacheInfo = queryCacheInfo(authToken, request)
+    if (cacheInfo == null && fetchPolicy == FetchPolicy.CACHE_ONLY) {
+      throw CachedDataNotFoundException(
+        "FetchPolicy.CACHE_ONLY cannot be used because local caching is not configured. " +
+          "To use CACHE_ONLY, specify a DataConnectSettings object with a non-null `cacheSettings` " +
+          "property to FirebaseDataConnect.getInstance() [sz664hyg7t]"
+      )
+    }
+
     logger.logGrpcSending(
       requestId = requestId,
       kotlinMethodName = kotlinMethodName,
@@ -288,8 +297,6 @@ internal class DataConnectGrpcRPCs(
       requestTypeName = "ExecuteQueryRequest",
       authUid = authToken?.authUid,
     )
-
-    val cacheInfo = queryCacheInfo(authToken, request)
 
     if (fetchPolicy != FetchPolicy.SERVER_ONLY) {
       val cachedResult: ExecuteQueryResult.FromCache? =
@@ -301,6 +308,17 @@ internal class DataConnectGrpcRPCs(
       if (cachedResult !== null) {
         return cachedResult
       }
+    }
+
+    if (fetchPolicy == FetchPolicy.CACHE_ONLY) {
+      val exception =
+        CachedDataNotFoundException("query was not found in the local cache [cck6p3fmd5]")
+      logger.logGrpcFailed(
+        requestId = requestId,
+        kotlinMethodName = kotlinMethodName,
+        throwable = exception,
+      )
+      throw exception
     }
 
     val result = lazyGrpcStub.get().runCatching { executeQuery(request, metadata) }
@@ -369,17 +387,6 @@ internal class DataConnectGrpcRPCs(
         }
         is DataConnectCacheDatabase.GetQueryResultResult.NotFound -> null
       }
-
-    if (cachedData === null && fetchPolicy == FetchPolicy.CACHE_ONLY) {
-      val exception =
-        CachedDataNotFoundException("query was not found in the local cache [cck6p3fmd5]")
-      logger.logGrpcFailed(
-        requestId = requestId,
-        kotlinMethodName = kotlinMethodName,
-        throwable = exception,
-      )
-      throw exception
-    }
 
     return cachedData?.let(ExecuteQueryResult::FromCache)
   }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
@@ -263,6 +263,48 @@ class DataConnectGrpcRPCsUnitTest {
   }
 
   @Test
+  fun `executeQuery(fetchPolicy=CACHE_ONLY) with null cacheSettings throws CachedDataNotFoundException`() =
+    runTest {
+      startServer().use { server ->
+        val dataConnectGrpcRPCs =
+          DataConnectGrpcRPCs(
+            context = RuntimeEnvironment.getApplication(),
+            host = "localhost:${server.port}",
+            sslEnabled = false,
+            connectorResourceName = connectorResourceNameArb.next(rs),
+            nonBlockingCoroutineDispatcher = Dispatchers.Default,
+            blockingCoroutineDispatcher = Dispatchers.IO,
+            grpcMetadata = grpcMetadataArb.next(rs),
+            cacheSettings = null,
+            parentLogger = mockLogger,
+          )
+        val request = operationNameVariablesPairArb.next(rs)
+
+        val exception =
+          shouldThrow<CachedDataNotFoundException> {
+            dataConnectGrpcRPCs.executeQuery(
+              requestIdArb.next(rs),
+              request.operationName,
+              request.variables,
+              callerSdkTypeArb.next(rs),
+              FetchPolicy.CACHE_ONLY,
+              Arb.dataConnect.authTokenResult().orNull(nullProbability = 0.3).next(rs),
+              Arb.dataConnect.appCheckTokenResult().orNull(nullProbability = 0.3).next(rs),
+            )
+          }
+
+        assertSoftly {
+          withClue("executeQueryInvocationCount") { server.executeQueryInvocationCount shouldBe 0 }
+          exception.message shouldContainWithNonAbuttingText "sz664hyg7t"
+          exception.message shouldContainWithNonAbuttingTextIgnoringCase
+            "FetchPolicy.CACHE_ONLY cannot be used"
+          exception.message shouldContainWithNonAbuttingTextIgnoringCase
+            "DataConnectSettings object with a non-null `cacheSettings`"
+        }
+      }
+    }
+
+  @Test
   fun `executeQuery(fetchPolicy!=SERVER_ONLY) returns non-normalized query results from cache`() =
     runTest {
       val fetchPolicy1Arb = Arb.of(FetchPolicy.PREFER_CACHE, FetchPolicy.SERVER_ONLY)


### PR DESCRIPTION
This PR fixes a bug in Data Connect where queries executed with `FetchPolicy.CACHE_ONLY` would incorrectly fall back to performing a server request when local caching was not enabled, instead of failing with an exception as expected. Now, `CACHE_ONLY` queries will immediately fail with a `CachedDataNotFoundException` if caching is not configured.

### Highlights

* **Immediate Caching Enforcement**: Enforces that queries executed with `FetchPolicy.CACHE_ONLY` immediately throw a `CachedDataNotFoundException` when local caching is not configured on the `FirebaseDataConnect` instance.
* **Correct Cache-Only Behavior on Cache Misses**: Relocates the cache-miss check for `FetchPolicy.CACHE_ONLY` to immediately follow the local cache lookup, improving code readability.
* **Diagnostic Error Messages**: Improved error messages to guide developers on how to properly enable caching (by specifying non-null `cacheSettings` in the `DataConnectSettings` object) when they intend to use `FetchPolicy.CACHE_ONLY`.
* **Unit Test Updates**: Added targeted unit tests to verify that `FetchPolicy.CACHE_ONLY` throws the expected exception and does not execute gRPC requests on the server when caching is disabled.

<details>

<summary><b>Changelog</b></summary>

* **CHANGELOG.md**
  * Added a fixed entry explaining that queries run with `FetchPolicy.CACHE_ONLY` now correctly fail when local caching is disabled instead of falling back to the server.
* **DataConnectGrpcRPCs.kt**
  * Introduced a pre-flight check to verify local caching is configured when using `FetchPolicy.CACHE_ONLY` and throw a detailed `CachedDataNotFoundException` if it is not.
  * Repositioned the cache miss handler for `FetchPolicy.CACHE_ONLY` to check for empty results immediately after attempting to retrieve the query from the cache.
  * Removed the now-redundant cache miss check from the helper query-against-cache method.
* **DataConnectGrpcRPCsUnitTest.kt**
  * Added a new unit test `executeQuery(fetchPolicy=CACHE_ONLY) with null cacheSettings throws CachedDataNotFoundException` to assert that cache-only queries correctly fail and never invoke gRPC endpoints when caching is disabled.

</details>