### PR TITLE
dataconnect(chore): add `last_update_sequence_number` to cache db

### DIFF
--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/sqlite/DataConnectCacheDatabase.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/sqlite/DataConnectCacheDatabase.kt
@@ -197,6 +197,15 @@ internal class DataConnectCacheDatabase(
     }
   }
 
+  @JvmInline value class SqliteSequenceNumber(val sequenceNumber: Long)
+
+  private fun SQLiteDatabase.nextSequenceNumber(): SqliteSequenceNumber {
+    execSQL(logger, "INSERT INTO sequence_number DEFAULT VALUES")
+    val sequenceNumber = getLastInsertRowId(logger)
+    execSQL(logger, "DELETE FROM sequence_number")
+    return SqliteSequenceNumber(sequenceNumber)
+  }
+
   @JvmInline private value class SqliteUserId(val sqliteRowId: Long)
 
   @JvmInline private value class SqliteQueryId(val sqliteRowId: Long)
@@ -224,12 +233,19 @@ internal class DataConnectCacheDatabase(
     val id: SqliteQueryId,
     val proto: QueryResultProto,
     val expiryProto: QueryResultExpiry,
+    // lastUpdateSequenceNumber==null comes from migrating from an older schema that lacked the
+    // "last_update_sequence_number" column in the "queries" table.
+    val lastUpdateSequenceNumber: SqliteSequenceNumber?,
   )
 
   private fun SQLiteDatabase.getQuery(user: SqliteUserId, queryId: QueryId): GetQueryResult? =
     rawQuery(
       logger,
-      "SELECT id, data, expiry, flags FROM queries WHERE user_id=? AND query_id=?",
+      """
+        SELECT id, data, expiry, flags, last_update_sequence_number
+        FROM queries
+        WHERE user_id=? AND query_id=?
+      """,
       bindArgs = arrayOf(user.sqliteRowId, queryId.bytes.peek()),
     ) { cursor ->
       if (!cursor.moveToNext()) {
@@ -239,6 +255,7 @@ internal class DataConnectCacheDatabase(
         val protoBytes = cursor.getBlob(1)
         val expiryBytes = cursor.getBlob(2)
         val flags = cursor.getLong(3).toULong()
+        val lastUpdateSequenceNumber = if (cursor.isNull(4)) null else cursor.getLong(4)
 
         val parseResult = runCatching {
           // The lower 32 bits of the "flags" are "required". So if there are any flags set there
@@ -269,7 +286,12 @@ internal class DataConnectCacheDatabase(
           }
         }
 
-        GetQueryResult(id, parseResult.getOrThrow(), expiryParseResult.getOrThrow())
+        GetQueryResult(
+          id,
+          parseResult.getOrThrow(),
+          expiryParseResult.getOrThrow(),
+          lastUpdateSequenceNumber?.toSqliteSequenceNumber(),
+        )
       }
     }
 
@@ -278,19 +300,21 @@ internal class DataConnectCacheDatabase(
     queryId: QueryId,
     queryResultProtoBytes: ImmutableByteArray,
     expiryProtoBytes: ImmutableByteArray,
+    lastUpdateSequenceNumber: SqliteSequenceNumber,
   ): SqliteQueryId {
     execSQL(
       logger,
       """
         INSERT OR REPLACE INTO queries
-        (user_id, query_id, data, expiry, flags)
-        VALUES (?, ?, ?, ?, 0)
+        (user_id, query_id, data, expiry, flags, last_update_sequence_number)
+        VALUES (?, ?, ?, ?, 0, ?)
       """,
       arrayOf(
         user.sqliteRowId,
         queryId.bytes.peek(),
         queryResultProtoBytes.peek(),
-        expiryProtoBytes.peek()
+        expiryProtoBytes.peek(),
+        lastUpdateSequenceNumber.sequenceNumber,
       )
     )
     val rowId = getLastInsertRowId(logger)
@@ -300,6 +324,7 @@ internal class DataConnectCacheDatabase(
   private fun SQLiteDatabase.updateEntities(
     user: SqliteUserId,
     entityStructById: Map<String, Struct>,
+    lastUpdateSequenceNumber: SqliteSequenceNumber,
   ): List<SqliteEntityId> {
     val baseEntityStructById =
       getEntities(
@@ -315,7 +340,7 @@ internal class DataConnectCacheDatabase(
     //  baseEntityStruct.toBuilder() call if the fields of entityStruct are a superset of those of
     //  baseEntityStruct.
     entityStructById.entries.forEach { (entityId, entityStruct) ->
-      val baseEntityStruct = baseEntityStructById[entityId]
+      val baseEntityStruct = baseEntityStructById[entityId]?.struct
       val overlaidEntityStruct =
         if (baseEntityStruct === null) {
           entityStruct
@@ -323,7 +348,13 @@ internal class DataConnectCacheDatabase(
           baseEntityStruct.toBuilder().putAllFields(entityStruct.fieldsMap).build()
         }
 
-      val sqliteEntityId = insertEntity(user, entityId, overlaidEntityStruct)
+      val sqliteEntityId =
+        insertEntity(
+          user,
+          entityId,
+          overlaidEntityStruct,
+          lastUpdateSequenceNumber,
+        )
       sqliteEntityIds.add(sqliteEntityId)
     }
 
@@ -334,6 +365,7 @@ internal class DataConnectCacheDatabase(
     user: SqliteUserId,
     entityId: String,
     entityStruct: Struct,
+    lastUpdateSequenceNumber: SqliteSequenceNumber,
   ): SqliteEntityId {
     val entityStructBytes = entityStruct.toByteArray()
 
@@ -341,10 +373,15 @@ internal class DataConnectCacheDatabase(
       logger,
       """
         INSERT OR REPLACE INTO entities
-        (user_id, entity_id, data, flags)
-        VALUES (?, ?, ?, 0)
+        (user_id, entity_id, data, flags, last_update_sequence_number)
+        VALUES (?, ?, ?, 0, ?)
       """,
-      arrayOf(user.sqliteRowId, entityId, entityStructBytes)
+      arrayOf(
+        user.sqliteRowId,
+        entityId,
+        entityStructBytes,
+        lastUpdateSequenceNumber.sequenceNumber,
+      )
     )
 
     val rowId = getLastInsertRowId(logger)
@@ -371,18 +408,25 @@ internal class DataConnectCacheDatabase(
     Error,
   }
 
+  private class EntityStructLastUpdateSequenceNumberPair(
+    val struct: Struct,
+    // lastUpdateSequenceNumber==null comes from migrating from an older schema that lacked the
+    // "last_update_sequence_number" column in the "entities" table.
+    val lastUpdateSequenceNumber: SqliteSequenceNumber?,
+  )
+
   private fun SQLiteDatabase.getEntities(
     user: SqliteUserId,
     entityIds: Collection<String>,
     entityParseFailureAction: EntityParseFailureAction,
-  ): Map<String, Struct> {
+  ): Map<String, EntityStructLastUpdateSequenceNumberPair> {
     if (entityIds.isEmpty()) {
       return emptyMap()
     }
 
     val (sql, bindArgs) =
       SQLiteStatementBuilder().run {
-        append("SELECT entity_id, data, flags FROM entities")
+        append("SELECT entity_id, data, flags, last_update_sequence_number FROM entities")
         append(" WHERE user_id=").appendBinding(user.sqliteRowId)
         append(" AND entity_id IN (")
         entityIds.forEachIndexed { index, entityId ->
@@ -399,6 +443,7 @@ internal class DataConnectCacheDatabase(
           val entityId = cursor.getString(0)
           val data = cursor.getBlob(1)
           val flags = cursor.getLong(2).toULong()
+          val lastUpdateSequenceNumber = if (cursor.isNull(3)) null else cursor.getLong(3)
 
           val parseResult = runCatching {
             // The lower 32 bits of the "flags" are "required". So if there are any flags set there
@@ -426,7 +471,12 @@ internal class DataConnectCacheDatabase(
             }
 
           if (entityStruct !== null) {
-            put(entityId, entityStruct)
+            val entityInfo =
+              EntityStructLastUpdateSequenceNumberPair(
+                entityStruct,
+                lastUpdateSequenceNumber?.toSqliteSequenceNumber(),
+              )
+            put(entityId, entityInfo)
           }
         }
       }
@@ -446,9 +496,15 @@ internal class DataConnectCacheDatabase(
 
     data class Stale(val staleness: Duration) : GetQueryResultResult
 
+    /**
+     * @property maxLastUpdateSequenceNumber The largest sequence number of the query or any of its
+     * constituent entities; null indicates that the sequence number is not known because the
+     * database was populated by an older version that was not sequence number aware.
+     */
     data class Found(
       val struct: Struct,
       val freshnessRemaining: Duration,
+      val maxLastUpdateSequenceNumber: SqliteSequenceNumber?,
     ) : GetQueryResultResult
   }
 
@@ -472,7 +528,9 @@ internal class DataConnectCacheDatabase(
       if (getQueryResult === null) {
         GetQueryResultResult.NotFound
       } else {
-        val (sqliteQueryId, queryResultProto, expiryProto) = getQueryResult
+        val sqliteQueryId: SqliteQueryId = getQueryResult.id
+        val queryResultProto: QueryResultProto = getQueryResult.proto
+        val expiryProto: QueryResultExpiry = getQueryResult.expiryProto
 
         val staleness = expiryProto.calculateStaleness(currentTimeMillis)
         val staleDuration =
@@ -497,7 +555,7 @@ internal class DataConnectCacheDatabase(
         }
 
         val entityIds: Set<String> = queryResultProto.referencedEntityIds()
-        val entityStructByEntityId =
+        val entityInfoByEntityId =
           sqliteDatabase.getEntities(
             sqliteUserId,
             entityIds,
@@ -505,7 +563,7 @@ internal class DataConnectCacheDatabase(
           )
 
         val rehydrateResult = runCatching {
-          rehydrateQueryResult(queryResultProto, entityStructByEntityId)
+          rehydrateQueryResult(queryResultProto, entityInfoByEntityId.mapValues { it.value.struct })
         }
         rehydrateResult.onFailure {
           logger.warn {
@@ -520,7 +578,25 @@ internal class DataConnectCacheDatabase(
             else -> 1
           }
         val freshnessRemaining = staleDuration * staleDurationMultiplier
-        GetQueryResultResult.Found(rehydrateResult.getOrThrow(), freshnessRemaining)
+
+        val maxLastUpdateSequenceNumber =
+          entityInfoByEntityId.values.fold(getQueryResult.lastUpdateSequenceNumber) {
+            currentMax,
+            entityInfo ->
+            val candidateMax = entityInfo.lastUpdateSequenceNumber
+            when {
+              currentMax == null -> candidateMax
+              candidateMax == null -> currentMax
+              candidateMax.sequenceNumber > currentMax.sequenceNumber -> candidateMax
+              else -> currentMax
+            }
+          }
+
+        GetQueryResultResult.Found(
+          struct = rehydrateResult.getOrThrow(),
+          freshnessRemaining = freshnessRemaining,
+          maxLastUpdateSequenceNumber = maxLastUpdateSequenceNumber,
+        )
       }
     }
   }
@@ -532,7 +608,7 @@ internal class DataConnectCacheDatabase(
     maxAge: DurationProto,
     currentTimeMillis: Long,
     getEntityIdForPath: GetEntityIdForPathFunction?,
-  ) {
+  ): SqliteSequenceNumber {
     require(queryId.bytes.size > 0) {
       "queryId.bytes.size=${queryId.bytes.size}, but must be greater than zero [ab4em538tb]"
     }
@@ -554,7 +630,8 @@ internal class DataConnectCacheDatabase(
         }
     }
 
-    runReadWriteTransaction { sqliteDatabase ->
+    return runReadWriteTransaction { sqliteDatabase ->
+      val sequenceNumber = sqliteDatabase.nextSequenceNumber()
       val user = sqliteDatabase.getOrInsertAuthUid(authUid)
 
       val query =
@@ -563,18 +640,22 @@ internal class DataConnectCacheDatabase(
           queryId = queryId,
           queryResultProtoBytes = queryResultProtoBytes,
           expiryProtoBytes = expiryProtoBytes,
+          lastUpdateSequenceNumber = sequenceNumber,
         )
 
       val sqliteEntityIds =
         sqliteDatabase.updateEntities(
           user = user,
           entityStructById = entityStructById,
+          lastUpdateSequenceNumber = sequenceNumber
         )
 
       sqliteDatabase.deleteEntityIdMappingsForQuery(query)
       sqliteEntityIds.forEach { sqliteEntityId ->
         sqliteDatabase.insertQueryIdEntityIdMapping(query, sqliteEntityId)
       }
+
+      sequenceNumber
     }
   }
 
@@ -771,3 +852,6 @@ private val supportedStaleResults =
     GetQueryResultResult.Found::class,
     GetQueryResultResult.Stale::class,
   )
+
+private fun Long.toSqliteSequenceNumber(): DataConnectCacheDatabase.SqliteSequenceNumber =
+  DataConnectCacheDatabase.SqliteSequenceNumber(this)

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/sqlite/DataConnectCacheDatabaseMigrator.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/sqlite/DataConnectCacheDatabaseMigrator.kt
@@ -57,7 +57,6 @@ private constructor(private val sqliteDatabase: SQLiteDatabase, private val logg
     if (stopAtVersionForTesting != null) {
       logger.warn {
         "WARNING q9dfsdxdmp: migrate() called with " +
-          "" +
           "stopAtVersionForTesting=$stopAtVersionForTesting, " +
           "which should ONLY be done by tests for the SDK itself"
       }
@@ -72,7 +71,6 @@ private constructor(private val sqliteDatabase: SQLiteDatabase, private val logg
     if (stopAtVersionForTesting != null) {
       logger.warn {
         "WARNING n7d2qazseq: migrateDatabase() called with " +
-          "" +
           "stopAtVersionForTesting=$stopAtVersionForTesting, " +
           "which should ONLY be done by tests for the SDK itself"
       }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/sqlite/DataConnectCacheDatabaseMigrator.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/sqlite/DataConnectCacheDatabaseMigrator.kt
@@ -18,14 +18,15 @@ package com.google.firebase.dataconnect.sqlite
 
 import android.annotation.SuppressLint
 import android.database.sqlite.SQLiteDatabase
+import androidx.annotation.VisibleForTesting
 import com.google.firebase.dataconnect.core.Logger
 import com.google.firebase.dataconnect.core.LoggerGlobals.debug
+import com.google.firebase.dataconnect.core.LoggerGlobals.warn
 import com.google.firebase.dataconnect.sqlite.SQLiteDatabaseExts.execSQL
 import com.google.firebase.dataconnect.sqlite.SQLiteDatabaseExts.getApplicationId
 import com.google.firebase.dataconnect.sqlite.SQLiteDatabaseExts.setApplicationId
 import com.google.firebase.dataconnect.util.SemanticVersion
 import com.google.firebase.dataconnect.util.StringUtil.to0xHexString
-import com.google.firebase.dataconnect.util.decodeSemanticVersion
 
 internal class DataConnectCacheDatabaseMigrator
 private constructor(private val sqliteDatabase: SQLiteDatabase, private val logger: Logger) {
@@ -34,16 +35,100 @@ private constructor(private val sqliteDatabase: SQLiteDatabase, private val logg
 
     private const val APPLICATION_ID: Int = 0x7f1bc816
 
+    private val version_1_0_0 = SemanticVersion(1, 0, 0)
+    private val version_1_1_0 = SemanticVersion(1, 1, 0)
+
     fun migrate(sqliteDatabase: SQLiteDatabase, logger: Logger) {
       DataConnectCacheDatabaseMigrator(sqliteDatabase, logger).migrate()
     }
+
+    @VisibleForTesting
+    fun migrateToVersionForTesting(
+      sqliteDatabase: SQLiteDatabase,
+      stopAtVersion: SemanticVersion,
+      logger: Logger,
+    ) {
+      DataConnectCacheDatabaseMigrator(sqliteDatabase, logger)
+        .migrate(stopAtVersionForTesting = stopAtVersion)
+    }
   }
 
-  private fun migrate() {
+  private fun migrate(stopAtVersionForTesting: SemanticVersion? = null) {
+    if (stopAtVersionForTesting != null) {
+      logger.warn {
+        "WARNING q9dfsdxdmp: migrate() called with " +
+          "" +
+          "stopAtVersionForTesting=$stopAtVersionForTesting, " +
+          "which should ONLY be done by tests for the SDK itself"
+      }
+    }
     logger.debug { "migrate() started" }
     migrateApplicationId()
-    migrateSchema()
+    migrateDatabase(stopAtVersionForTesting)
     logger.debug { "migrate() completed" }
+  }
+
+  private fun migrateDatabase(stopAtVersionForTesting: SemanticVersion?) {
+    if (stopAtVersionForTesting != null) {
+      logger.warn {
+        "WARNING n7d2qazseq: migrateDatabase() called with " +
+          "" +
+          "stopAtVersionForTesting=$stopAtVersionForTesting, " +
+          "which should ONLY be done by tests for the SDK itself"
+      }
+    }
+    val stopAtVersionForTestingInt = stopAtVersionForTesting?.encodeToInt()
+
+    val visitedUserVersions: MutableSet<Int> = mutableSetOf()
+
+    while (true) {
+      val migrateOneStepResult: MigrateOneStepResult
+      val userVersionAfter: Int
+
+      try {
+        sqliteDatabase.beginTransaction()
+
+        val userVersionBefore = sqliteDatabase.version
+        migrateOneStepResult = migrateOneStep()
+        userVersionAfter = sqliteDatabase.version
+
+        if (migrateOneStepResult == MigrateOneStepResult.MigrationStepSuccessful) {
+          check(userVersionBefore != userVersionAfter) {
+            "internal error bpabj7creb: migrateOneStepResult==MigrationStepSuccessful but " +
+              "userVersionBefore==userVersionAfter, contrarily indicating that " +
+              "no migration occurred (userVersionBefore=$userVersionBefore, " +
+              "userVersionAfter=$userVersionAfter)"
+          }
+          check(userVersionAfter !in visitedUserVersions) {
+            "internal error vxznqxhsjf: userVersionAfter=$userVersionAfter, " +
+              "but that value is contained in visitedUserVersions; " +
+              "aborting to avoid an infinite loop " +
+              "(visitedUserVersions.size=${visitedUserVersions.size}, " +
+              "visitedUserVersions=${visitedUserVersions.sorted().joinToString()})"
+          }
+          visitedUserVersions.add(userVersionBefore)
+          visitedUserVersions.add(userVersionAfter)
+        }
+
+        sqliteDatabase.setTransactionSuccessful()
+      } finally {
+        sqliteDatabase.endTransaction()
+      }
+
+      if (stopAtVersionForTestingInt != null && userVersionAfter == stopAtVersionForTestingInt) {
+        logger.warn {
+          "WARNING zqpjcejdcq: stopping database migrations at user_version " +
+            "$stopAtVersionForTestingInt, because a non-null value of $stopAtVersionForTesting " +
+            "was specified, which should ONLY be done by tests for the SDK itself"
+        }
+        break
+      }
+
+      when (migrateOneStepResult) {
+        MigrateOneStepResult.MigrationStepSuccessful -> continue
+        MigrateOneStepResult.NoMoreMigrationsToPerform -> break
+      }
+    }
   }
 
   private fun migrateApplicationId() {
@@ -79,33 +164,49 @@ private constructor(private val sqliteDatabase: SQLiteDatabase, private val logg
     }
   }
 
-  private fun migrateSchema() {
-    try {
-      sqliteDatabase.beginTransaction()
+  private enum class MigrateOneStepResult {
+    MigrationStepSuccessful,
+    NoMoreMigrationsToPerform,
+  }
 
-      val userVersion = sqliteDatabase.version
-      if (userVersion == 0) {
-        logger.debug { "user_version is 0; initializing database" }
-        initializeDatabase()
-        val newUserVersion = SemanticVersion(1, 0, 0)
-        val newUserVersionInt = newUserVersion.encodeToInt()
-        logger.debug { "setting user_version to $newUserVersionInt ($newUserVersion)" }
-        sqliteDatabase.version = newUserVersionInt
-      } else {
-        val decodedUserVersion: SemanticVersion = userVersion.decodeSemanticVersion()
-        logger.debug { "user_version is $userVersion, decoded as $decodedUserVersion" }
-        if (decodedUserVersion.major != 1) {
-          throw UnsupportedUserVersionException(
-            "user_version $userVersion has a 'major' version number of " +
-              "${decodedUserVersion.major}, but only major version 1 is supported " +
-              "(decodedUserVersion=$decodedUserVersion) [szetvza49k]"
-          )
-        }
-      }
+  private fun migrateOneStep(): MigrateOneStepResult {
+    val newUserVersion: SemanticVersion? = migrateToNextVersionFrom(sqliteDatabase.version)
 
-      sqliteDatabase.setTransactionSuccessful()
-    } finally {
-      sqliteDatabase.endTransaction()
+    return if (newUserVersion == null) {
+      MigrateOneStepResult.NoMoreMigrationsToPerform
+    } else {
+      val newUserVersionInt = newUserVersion.encodeToInt()
+      logger.debug { "setting user_version to $newUserVersionInt ($newUserVersion)" }
+      sqliteDatabase.version = newUserVersionInt
+      MigrateOneStepResult.MigrationStepSuccessful
+    }
+  }
+
+  private fun migrateToNextVersionFrom(userVersionInt: Int): SemanticVersion? {
+    if (userVersionInt == 0) {
+      logger.debug { "user_version is 0; initializing database" }
+      initializeDatabase()
+      return version_1_0_0
+    }
+
+    val userVersion = SemanticVersion.decodeFromInt(userVersionInt)
+
+    return if (userVersion.major != 1) {
+      throw UnsupportedUserVersionException(
+        "user_version $userVersionInt ($userVersion) has 'major' version number " +
+          "${userVersion.major}, but only major version 1 is supported [szetvza49k]"
+      )
+    } else if (userVersion == version_1_0_0) {
+      migrateFrom100To110(userVersion)
+    } else if (userVersion.minor >= 1) {
+      logger.debug { "user_version is $userVersionInt ($userVersion); all migrations complete" }
+      null
+    } else {
+      throw UnsupportedUserVersionException(
+        "unsupported user_version: $userVersion ($userVersionInt); " +
+          "it is between 1.0.0 and 1.1.0, for which there are no known migrations; " +
+          "aborting to avoid corrupting the database [vdzgyhdche]"
+      )
     }
   }
 
@@ -162,6 +263,28 @@ private constructor(private val sqliteDatabase: SQLiteDatabase, private val logg
       logger,
       "CREATE INDEX entity_query_map_entity_index ON entity_query_map(entity_id)"
     )
+  }
+
+  private fun migrateFrom100To110(userVersion: SemanticVersion): SemanticVersion {
+    check(userVersion == version_1_0_0) {
+      "internal error tka7dm6nch: userVersion=$userVersion but expected $version_1_0_0"
+    }
+    val newVersion = version_1_1_0
+    logger.debug {
+      "user_version is $userVersion (${userVersion.encodeToInt()}); " +
+        "migrating to $newVersion (${newVersion.encodeToInt()})"
+    }
+
+    sqliteDatabase.execSQL(
+      logger,
+      "ALTER TABLE queries ADD COLUMN last_update_sequence_number INTEGER"
+    )
+    sqliteDatabase.execSQL(
+      logger,
+      "ALTER TABLE entities ADD COLUMN last_update_sequence_number INTEGER"
+    )
+
+    return newVersion
   }
 
   class InvalidApplicationIdException(message: String) : Exception(message)

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/ByteArrayUtils.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/ByteArrayUtils.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.dataconnect.util
+
+/**
+ * Compares this [ByteArray] with another [ByteArray] lexicographically based on the signed values
+ * of their bytes.
+ *
+ * The comparison is performed byte-by-byte from left to right (index 0 upwards) until a difference
+ * is found:
+ * - If a byte difference is found, the result of comparing the signed values of those two bytes is
+ * returned.
+ * - If no difference is found up to the length of the shorter array, the shorter array is
+ * considered lexicographically less than (smaller than) the longer one.
+ * - If the arrays have the same size and identical elements, they are considered equal.
+ *
+ * This is a backport/alternative to `java.util.Arrays.compare(byte[], byte[])` which is only
+ * available on Android API level 33 or greater.
+ *
+ * @param other The [ByteArray] to be compared with this one.
+ * @return A negative integer, zero, or a positive integer as this [ByteArray] is lexicographically
+ * less than, equal to, or greater than the other [ByteArray], respectively.
+ */
+internal fun ByteArray.contentCompareTo(other: ByteArray): Int = contentCompare(this, other)
+
+// NOTE: Replace this method with Arrays.compare() once minSdkVersion is set to 33 or greater.
+// At the time of writing (May 2026) minSdkVersion is 23, so I predict this will be around 2032 :)
+private fun contentCompare(array1: ByteArray, array2: ByteArray): Int {
+  if (array1 === array2) {
+    return 0
+  }
+
+  val minSize = minOf(array1.size, array2.size)
+  for (i in 0 until minSize) {
+    val cmp = array1[i].compareTo(array2[i])
+    if (cmp != 0) return cmp
+  }
+
+  return array1.size.compareTo(array2.size)
+}

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/ImmutableByteArray.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/ImmutableByteArray.kt
@@ -16,6 +16,7 @@
 
 package com.google.firebase.dataconnect.util
 
+import com.google.firebase.dataconnect.util.ImmutableByteArray.Companion.adopt
 import com.google.firebase.dataconnect.util.StringUtil.to0xHexString
 
 /**
@@ -24,7 +25,8 @@ import com.google.firebase.dataconnect.util.StringUtil.to0xHexString
  * This class provides a way to pass around a [ByteArray] while ensuring that it won't be modified.
  * It does not copy the array when created via [adopt], but rather takes ownership of it.
  */
-internal class ImmutableByteArray private constructor(private val array: ByteArray) {
+internal class ImmutableByteArray private constructor(private val array: ByteArray) :
+  Comparable<ImmutableByteArray> {
 
   /** The size of the underlying byte array. */
   val size: Int
@@ -61,6 +63,18 @@ internal class ImmutableByteArray private constructor(private val array: ByteArr
    */
   fun to0xHexString(include0xPrefix: Boolean = true): String =
     array.to0xHexString(include0xPrefix = include0xPrefix)
+
+  /**
+   * Compares this object's underlying byte array with that of the given [ImmutableByteArray] for
+   * relative ordering based on the contents and the size of the arrays.
+   *
+   * Although the exact algorithm is not specified, it is guaranteed to produce a stable ordering
+   * for every call with the same arrays with the same contents, across process and device restarts.
+   * That is, if you call `a.compareTo(b)` today, then save `a` and `b` to files, then in 10 years,
+   * after many process restarts, load `a` and `b` from those files and call `a.compareTo(b)` again,
+   * it will return the same sign, or zero, as it did before.
+   */
+  override fun compareTo(other: ImmutableByteArray): Int = array.contentCompareTo(other.array)
 
   /**
    * Creates a deep copy of this [ImmutableByteArray].

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/sqlite/DataConnectCacheDatabaseMigratorUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/sqlite/DataConnectCacheDatabaseMigratorUnitTest.kt
@@ -16,16 +16,24 @@
 
 package com.google.firebase.dataconnect.sqlite
 
+import android.database.sqlite.SQLiteDatabase
 import com.google.firebase.dataconnect.core.Logger
 import com.google.firebase.dataconnect.sqlite.DataConnectCacheDatabaseMigrator.InvalidApplicationIdException
 import com.google.firebase.dataconnect.sqlite.DataConnectCacheDatabaseMigrator.UnsupportedUserVersionException
+import com.google.firebase.dataconnect.sqlite.SQLiteDatabaseExts.execSQL
 import com.google.firebase.dataconnect.sqlite.SQLiteDatabaseExts.getApplicationId
+import com.google.firebase.dataconnect.sqlite.SQLiteDatabaseExts.getLastInsertRowId
+import com.google.firebase.dataconnect.sqlite.SQLiteDatabaseExts.rawQuery
 import com.google.firebase.dataconnect.sqlite.SQLiteDatabaseExts.setApplicationId
 import com.google.firebase.dataconnect.testutil.DataConnectLogLevelRule
+import com.google.firebase.dataconnect.testutil.RandomSeedTestRule
+import com.google.firebase.dataconnect.testutil.cartesianProduct
+import com.google.firebase.dataconnect.testutil.property.arbitrary.TestValueGenerator
 import com.google.firebase.dataconnect.testutil.property.arbitrary.dataConnect
 import com.google.firebase.dataconnect.testutil.property.arbitrary.semanticVersion
 import com.google.firebase.dataconnect.testutil.shouldContainWithNonAbuttingText
 import com.google.firebase.dataconnect.testutil.shouldContainWithNonAbuttingTextIgnoringCase
+import com.google.firebase.dataconnect.util.ImmutableByteArray
 import com.google.firebase.dataconnect.util.SemanticVersion
 import com.google.firebase.dataconnect.util.StringUtil.to0xHexString
 import com.google.firebase.dataconnect.util.decodeSemanticVersion
@@ -37,9 +45,14 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.EdgeConfig
 import io.kotest.property.PropTestConfig
+import io.kotest.property.arbitrary.byte
+import io.kotest.property.arbitrary.byteArray
 import io.kotest.property.arbitrary.constant
 import io.kotest.property.arbitrary.filterNot
 import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.long
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.orNull
 import io.kotest.property.assume
 import io.kotest.property.checkAll
 import io.mockk.mockk
@@ -59,6 +72,11 @@ class DataConnectCacheDatabaseMigratorUnitTest {
 
   @get:Rule val dataConnectLogLevelRule = DataConnectLogLevelRule()
 
+  @get:Rule(order = Int.MIN_VALUE) val randomSeedTestRule = RandomSeedTestRule()
+  private val testValueGenerator by lazy {
+    TestValueGenerator(randomSeedTestRule, edgeCaseProbability = 0.2)
+  }
+
   @Test
   fun `migrate() idempotency`() {
     val mockLogger: Logger = mockk(relaxed = true)
@@ -70,7 +88,7 @@ class DataConnectCacheDatabaseMigratorUnitTest {
   }
 
   @Test
-  fun `migrate() should set application_id on a new database`() {
+  fun `migrate() sets application_id on a new database`() {
     val mockLogger: Logger = mockk(relaxed = true)
     val applicationId =
       DataConnectSQLiteDatabaseOpener.open(dbFile, mockLogger).use { db ->
@@ -81,7 +99,7 @@ class DataConnectCacheDatabaseMigratorUnitTest {
   }
 
   @Test
-  fun `migrate() leave application_id alone if already correct`() {
+  fun `migrate() leaves application_id alone if already correct`() {
     val mockLogger: Logger = mockk(relaxed = true)
     val applicationId =
       DataConnectSQLiteDatabaseOpener.open(dbFile, mockLogger).use { db ->
@@ -93,7 +111,7 @@ class DataConnectCacheDatabaseMigratorUnitTest {
   }
 
   @Test
-  fun `migrate() should throw if application_id is invalid`() = runTest {
+  fun `migrate() throws if application_id is invalid`() = runTest {
     checkAll(propTestConfig, Arb.int()) { applicationId ->
       assume(applicationId != 0 && applicationId != 0x7f1bc816)
       val mockLogger: Logger = mockk(relaxed = true)
@@ -119,7 +137,7 @@ class DataConnectCacheDatabaseMigratorUnitTest {
   }
 
   @Test
-  fun `migrate() should set user_version on a new database`() {
+  fun `migrate() sets user_version on a new database`() {
     val mockLogger: Logger = mockk(relaxed = true)
     val userVersion =
       DataConnectSQLiteDatabaseOpener.open(dbFile, mockLogger).use { db ->
@@ -127,16 +145,47 @@ class DataConnectCacheDatabaseMigratorUnitTest {
         db.version
       }
     withClue("userVersion=$userVersion") {
-      userVersion.decodeSemanticVersion() shouldBe SemanticVersion(1, 0, 0)
+      userVersion.decodeSemanticVersion() shouldBe SemanticVersion(1, 1, 0)
     }
   }
 
   @Test
-  fun `migrate() should leave user_version if major version is 1`() = runTest {
+  fun `migrate() from 1_0_0 to 1_1_0 preserves data`() {
+    val mockLogger: Logger = mockk(relaxed = true)
+    repeat(50) {
+      val dbFile = File(temporaryFolder.newFolder(), "db.sqlite")
+      val seedData = createVersion100Database(dbFile, testValueGenerator, mockLogger)
+      val startVersion = SemanticVersion(1, 0, 0)
+
+      val actualData =
+        DataConnectSQLiteDatabaseOpener.open(dbFile, mockLogger).use { db ->
+          check(db.version == 1_000_000) {
+            "internal error y4asg7a3wv: db.version==${db.version} but expected " +
+              startVersion.encodeToInt()
+          }
+
+          DataConnectCacheDatabaseMigrator.migrateToVersionForTesting(
+            db,
+            SemanticVersion(1, 1, 0),
+            mockLogger,
+          )
+          db.version shouldBe 1_001_000
+
+          db.loadVersion110Database(mockLogger)
+        }
+
+      val actualDataSorted = actualData.sorted()
+      val expectedDataSorted = seedData.toVersion110Database().sorted()
+      actualDataSorted shouldBe expectedDataSorted
+    }
+  }
+
+  @Test
+  fun `migrate() should leave user_version alone if it is between 1_1_0 and 2_0_0`() = runTest {
     val semanticVersionArb =
       Arb.dataConnect.semanticVersion(
         major = Arb.constant(1),
-        minor = Arb.int(0..999),
+        minor = Arb.int(1..999),
         patch = Arb.int(0..999),
       )
     checkAll(propTestConfig, semanticVersionArb) { userVersion ->
@@ -148,6 +197,33 @@ class DataConnectCacheDatabaseMigratorUnitTest {
           db.version
         }
       userVersionAfter shouldBe userVersion.encodeToInt()
+    }
+  }
+
+  @Test
+  fun `migrate() should throw if user_version is between 1_0_0 and 1_1_0`() = runTest {
+    val semanticVersionArb =
+      Arb.dataConnect.semanticVersion(
+        major = Arb.constant(1),
+        minor = Arb.constant(0),
+        patch = Arb.int(1..999),
+      )
+    checkAll(propTestConfig, semanticVersionArb) { userVersion ->
+      val mockLogger: Logger = mockk(relaxed = true)
+      val exception =
+        DataConnectSQLiteDatabaseOpener.open(null, mockLogger).use { db ->
+          db.version = userVersion.encodeToInt()
+          shouldThrow<UnsupportedUserVersionException> {
+            DataConnectCacheDatabaseMigrator.migrate(db, mockLogger)
+          }
+        }
+      assertSoftly {
+        exception.message shouldContainWithNonAbuttingText "vdzgyhdche"
+        exception.message shouldContainWithNonAbuttingText userVersion.encodeToInt().toString()
+        exception.message shouldContainWithNonAbuttingText userVersion.toString()
+        exception.message shouldContainWithNonAbuttingTextIgnoringCase "unsupported user_version"
+        exception.message shouldContainWithNonAbuttingTextIgnoringCase "between 1.0.0 and 1.1.0"
+      }
     }
   }
 
@@ -192,3 +268,337 @@ class DataConnectCacheDatabaseMigratorUnitTest {
       )
   }
 }
+
+private data class Version100Database(
+  val sequenceNumbers: List<Long>,
+  val users: List<User>,
+  val entities: List<Entity>,
+  val queries: List<Query>,
+) {
+  data class User(val id: Long, val authUid: String?, val debugInfo: String?) : Comparable<User> {
+    override fun compareTo(other: User) =
+      compareValuesBy(this, other, User::id, User::authUid, User::debugInfo)
+  }
+
+  data class Entity(
+    val id: Long,
+    val userId: Long,
+    val entityId: String,
+    val data: ImmutableByteArray,
+    val flags: Long,
+    val debugInfo: String?,
+  )
+
+  data class Query(
+    val id: Long,
+    val userId: Long,
+    val queryId: ImmutableByteArray,
+    val data: ImmutableByteArray,
+    val flags: Long,
+    val expiry: ImmutableByteArray,
+    val debugInfo: String?,
+  )
+}
+
+private data class Version110Database(
+  val sequenceNumbers: List<Long>,
+  val users: List<Version100Database.User>,
+  val entities: List<Entity>,
+  val queries: List<Query>,
+) {
+
+  data class Entity(
+    val id: Long,
+    val userId: Long,
+    val entityId: String,
+    val data: ImmutableByteArray,
+    val flags: Long,
+    val debugInfo: String?,
+    val lastUpdateSequenceNumber: Long?,
+  ) : Comparable<Entity> {
+    override fun compareTo(other: Entity) =
+      compareValuesBy(
+        this,
+        other,
+        Entity::id,
+        Entity::userId,
+        Entity::entityId,
+        Entity::data,
+        Entity::flags,
+        Entity::debugInfo,
+        Entity::lastUpdateSequenceNumber,
+      )
+  }
+
+  data class Query(
+    val id: Long,
+    val userId: Long,
+    val queryId: ImmutableByteArray,
+    val data: ImmutableByteArray,
+    val flags: Long,
+    val expiry: ImmutableByteArray,
+    val debugInfo: String?,
+    val lastUpdateSequenceNumber: Long?,
+  ) : Comparable<Query> {
+    override fun compareTo(other: Query) =
+      compareValuesBy(
+        this,
+        other,
+        Query::id,
+        Query::userId,
+        Query::queryId,
+        Query::data,
+        Query::flags,
+        Query::expiry,
+        Query::debugInfo,
+        Query::lastUpdateSequenceNumber,
+      )
+  }
+}
+
+private fun Version110Database.sorted(): Version110Database =
+  Version110Database(
+    sequenceNumbers = sequenceNumbers.sorted(),
+    users = users.sorted(),
+    entities = entities.sorted(),
+    queries = queries.sorted(),
+  )
+
+private fun Version100Database.Entity.toVersion110DatabaseEntity(
+  lastUpdateSequenceNumber: Long?
+): Version110Database.Entity =
+  Version110Database.Entity(
+    id = id,
+    userId = userId,
+    entityId = entityId,
+    data = data,
+    flags = flags,
+    debugInfo = debugInfo,
+    lastUpdateSequenceNumber = lastUpdateSequenceNumber,
+  )
+
+private fun Version100Database.Query.toVersion110DatabaseQuery(
+  lastUpdateSequenceNumber: Long?
+): Version110Database.Query =
+  Version110Database.Query(
+    id = id,
+    userId = userId,
+    queryId = queryId,
+    data = data,
+    flags = flags,
+    expiry = expiry,
+    debugInfo = debugInfo,
+    lastUpdateSequenceNumber = lastUpdateSequenceNumber,
+  )
+
+private fun Version100Database.toVersion110Database(): Version110Database =
+  Version110Database(
+    sequenceNumbers = sequenceNumbers,
+    users = users,
+    entities = entities.map { it.toVersion110DatabaseEntity(lastUpdateSequenceNumber = null) },
+    queries = queries.map { it.toVersion110DatabaseQuery(lastUpdateSequenceNumber = null) },
+  )
+
+private fun SQLiteDatabase.loadVersion110Database(logger: Logger): Version110Database {
+  val sequenceNumbers: List<Long> = buildList {
+    rawQuery(logger, "SELECT id FROM sequence_number") { cursor ->
+      while (cursor.moveToNext()) {
+        add(cursor.getLong(0))
+      }
+    }
+  }
+
+  val users: List<Version100Database.User> = buildList {
+    rawQuery(logger, "SELECT id, auth_uid, debug_info FROM users") { cursor ->
+      while (cursor.moveToNext()) {
+        val id = cursor.getLong(0)
+        val authUid = if (cursor.isNull(1)) null else cursor.getString(1)
+        val debugInfo = if (cursor.isNull(2)) null else cursor.getString(2)
+        add(Version100Database.User(id = id, authUid = authUid, debugInfo = debugInfo))
+      }
+    }
+  }
+
+  val entities: List<Version110Database.Entity> = buildList {
+    rawQuery(
+      logger,
+      """
+        SELECT
+          id, user_id, entity_id, data, flags, debug_info, last_update_sequence_number
+        FROM
+          entities
+      """
+    ) { cursor ->
+      while (cursor.moveToNext()) {
+        val id = cursor.getLong(0)
+        val userId = cursor.getLong(1)
+        val entityId = cursor.getString(2)
+        val data = ImmutableByteArray.adopt(cursor.getBlob(3))
+        val flags = cursor.getLong(4)
+        val debugInfo = if (cursor.isNull(5)) null else cursor.getString(5)
+        val lastUpdateSequenceNumber = if (cursor.isNull(6)) null else cursor.getLong(6)
+        add(
+          Version110Database.Entity(
+            id = id,
+            userId = userId,
+            entityId = entityId,
+            data = data,
+            flags = flags,
+            debugInfo = debugInfo,
+            lastUpdateSequenceNumber = lastUpdateSequenceNumber,
+          )
+        )
+      }
+    }
+  }
+
+  val queries: List<Version110Database.Query> = buildList {
+    rawQuery(
+      logger,
+      """
+        SELECT
+          id, user_id, query_id, data, flags, expiry, debug_info, last_update_sequence_number
+        FROM
+          queries
+      """
+    ) { cursor ->
+      while (cursor.moveToNext()) {
+        val id = cursor.getLong(0)
+        val userId = cursor.getLong(1)
+        val queryId = ImmutableByteArray.adopt(cursor.getBlob(2))
+        val data = ImmutableByteArray.adopt(cursor.getBlob(3))
+        val flags = cursor.getLong(4)
+        val expiry = ImmutableByteArray.adopt(cursor.getBlob(5))
+        val debugInfo = if (cursor.isNull(6)) null else cursor.getString(6)
+        val lastUpdateSequenceNumber = if (cursor.isNull(7)) null else cursor.getLong(7)
+        add(
+          Version110Database.Query(
+            id = id,
+            userId = userId,
+            queryId = queryId,
+            data = data,
+            flags = flags,
+            expiry = expiry,
+            debugInfo = debugInfo,
+            lastUpdateSequenceNumber = lastUpdateSequenceNumber,
+          )
+        )
+      }
+    }
+  }
+
+  return Version110Database(
+    sequenceNumbers = sequenceNumbers,
+    users = users,
+    entities = entities,
+    queries = queries,
+  )
+}
+
+private fun createVersion100Database(
+  dbFile: File,
+  testValueGenerator: TestValueGenerator,
+  logger: Logger,
+): Version100Database {
+  val version100 = SemanticVersion(1, 0, 0)
+  DataConnectSQLiteDatabaseOpener.open(dbFile, logger).use { db ->
+    DataConnectCacheDatabaseMigrator.migrateToVersionForTesting(db, version100, logger)
+    check(db.version == version100.encodeToInt()) {
+      "internal error svadycq5bd: db.version==${db.version} " +
+        "but expected ${version100.encodeToInt()}"
+    }
+    db.beginTransaction()
+    try {
+      val populatedData = db.populateVersion100Data(testValueGenerator, logger)
+      db.setTransactionSuccessful()
+      return populatedData
+    } finally {
+      db.endTransaction()
+    }
+  }
+}
+
+private fun SQLiteDatabase.populateVersion100Data(
+  testValueGenerator: TestValueGenerator,
+  logger: Logger,
+): Version100Database =
+  testValueGenerator.run {
+    val stringArb: Arb<String> = Arb.dataConnect.alphabeticString(0..4)
+    val nullableStringArb: Arb<String?> = stringArb.orNull(nullProbability = 0.2)
+    val flagsArb = Arb.long()
+    val immutableByteArrayArb: Arb<ImmutableByteArray> =
+      Arb.byteArray(Arb.int(0..10), Arb.byte()).map(ImmutableByteArray::adopt)
+    val entityIds = stringArb.generateDistinctValues(1..10)
+    val queryIds = immutableByteArrayArb.generateDistinctValues(1..10)
+
+    val sequenceNumber = Arb.long(min = 0).generateValue()
+    execSQL(logger, "INSERT INTO sequence_number (id) VALUES ($sequenceNumber)")
+
+    val users = run {
+      val authUids = nullableStringArb.generateDistinctValues(1..5)
+      val debugInfos = nullableStringArb.generateValues(authUids.size)
+      authUids.zip(debugInfos) { authUid, debugInfo ->
+        execSQL(
+          logger,
+          "INSERT INTO users (auth_uid, debug_info) VALUES (?, ?)",
+          arrayOf(authUid, debugInfo)
+        )
+        val id = getLastInsertRowId(logger)
+        Version100Database.User(id, authUid = authUid, debugInfo = debugInfo)
+      }
+    }
+
+    val userEntityIdPairs = cartesianProduct(users, entityIds).randomDistinctValues()
+    val entities =
+      userEntityIdPairs.map { (user, entityId) ->
+        val data = immutableByteArrayArb.generateValue()
+        val debugInfo = nullableStringArb.generateValue()
+        val flags = flagsArb.generateValue()
+        execSQL(
+          logger,
+          "INSERT INTO entities (user_id, entity_id, data, flags, debug_info) VALUES (?, ?, ?, ?, ?)",
+          arrayOf(user.id, entityId, data.peek(), flags, debugInfo)
+        )
+        val id = getLastInsertRowId(logger)
+        Version100Database.Entity(
+          id = id,
+          userId = user.id,
+          entityId = entityId,
+          data = data,
+          flags = flags,
+          debugInfo = debugInfo,
+        )
+      }
+
+    val userQueryIdPairs = cartesianProduct(users, queryIds).randomDistinctValues()
+    val queries =
+      userQueryIdPairs.map { (user, queryId) ->
+        val data = immutableByteArrayArb.generateValue()
+        val debugInfo = nullableStringArb.generateValue()
+        val flags = flagsArb.generateValue()
+        val expiry = immutableByteArrayArb.generateValue()
+
+        execSQL(
+          logger,
+          "INSERT INTO queries (user_id, query_id, data, flags, expiry, debug_info) VALUES (?, ?, ?, ?, ?, ?)",
+          arrayOf(user.id, queryId.peek(), data.peek(), flags, expiry.peek(), debugInfo)
+        )
+        val id = getLastInsertRowId(logger)
+        Version100Database.Query(
+          id = id,
+          userId = user.id,
+          queryId = queryId,
+          data = data,
+          flags = flags,
+          expiry = expiry,
+          debugInfo = debugInfo,
+        )
+      }
+
+    Version100Database(
+      sequenceNumbers = listOf(sequenceNumber),
+      users = users,
+      entities = entities,
+      queries = queries,
+    )
+  }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/sqlite/DataConnectCacheDatabaseUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/sqlite/DataConnectCacheDatabaseUnitTest.kt
@@ -24,8 +24,11 @@ import com.google.firebase.dataconnect.sqlite.DataConnectCacheDatabase.GetQueryR
 import com.google.firebase.dataconnect.sqlite.DataConnectCacheDatabase.GetQueryResultResult.Found
 import com.google.firebase.dataconnect.sqlite.DataConnectCacheDatabase.GetQueryResultResult.NotFound
 import com.google.firebase.dataconnect.sqlite.DataConnectCacheDatabase.GetQueryResultResult.Stale
+import com.google.firebase.dataconnect.sqlite.DataConnectCacheDatabase.SqliteSequenceNumber
 import com.google.firebase.dataconnect.sqlite.QueryResultArb.EntityRepeatPolicy.INTER_SAMPLE
 import com.google.firebase.dataconnect.sqlite.QueryResultArb.EntityRepeatPolicy.INTER_SAMPLE_MUTATED
+import com.google.firebase.dataconnect.sqlite.SQLiteDatabaseExts.execSQL
+import com.google.firebase.dataconnect.sqlite.SQLiteDatabaseExts.rawQuery
 import com.google.firebase.dataconnect.testutil.CleanupsRule
 import com.google.firebase.dataconnect.testutil.DataConnectLogLevelRule
 import com.google.firebase.dataconnect.testutil.Quadruple
@@ -53,23 +56,27 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.withClue
 import io.kotest.common.DelicateKotest
 import io.kotest.common.ExperimentalKotest
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.kotest.property.Arb
 import io.kotest.property.EdgeConfig
 import io.kotest.property.PropTestConfig
+import io.kotest.property.PropertyContext
 import io.kotest.property.ShrinkingMode
 import io.kotest.property.arbitrary.bind
 import io.kotest.property.arbitrary.byte
 import io.kotest.property.arbitrary.byteArray
 import io.kotest.property.arbitrary.distinct
+import io.kotest.property.arbitrary.filter
 import io.kotest.property.arbitrary.filterNot
 import io.kotest.property.arbitrary.flatMap
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.of
 import io.kotest.property.arbitrary.orNull
+import io.kotest.property.assume
 import io.kotest.property.checkAll
 import io.mockk.CapturingSlot
 import io.mockk.every
@@ -638,18 +645,144 @@ class DataConnectCacheDatabaseUnitTest {
   }
 
   @Test
+  fun `insertQueryResult() should set last_update_sequence_number only for itself`() = runTest {
+    dataConnectCacheDatabase.initialize()
+
+    checkAll(
+      propTestConfig,
+      authUidArb(),
+      Arb.dataConnect.maxAge(min = MIN_NONZERO_DURATION),
+      queryIdArb().distinctPair(),
+    ) { authUid, maxAge, (queryId1, queryId2) ->
+      val queryResultArb =
+        QueryResultArb(
+          entityIdArb = @OptIn(DelicateKotest::class) Arb.proto.structKey(length = 4).distinct(),
+          entityCountRange = 0..5,
+        )
+      val queryResult1 = queryResultArb.bind()
+      val queryResult2 = queryResultArb.bind()
+
+      val sequenceNumber1 =
+        dataConnectCacheDatabase.insertQueryResult(
+          authUid.authUid,
+          queryId1.queryId,
+          queryResult1.hydratedStruct,
+          maxAge = maxAge,
+          currentTimeMillis = 0L,
+          getEntityIdForPath = queryResult1::getEntityIdForPath,
+        )
+      val sequenceNumber2 =
+        dataConnectCacheDatabase.insertQueryResult(
+          authUid.authUid,
+          queryId2.queryId,
+          queryResult2.hydratedStruct,
+          maxAge = maxAge,
+          currentTimeMillis = 0L,
+          getEntityIdForPath = queryResult2::getEntityIdForPath,
+        )
+
+      withClue("query1") {
+        val result =
+          dataConnectCacheDatabase.getQueryResult(
+            authUid.authUid,
+            queryId1.queryId,
+            currentTimeMillis = 0L,
+            staleResult = Stale::class,
+          )
+        check(result is Found)
+        result.maxLastUpdateSequenceNumber shouldBe sequenceNumber1
+      }
+      withClue("query2") {
+        val result =
+          dataConnectCacheDatabase.getQueryResult(
+            authUid.authUid,
+            queryId2.queryId,
+            currentTimeMillis = 0L,
+            staleResult = Stale::class,
+          )
+        check(result is Found)
+        result.maxLastUpdateSequenceNumber shouldBe sequenceNumber2
+      }
+    }
+  }
+
+  @Test
+  fun `insertQueryResult() should update last_update_sequence_number for its entities`() = runTest {
+    dataConnectCacheDatabase.initialize()
+
+    checkAll(
+      propTestConfig,
+      authUidArb(),
+      Arb.dataConnect.maxAge(min = MIN_NONZERO_DURATION),
+      queryIdArb().distinctPair(),
+    ) { authUid, maxAge, (queryId1, queryId2) ->
+      val queryResultArb =
+        QueryResultArb(
+            entityCountRange = 0..5,
+            entityRepeatPolicy = INTER_SAMPLE,
+          )
+          .filter { it.entityByPath.isNotEmpty() }
+      val queryResult1 = queryResultArb.bind()
+      val queryResult2 = queryResultArb.bind()
+
+      dataConnectCacheDatabase.insertQueryResult(
+        authUid.authUid,
+        queryId1.queryId,
+        queryResult1.hydratedStruct,
+        maxAge = maxAge,
+        currentTimeMillis = 0L,
+        getEntityIdForPath = queryResult1::getEntityIdForPath,
+      )
+      val sequenceNumber2 =
+        dataConnectCacheDatabase.insertQueryResult(
+          authUid.authUid,
+          queryId2.queryId,
+          queryResult2.hydratedStruct,
+          maxAge = maxAge,
+          currentTimeMillis = 0L,
+          getEntityIdForPath = queryResult2::getEntityIdForPath,
+        )
+
+      withClue("query1") {
+        val result =
+          dataConnectCacheDatabase.getQueryResult(
+            authUid.authUid,
+            queryId1.queryId,
+            currentTimeMillis = 0L,
+            staleResult = Stale::class,
+          )
+        check(result is Found)
+        // Even query1 should report query2's sequence number since its insert modified the
+        // last_update_sequence_number of at least one of query1's entities.
+        result.maxLastUpdateSequenceNumber shouldBe sequenceNumber2
+      }
+      withClue("query2") {
+        val result =
+          dataConnectCacheDatabase.getQueryResult(
+            authUid.authUid,
+            queryId2.queryId,
+            currentTimeMillis = 0L,
+            staleResult = Stale::class,
+          )
+        check(result is Found)
+        result.maxLastUpdateSequenceNumber shouldBe sequenceNumber2
+      }
+    }
+  }
+
+  @Test
   fun `getQueryResult() when maxAge is zero and staleResult=Stale should return Stale`() =
     testQueryResultInsertedWithMaxAgeZero(
       staleResult = Stale::class,
-      verifyResult = { result, _, expectedStaleness -> result shouldBe Stale(expectedStaleness) }
+      verifyResult = { result, _, expectedStaleness, _ -> result shouldBe Stale(expectedStaleness) }
     )
 
   @Test
   fun `getQueryResult() when maxAge is zero and staleResult=Found should return Found`() =
     testQueryResultInsertedWithMaxAgeZero(
       staleResult = Found::class,
-      verifyResult = { result, insertedData, expectedStaleness ->
-        result shouldBe Found(insertedData, -expectedStaleness)
+      verifyResult = { result, insertedData, expectedStaleness, insertSequenceNumber ->
+        result shouldBe Found(insertedData, -expectedStaleness, insertSequenceNumber)
       }
     )
 
@@ -657,12 +790,18 @@ class DataConnectCacheDatabaseUnitTest {
   fun `getQueryResult() when maxAge is zero and staleResult=NotFound should return NotFound`() =
     testQueryResultInsertedWithMaxAgeZero(
       staleResult = NotFound::class,
-      verifyResult = { result, _, _ -> result shouldBe NotFound }
+      verifyResult = { result, _, _, _ -> result shouldBe NotFound }
     )
 
   private fun testQueryResultInsertedWithMaxAgeZero(
     staleResult: KClass<out GetQueryResultResult>,
-    verifyResult: (GetQueryResultResult, insertedData: Struct, expectedStaleness: Duration) -> Unit,
+    verifyResult:
+      (
+        GetQueryResultResult,
+        insertedData: Struct,
+        expectedStaleness: Duration,
+        sequenceNumber: SqliteSequenceNumber,
+      ) -> Unit,
   ) = runTest {
     dataConnectCacheDatabase.initialize()
 
@@ -682,9 +821,9 @@ class DataConnectCacheDatabaseUnitTest {
         time1 = time1,
         time2 = time2,
         staleResult = staleResult,
-        verifyResult = {
+        verifyResult = { result, insertSequenceNumber ->
           val expectedStaleness = durationFromMillis(time2.toBigInteger() - time1.toBigInteger())
-          verifyResult(it, queryResult.hydratedStruct, expectedStaleness)
+          verifyResult(result, queryResult.hydratedStruct, expectedStaleness, insertSequenceNumber)
         },
       )
     }
@@ -694,15 +833,15 @@ class DataConnectCacheDatabaseUnitTest {
   fun `getQueryResult() after maxAge time has passed and staleResult=Stale should return Stale`() =
     testGetQueryResultAfterMaxAgeTimeHasPassed(
       staleResult = Stale::class,
-      verifyResult = { result, _, expectedStaleness -> result shouldBe Stale(expectedStaleness) }
+      verifyResult = { result, _, expectedStaleness, _ -> result shouldBe Stale(expectedStaleness) }
     )
 
   @Test
   fun `getQueryResult() after maxAge time has passed and staleResult=Found should return Found`() =
     testGetQueryResultAfterMaxAgeTimeHasPassed(
       staleResult = Found::class,
-      verifyResult = { result, insertedData, expectedStaleness ->
-        result shouldBe Found(insertedData, -expectedStaleness)
+      verifyResult = { result, insertedData, expectedStaleness, insertSequenceNumber ->
+        result shouldBe Found(insertedData, -expectedStaleness, insertSequenceNumber)
       }
     )
 
@@ -710,12 +849,18 @@ class DataConnectCacheDatabaseUnitTest {
   fun `getQueryResult() after maxAge time has passed and staleResult=NotFound should return NotFound`() =
     testGetQueryResultAfterMaxAgeTimeHasPassed(
       staleResult = NotFound::class,
-      verifyResult = { result, _, _ -> result shouldBe NotFound }
+      verifyResult = { result, _, _, _ -> result shouldBe NotFound }
     )
 
   private fun testGetQueryResultAfterMaxAgeTimeHasPassed(
     staleResult: KClass<out GetQueryResultResult>,
-    verifyResult: (GetQueryResultResult, insertedData: Struct, expectedStaleness: Duration) -> Unit,
+    verifyResult:
+      (
+        GetQueryResultResult,
+        insertedData: Struct,
+        expectedStaleness: Duration,
+        insertSequenceNumber: SqliteSequenceNumber,
+      ) -> Unit,
   ) = runTest {
     dataConnectCacheDatabase.initialize()
 
@@ -758,7 +903,14 @@ class DataConnectCacheDatabaseUnitTest {
         time1 = time1,
         time2 = time2,
         staleResult = staleResult,
-        verifyResult = { verifyResult(it, queryResult.hydratedStruct, expectedStaleness) },
+        verifyResult = { result, insertSequenceNumber ->
+          verifyResult(
+            result,
+            queryResult.hydratedStruct,
+            expectedStaleness,
+            insertSequenceNumber,
+          )
+        },
       )
     }
   }
@@ -793,7 +945,14 @@ class DataConnectCacheDatabaseUnitTest {
         time1 = time1,
         time2 = time2,
         staleResult = staleResult,
-        verifyResult = { it shouldBe Found(queryResult.hydratedStruct, Duration.ZERO) },
+        verifyResult = { result, insertSequenceNumber ->
+          result shouldBe
+            Found(
+              queryResult.hydratedStruct,
+              Duration.ZERO,
+              insertSequenceNumber,
+            )
+        },
       )
     }
   }
@@ -844,7 +1003,14 @@ class DataConnectCacheDatabaseUnitTest {
           time1 = time1,
           time2 = time2,
           staleResult = staleResult,
-          verifyResult = { it shouldBe Found(queryResult.hydratedStruct, freshnessRemaining) },
+          verifyResult = { result, insertSequenceNumber ->
+            result shouldBe
+              Found(
+                queryResult.hydratedStruct,
+                freshnessRemaining,
+                insertSequenceNumber,
+              )
+          },
         )
       }
     }
@@ -857,16 +1023,17 @@ class DataConnectCacheDatabaseUnitTest {
     time1: Long,
     time2: Long,
     staleResult: KClass<out GetQueryResultResult>,
-    verifyResult: (GetQueryResultResult) -> Unit,
+    verifyResult: (GetQueryResultResult, insertSequenceNumber: SqliteSequenceNumber) -> Unit,
   ) {
-    dataConnectCacheDatabase.insertQueryResult(
-      authUid.authUid,
-      queryId.queryId,
-      queryResultData,
-      maxAge = maxAge,
-      currentTimeMillis = time1,
-      getEntityIdForPath = null,
-    )
+    val sequenceNumber =
+      dataConnectCacheDatabase.insertQueryResult(
+        authUid.authUid,
+        queryId.queryId,
+        queryResultData,
+        maxAge = maxAge,
+        currentTimeMillis = time1,
+        getEntityIdForPath = null,
+      )
 
     val result =
       dataConnectCacheDatabase.getQueryResult(
@@ -876,7 +1043,174 @@ class DataConnectCacheDatabaseUnitTest {
         staleResult,
       )
 
-    verifyResult(result)
+    verifyResult(result, sequenceNumber)
+  }
+
+  @Test
+  fun `getQueryResult() last_update_sequence_number all null`() =
+    testGetQueryResultReturnsCorrectMaxLastUpdateSequenceNumber(
+      editDbAfterInsert = { db, _, logger ->
+        db.execSQL(logger, "UPDATE queries SET last_update_sequence_number = NULL")
+        db.execSQL(logger, "UPDATE entities SET last_update_sequence_number = NULL")
+      },
+      verifyResult = { result, _, _ -> result.maxLastUpdateSequenceNumber.shouldBeNull() },
+    )
+
+  @Test
+  fun `getQueryResult() query last_update_sequence_number is null`() =
+    testGetQueryResultReturnsCorrectMaxLastUpdateSequenceNumber(
+      editDbAfterInsert = { db, _, logger ->
+        db.execSQL(logger, "UPDATE queries SET last_update_sequence_number = NULL")
+      },
+      verifyResult = { result, insertSequenceNumber, _ ->
+        result.maxLastUpdateSequenceNumber shouldBe insertSequenceNumber
+      },
+    )
+
+  @Test
+  fun `getQueryResult() entities last_update_sequence_number are null`() =
+    testGetQueryResultReturnsCorrectMaxLastUpdateSequenceNumber(
+      editDbAfterInsert = { db, _, logger ->
+        db.execSQL(logger, "UPDATE entities SET last_update_sequence_number = NULL")
+      },
+      verifyResult = { result, insertSequenceNumber, _ ->
+        result.maxLastUpdateSequenceNumber shouldBe insertSequenceNumber
+      },
+    )
+
+  @Test
+  fun `getQueryResult() query last_update_sequence_number is largest`() =
+    testGetQueryResultReturnsCorrectMaxLastUpdateSequenceNumber(
+      editDbAfterInsert = { db, insertSequenceNumber, logger ->
+        val newSequenceNumber = insertSequenceNumber.sequenceNumber + 1
+        db.execSQL(logger, "UPDATE queries SET last_update_sequence_number = $newSequenceNumber")
+        SqliteSequenceNumber(newSequenceNumber)
+      },
+      verifyResult = { result, _, querySequenceNumber ->
+        result.maxLastUpdateSequenceNumber shouldBe querySequenceNumber
+      },
+    )
+
+  @Test
+  fun `getQueryResult() entity last_update_sequence_number is largest`() =
+    testGetQueryResultReturnsCorrectMaxLastUpdateSequenceNumber(
+      editDbAfterInsert = { db, _, logger ->
+        val entityRowIds =
+          db.rawQuery(logger, "SELECT id FROM entities") { cursor ->
+            buildList {
+              while (cursor.moveToNext()) {
+                add(cursor.getLong(0))
+              }
+            }
+          }
+
+        val sequenceNumberArb = Arb.longWithEvenNumDigitsDistribution()
+        val sequenceNumbers = List(entityRowIds.size + 1) { sequenceNumberArb.bind() }
+        val distinctSortedSequenceNumbers = sequenceNumbers.distinct().sorted()
+        assume(distinctSortedSequenceNumbers.size >= 2)
+
+        val querySequenceNumber =
+          distinctSortedSequenceNumbers.dropLast(1).random(randomSource().random)
+        db.execSQL(logger, "UPDATE queries SET last_update_sequence_number = $querySequenceNumber")
+
+        val entitySequenceNumbers = sequenceNumbers.minus(querySequenceNumber).iterator()
+        entityRowIds.forEach { entityRowId ->
+          val entitySequenceNumber = entitySequenceNumbers.next()
+          db.execSQL(
+            logger,
+            """
+          UPDATE entities
+          SET last_update_sequence_number = $entitySequenceNumber
+          WHERE id=$entityRowId
+        """
+          )
+        }
+
+        SqliteSequenceNumber(distinctSortedSequenceNumbers.last())
+      },
+      verifyResult = { result, _, maxEntitySequenceNumber ->
+        result.maxLastUpdateSequenceNumber shouldBe maxEntitySequenceNumber
+      },
+    )
+
+  private fun <T> testGetQueryResultReturnsCorrectMaxLastUpdateSequenceNumber(
+    editDbAfterInsert: PropertyContext.(SQLiteDatabase, SqliteSequenceNumber, Logger) -> T,
+    verifyResult: (Found, SqliteSequenceNumber, T) -> Unit,
+  ) = runTest {
+    dataConnectCacheDatabase.initialize()
+
+    checkAll(
+      propTestConfig,
+      authUidArb(),
+      queryIdArb(),
+      Arb.dataConnect.maxAge(min = MIN_NONZERO_DURATION),
+      QueryResultArb(entityCountRange = 1..5),
+    ) { authUid, queryId, maxAge, queryResult ->
+      val dbFile = File(temporaryFolder.newFolder(), "db.sqlite")
+      val mockLogger: Logger = mockk(relaxed = true)
+
+      // Insert a query and entities into the database
+      val insertSequenceNumber = run {
+        val dataConnectCacheDatabase =
+          DataConnectCacheDatabase(
+            dbFile,
+            Dispatchers.Default,
+            mockLogger,
+          )
+        try {
+          dataConnectCacheDatabase.initialize()
+          dataConnectCacheDatabase.insertQueryResult(
+            authUid.authUid,
+            queryId.queryId,
+            queryResult.hydratedStruct,
+            maxAge = maxAge,
+            currentTimeMillis = 0L,
+            getEntityIdForPath = queryResult::getEntityIdForPath,
+          )
+        } finally {
+          dataConnectCacheDatabase.close()
+        }
+      }
+
+      // Manually edit the "last_update_sequence_number" column in the database
+      val editDbAfterInsertResult = run {
+        DataConnectSQLiteDatabaseOpener.open(dbFile, mockLogger).use { db ->
+          db.beginTransaction()
+          try {
+            val result = editDbAfterInsert(db, insertSequenceNumber, mockLogger)
+            db.setTransactionSuccessful()
+            result
+          } finally {
+            db.endTransaction()
+          }
+        }
+      }
+
+      // Load the query from the database
+      val result = run {
+        val dataConnectCacheDatabase =
+          DataConnectCacheDatabase(
+            dbFile,
+            Dispatchers.Default,
+            mockLogger,
+          )
+        try {
+          dataConnectCacheDatabase.initialize()
+          dataConnectCacheDatabase.getQueryResult(
+            authUid.authUid,
+            queryId.queryId,
+            currentTimeMillis = 0L,
+            staleResult = Stale::class,
+          )
+        } finally {
+          dataConnectCacheDatabase.close()
+        }
+      }
+
+      // Verify that the maxLastUpdateSequenceNumber was the expected value
+      check(result is Found)
+      verifyResult(result, insertSequenceNumber, editDbAfterInsertResult)
+    }
   }
 }
 

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/util/ImmutableByteArrayUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/util/ImmutableByteArrayUnitTest.kt
@@ -19,12 +19,17 @@ package com.google.firebase.dataconnect.util
 import com.google.firebase.dataconnect.testutil.property.arbitrary.distinctPair
 import com.google.firebase.dataconnect.util.StringUtil.to0xHexString
 import io.kotest.common.ExperimentalKotest
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.kotest.matchers.types.shouldNotBeSameInstanceAs
 import io.kotest.property.Arb
 import io.kotest.property.EdgeConfig
 import io.kotest.property.PropTestConfig
+import io.kotest.property.arbitrary.arbitrary
+import io.kotest.property.arbitrary.bind
+import io.kotest.property.arbitrary.boolean
 import io.kotest.property.arbitrary.byte
 import io.kotest.property.arbitrary.byteArray
 import io.kotest.property.arbitrary.choice
@@ -32,7 +37,9 @@ import io.kotest.property.arbitrary.constant
 import io.kotest.property.arbitrary.filterNot
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.shuffle
 import io.kotest.property.arbitrary.string
+import io.kotest.property.arbitrary.subsequence
 import io.kotest.property.checkAll
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -121,6 +128,90 @@ class ImmutableByteArrayUnitTest {
         val immutableByteArray = ImmutableByteArray.adopt(byteArray)
 
         immutableByteArray.equals(byteArray) shouldBe false
+      }
+    }
+
+  @Test
+  fun `ImmutableByteArray compareTo should return 0 when compared to itself`() = runTest {
+    checkAll(propTestConfig, immutableByteArrayArb()) { sample ->
+      val immutableByteArray = sample.immutableByteArray
+
+      immutableByteArray.compareTo(immutableByteArray) shouldBe 0
+    }
+  }
+
+  @Test
+  fun `ImmutableByteArray compareTo should return 0 for equal, but distinct, instances`() =
+    runTest {
+      checkAll(propTestConfig, immutableByteArrayArb()) { sample ->
+        val immutableByteArray1 = sample.immutableByteArray
+        val immutableByteArray2 = immutableByteArray1.copy()
+        check(immutableByteArray1 !== immutableByteArray2)
+        check(immutableByteArray1 == immutableByteArray2)
+
+        immutableByteArray1.compareTo(immutableByteArray2) shouldBe 0
+      }
+    }
+
+  @Test
+  fun `ImmutableByteArray compareTo should return positive for greater array of same length`() =
+    runTest {
+      checkAll(propTestConfig, comparedImmutableByteArraySameSizeArb()) { sample ->
+        val smaller: ImmutableByteArray = sample.smallerImmutableByteArray.immutableByteArray
+        val larger: ImmutableByteArray = sample.largerImmutableByteArray.immutableByteArray
+
+        larger.compareTo(smaller) shouldBeGreaterThan 0
+      }
+    }
+
+  @Test
+  fun `ImmutableByteArray compareTo should return negative for smaller array of same length`() =
+    runTest {
+      checkAll(propTestConfig, comparedImmutableByteArraySameSizeArb()) { sample ->
+        val smaller: ImmutableByteArray = sample.smallerImmutableByteArray.immutableByteArray
+        val larger: ImmutableByteArray = sample.largerImmutableByteArray.immutableByteArray
+
+        smaller.compareTo(larger) shouldBeLessThan 0
+      }
+    }
+
+  @Test
+  fun `ImmutableByteArray compareTo should return positive for a prefix`() = runTest {
+    checkAll(propTestConfig, comparedImmutableByteArrayPrefixArb()) { sample ->
+      val smaller: ImmutableByteArray = sample.smallerImmutableByteArray.immutableByteArray
+      val larger: ImmutableByteArray = sample.largerImmutableByteArray.immutableByteArray
+      larger.compareTo(smaller) shouldBeGreaterThan 0
+    }
+  }
+
+  @Test
+  fun `ImmutableByteArray compareTo should return positive when a prefix`() = runTest {
+    checkAll(propTestConfig, comparedImmutableByteArrayPrefixArb()) { sample ->
+      val smaller: ImmutableByteArray = sample.smallerImmutableByteArray.immutableByteArray
+      val larger: ImmutableByteArray = sample.largerImmutableByteArray.immutableByteArray
+      smaller.compareTo(larger) shouldBeLessThan 0
+    }
+  }
+
+  @Test
+  fun `ImmutableByteArray compareTo should return positive for greater array of different length`() =
+    runTest {
+      checkAll(propTestConfig, comparedImmutableByteArrayDifferentSizeArb()) { sample ->
+        val smaller: ImmutableByteArray = sample.smallerImmutableByteArray.immutableByteArray
+        val larger: ImmutableByteArray = sample.largerImmutableByteArray.immutableByteArray
+
+        larger.compareTo(smaller) shouldBeGreaterThan 0
+      }
+    }
+
+  @Test
+  fun `ImmutableByteArray compareTo should return negative for smaller array of different length`() =
+    runTest {
+      checkAll(propTestConfig, comparedImmutableByteArrayDifferentSizeArb()) { sample ->
+        val smaller: ImmutableByteArray = sample.smallerImmutableByteArray.immutableByteArray
+        val larger: ImmutableByteArray = sample.largerImmutableByteArray.immutableByteArray
+
+        smaller.compareTo(larger) shouldBeLessThan 0
       }
     }
 
@@ -219,3 +310,86 @@ private class ImmutableByteArraySample(val byteArray: ByteArray) {
 private fun immutableByteArrayArb(
   byteArray: Arb<ByteArray> = Arb.byteArray(Arb.int(0..10), Arb.byte())
 ): Arb<ImmutableByteArraySample> = byteArray.map(::ImmutableByteArraySample)
+
+private data class ComparedImmutableByteArraysSample(
+  val smallerImmutableByteArray: ImmutableByteArraySample,
+  val largerImmutableByteArray: ImmutableByteArraySample,
+)
+
+private fun comparedImmutableByteArraySameSizeArb(): Arb<ComparedImmutableByteArraysSample> {
+  val byteArb = Arb.byte()
+  val sizeArb = Arb.int(1..10)
+  val byteArrayArb = Arb.byteArray(sizeArb, byteArb)
+
+  return arbitrary {
+    val array1 = byteArrayArb.bind()
+    val array2 = array1.copyOf()
+    val startIndex = Arb.int(array1.indices).bind()
+    val array1ValueAtStartIndex = array1[startIndex]
+    val array2ValueAtStartIndex = byteArb.filterNot { it == array1ValueAtStartIndex }.bind()
+    array2[startIndex] = array2ValueAtStartIndex
+    val candidateIndicesToRandomize = (startIndex + 1 until array2.size).toList()
+    val indicesToRandomize = Arb.subsequence(Arb.shuffle(candidateIndicesToRandomize).bind()).bind()
+    indicesToRandomize.forEach { array2[it] = byteArb.bind() }
+
+    val smallerArray: ByteArray
+    val largerArray: ByteArray
+    if (array1ValueAtStartIndex < array2ValueAtStartIndex) {
+      smallerArray = array1
+      largerArray = array2
+    } else if (array1ValueAtStartIndex > array2ValueAtStartIndex) {
+      smallerArray = array2
+      largerArray = array1
+    } else {
+      error(
+        "internal error ckf3s8mwkv: array1ValueAtStartIndex==array2ValueAtStartIndex: " +
+          "$array2ValueAtStartIndex"
+      )
+    }
+
+    ComparedImmutableByteArraysSample(
+      smallerImmutableByteArray = ImmutableByteArraySample(smallerArray),
+      largerImmutableByteArray = ImmutableByteArraySample(largerArray),
+    )
+  }
+}
+
+private fun comparedImmutableByteArrayDifferentSizeArb(): Arb<ComparedImmutableByteArraysSample> {
+  val arb = comparedImmutableByteArraySameSizeArb()
+  val boolean = Arb.boolean()
+  val moreBytes = Arb.byteArray(Arb.int(1..10), Arb.byte())
+
+  return Arb.bind(arb, boolean, moreBytes) { sample, boolean, moreBytes ->
+    val smaller: ImmutableByteArraySample
+    val larger: ImmutableByteArraySample
+
+    if (boolean) {
+      smaller = sample.smallerImmutableByteArray
+      larger = ImmutableByteArraySample(sample.largerImmutableByteArray.byteArray.plus(moreBytes))
+    } else {
+      smaller = ImmutableByteArraySample(sample.smallerImmutableByteArray.byteArray.plus(moreBytes))
+      larger = sample.largerImmutableByteArray
+    }
+
+    ComparedImmutableByteArraysSample(
+      smallerImmutableByteArray = smaller,
+      largerImmutableByteArray = larger,
+    )
+  }
+}
+
+private fun comparedImmutableByteArrayPrefixArb(): Arb<ComparedImmutableByteArraysSample> {
+  val byteArb = Arb.byte()
+  val sizeArb = Arb.int(1..10)
+  val byteArrayArb = Arb.byteArray(sizeArb, byteArb)
+
+  return arbitrary {
+    val array1 = byteArrayArb.bind()
+    val array2Size = Arb.int(array1.indices).bind()
+    val array2 = array1.copyOfRange(0, array2Size)
+    ComparedImmutableByteArraysSample(
+      smallerImmutableByteArray = ImmutableByteArraySample(array2),
+      largerImmutableByteArray = ImmutableByteArraySample(array1),
+    )
+  }
+}

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/CartesianProduct.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/CartesianProduct.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.firebase.dataconnect.testutil
+
+fun <T1, T2> cartesianProduct(
+  iterable1: Iterable<T1>,
+  iterable2: Iterable<T2>
+): List<Pair<T1, T2>> = iterable1.flatMap { o1 -> iterable2.map { o2 -> o1 to o2 } }

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/TestValueGenerator.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/TestValueGenerator.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.dataconnect.testutil.property.arbitrary
+
+import com.google.firebase.dataconnect.testutil.RandomSeedTestRule
+import io.kotest.common.DelicateKotest
+import io.kotest.property.Arb
+import io.kotest.property.RandomSource
+import io.kotest.property.arbitrary.distinct
+import kotlin.random.Random
+import kotlin.random.nextInt
+
+/** Convenience class to generate values from [Arb] objects outside property-based tests. */
+class TestValueGenerator(val seed: Long, val edgeCaseProbability: Double) {
+
+  constructor(
+    random: Random,
+    edgeCaseProbability: Double
+  ) : this(random.nextLong(), edgeCaseProbability)
+
+  constructor(rs: RandomSource, edgeCaseProbability: Double) : this(rs.random, edgeCaseProbability)
+
+  constructor(
+    randomSeedTestRule: RandomSeedTestRule,
+    edgeCaseProbability: Double
+  ) : this(randomSeedTestRule.rs.value, edgeCaseProbability)
+
+  init {
+    require(edgeCaseProbability in 0.0..1.0) {
+      "invalid edgeCaseProbability: $edgeCaseProbability [dskqgdzq3z]"
+    }
+  }
+
+  val rs: RandomSource = RandomSource.seeded(seed)
+  val random: Random
+    get() = rs.random
+
+  fun <T> generateValueFrom(arb: Arb<T>): T {
+    if (random.nextDouble() < edgeCaseProbability) {
+      arb.edgecase(rs)?.let {
+        return it
+      }
+    }
+    return arb.sample(rs).value
+  }
+
+  fun <T> Arb<T>.generateValue(): T = generateValueFrom(this)
+
+  fun <T> generateValuesFrom(arb: Arb<T>, count: Int): List<T> {
+    require(count >= 0) { "invalid count: $count [s9hk6kf92r]" }
+    return List(count) { generateValueFrom(arb) }
+  }
+
+  fun <T> Arb<T>.generateValues(count: Int): List<T> = generateValuesFrom(this, count)
+
+  fun <T> generateValuesFrom(arb: Arb<T>, count: IntRange): List<T> {
+    require(count.first >= 0) { "invalid count: $count [hb792ys4tw]" }
+    require(!count.isEmpty()) { "invalid count: $count; range must not be empty [j5cwambyjk]" }
+    return generateValuesFrom(arb, random.nextInt(count))
+  }
+
+  fun <T> Arb<T>.generateValues(count: IntRange): List<T> = generateValuesFrom(this, count)
+
+  fun <T> generateDistinctValuesFrom(arb: Arb<T>, count: Int): List<T> {
+    @OptIn(DelicateKotest::class) val distinctArb = arb.distinct()
+    return generateValuesFrom(distinctArb, count)
+  }
+
+  fun <T> Arb<T>.generateDistinctValues(count: Int): List<T> =
+    generateDistinctValuesFrom(this, count)
+
+  fun <T> generateDistinctValuesFrom(arb: Arb<T>, count: IntRange): List<T> {
+    require(count.first >= 0) { "invalid count: $count [haxdhjr3da]" }
+    require(!count.isEmpty()) { "invalid count: $count; range must not be empty [txr58kan9c]" }
+    return generateDistinctValuesFrom(arb, random.nextInt(count))
+  }
+
+  fun <T> Arb<T>.generateDistinctValues(count: IntRange): List<T> =
+    generateDistinctValuesFrom(this, count)
+
+  fun <T> shuffled(iterable: Iterable<T>): List<T> = iterable.shuffled(random)
+
+  @JvmName("Iterable_shuffled_ext") fun <T> Iterable<T>.shuffled(): List<T> = shuffled(random)
+
+  fun <T> randomValuesFrom(values: List<T>, count: Int): List<T> {
+    require(count >= 0) { "invalid count: $count [zr9nrzn7nq]" }
+    require(count == 0 || values.isNotEmpty()) {
+      "values is empty, but count is greater than zero ($count) [jxd2ar7van]"
+    }
+    return List(count) { values.random(random) }
+  }
+
+  fun <T> List<T>.randomValues(count: Int): List<T> = randomValuesFrom(this, count)
+
+  fun <T> randomValuesFrom(values: List<T>, count: IntRange = 0..values.size): List<T> {
+    require(count.first >= 0) { "invalid count: $count; count.first < 0 [sxxwjdz3q9]" }
+    require(!count.isEmpty()) { "invalid count: $count; range must not be empty [f5pd45hgtv]" }
+    return randomValuesFrom(values, random.nextInt(count))
+  }
+
+  fun <T> List<T>.randomValues(count: IntRange = 0..size): List<T> = randomValuesFrom(this, count)
+
+  fun <T> randomDistinctValuesFrom(values: List<T>, count: Int): List<T> {
+    require(count >= 0) { "invalid count: $count [dj326qtqc8]" }
+    require(count <= values.size) {
+      "invalid count: $count; must be less than or equal to values.size, ${values.size} [mqyn2sggwk]"
+    }
+    return values.shuffled().take(count)
+  }
+
+  fun <T> List<T>.randomDistinctValues(count: Int): List<T> = randomDistinctValuesFrom(this, count)
+
+  fun <T> randomDistinctValuesFrom(values: List<T>, count: IntRange = 0..values.size): List<T> {
+    require(count.first >= 0) { "invalid count: $count; count.first < 0 [mxjs3dvywm]" }
+    require(!count.isEmpty()) { "invalid count: $count; range must not be empty [v2dyhdchqp]" }
+    require(count.last <= values.size) {
+      "invalid count: $count; count.last (${count.last}) must be less than or equal to " +
+        "values.size (${values.size}) [cka7mepcxm]"
+    }
+    return randomDistinctValuesFrom(values, random.nextInt(count))
+  }
+
+  fun <T> List<T>.randomDistinctValues(count: IntRange = 0..size): List<T> =
+    randomDistinctValuesFrom(this, count)
+}


### PR DESCRIPTION
This pull request introduces a new `last_update_sequence_number` column to the Data Connect SQLite cache database for queries and entities. This sequence number tracks the order of cache updates and will be used by subsequent work to avoid publishing duplicate query results from cache in realtime query subscriptions.

### Highlights

* **Monotonic Sequence Tracking**: Configured `DataConnectCacheDatabase` to generate monotonically increasing sequence numbers using a sequence helper table, assign them to queries and entities during update transactions, and report the maximum sequence number across a query and all of its referenced entities upon retrieval.
* **Incremental Database Schema Migrator**: Upgraded the cache database schema to version `1.1.0` and structured the schema migrator to perform incremental multi-step migrations, starting with database creation at `1.0.0` and applying the migration to `1.1.0` which adds the `last_update_sequence_number` columns.
* **Lexicographical Byte Array Ordering**: Conformed `ImmutableByteArray` to the `Comparable` interface, supported by a backport of signed lexicographical byte array comparison (`contentCompareTo`) to ensure compatibility with Android versions below API level 33.
* **Comprehensive Integration and Unit Tests**: Added regression tests for database migration and verification of database state, along with thorough testing of correct sequence number calculation and stable byte array sorting.

<details>
<summary><b>Changelog</b></summary>

* **DataConnectCacheDatabase.kt**
  * Added `last_update_sequence_number` tracking logic, including the `SqliteSequenceNumber` inline value class, sequence number generation helper, and maximum last update sequence number computation during query rehydration.
* **DataConnectCacheDatabaseMigrator.kt**
  * Upgraded the database schema version to `1.1.0`, introduced an incremental migration runner loop, and implemented step migration from `1.0.0` to `1.1.0` to alter `queries` and `entities` tables.
* **ByteArrayUtils.kt**
  * Created a utility file that backports signed lexicographical byte array comparison (`contentCompareTo`) for Android devices running on API levels below 33.
* **ImmutableByteArray.kt**
  * Conformed `ImmutableByteArray` to the `Comparable<ImmutableByteArray>` interface, utilizing the new `contentCompareTo` logic to achieve a stable cross-process sort order.
* **DataConnectCacheDatabaseMigratorUnitTest.kt**
  * Added integration tests verifying that existing data is preserved during progressive `1.0.0` to `1.1.0` migrations, and that proper exceptions are thrown when the database version or application ID is unrecognized.
* **DataConnectCacheDatabaseUnitTest.kt**
  * Added unit tests verifying proper sequence number updates during query insertion and verifying sequence number retrieval logic, including edge cases with null database values.
* **ImmutableByteArrayUnitTest.kt**
  * Added property and unit tests for the newly introduced comparison behaviors of `ImmutableByteArray`, covering identical arrays, prefixes, and different array lengths.
* **CartesianProduct.kt**
  * Added a utility function to compute the cartesian product of two iterables to support unit testing.
* **TestValueGenerator.kt**
  * Added a utility class to facilitate deterministic test sample generation from Kotest arbitrary data generators (`Arb`) outside of standard property-based tests.

</details>