### PR TITLE
[AppCheck] Revert changed key in ExchangeRecaptchaTokenRequest

### DIFF
--- a/appcheck/firebase-appcheck-recaptcha/src/main/java/com/google/firebase/appcheck/recaptcha/internal/ExchangeRecaptchaTokenRequest.java
+++ b/appcheck/firebase-appcheck-recaptcha/src/main/java/com/google/firebase/appcheck/recaptcha/internal/ExchangeRecaptchaTokenRequest.java
@@ -25,7 +25,7 @@ import org.json.JSONObject;
  */
 public class ExchangeRecaptchaTokenRequest {
 
-  @VisibleForTesting static final String RECAPTCHA_TOKEN_KEY = "recaptchaToken";
+  @VisibleForTesting static final String RECAPTCHA_TOKEN_KEY = "recaptchaEnterpriseToken";
 
   @VisibleForTesting static final String LIMITED_USE_TOKEN_KEY = "limited_use";
 


### PR DESCRIPTION
Renamed back the RECAPTCHA_TOKEN_KEY constant to `recaptchaEnterpriseToken` in the `ExchangeRecaptchaTokenRequest`. The backend expects the value as is.

Verified with manual testing