### PR TITLE
Bump firebase-appdistribution-gradle minor version

### DIFF
--- a/firebase-appdistribution-gradle/gradle.properties
+++ b/firebase-appdistribution-gradle/gradle.properties
@@ -1,3 +1,3 @@
 groupId=com.google.firebase
 artifactId=firebase-appdistribution-gradle
-version=5.2.2
+version=5.3.0


### PR DESCRIPTION
According to [the docs](https://firebase.google.com/policies/changes-to-firebase/versioning-and-maintenance#versioning-system-sdks-and-versioned-tooling), backwards-compatible new features should be represented by a minor version bump. 

I think it's fair to say that #8218 introduced new features with WIF and ADC support.