### PR TITLE
Crashlytics: report previous-run ANRs in didCrashOnPreviousExecution()

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -5,6 +5,9 @@
 - [fixed] Fixed race condition that caused logs from background threads to not be attached to
   reports in some cases [#8034]
 - [changed] Updated `firebase-sessions` dependency to v3.0.6
+- [changed] `didCrashOnPreviousExecution()` now also returns `true` when the previous run ended
+  with an ANR (Application Not Responding), in addition to JVM and native crashes. ANR detection
+  requires API level 30 (Android R) or above. [#4201]
 
 # 20.0.5
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreInitializationTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreInitializationTest.java
@@ -302,6 +302,18 @@ public class CrashlyticsCoreInitializationTest extends CrashlyticsTestCase {
     assertFalse(getCrashMarkerFile().exists());
   }
 
+  @Test
+  public void testOnPreExecute_didNotANROnPreviousExecution() {
+    // Without any ApplicationExitInfo entries indicating an ANR, didCrashOnPreviousExecution
+    // should return false.
+    final CrashlyticsCore crashlyticsCore = builder().build();
+    setupBuildIdRequired(String.valueOf(false));
+    setupAppData(BUILD_ID);
+
+    assertTrue(crashlyticsCore.onPreExecute(appData, mockSettingsController));
+    assertFalse(crashlyticsCore.didCrashOnPreviousExecution());
+  }
+
   private void setupLegacyBuildIdRequired(String booleanValue) {
     setupResource(
         RES_ID_LEGACY_REQUIRE_BUILD_ID,

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -454,9 +454,11 @@ public class FirebaseCrashlytics {
   // endregion
 
   /**
-   * Checks whether the app crashed on its previous run.
+   * Checks whether the app crashed on its previous run. Returns {@code true} for JVM crashes,
+   * native crashes, and ANRs (Application Not Responding). ANR detection requires Android API 30
+   * (R) or above.
    *
-   * @return true if a crash was recorded during the previous run of the app.
+   * @return true if a crash or ANR was recorded during the previous run of the app.
    */
   public boolean didCrashOnPreviousExecution() {
     return core.didCrashOnPreviousExecution();

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -119,6 +119,10 @@ class CrashlyticsController {
   // A token to make sure that checkForUnsentReports only gets called once.
   final AtomicBoolean checkForUnsentReportsCalled = new AtomicBoolean(false);
 
+  // Set during initialization's session finalization when the previous session ended with an ANR,
+  // so didCrashOnPreviousExecution() reports ANRs alongside JVM and native crashes.
+  private volatile boolean didPreviousExecutionEndWithAnr = false;
+
   CrashlyticsController(
       Context context,
       IdManager idManager,
@@ -930,6 +934,11 @@ class CrashlyticsController {
       // Passes the latest applicationExitInfo to ReportCoordinator, which persists it if it
       // happened during the session.
       if (applicationExitInfoList.size() != 0) {
+        // Record whether the previous session ended with an ANR so didCrashOnPreviousExecution()
+        // can report it, without re-querying the system or blocking the main thread.
+        if (reportingCoordinator.didRelevantAnrOccur(sessionId, applicationExitInfoList)) {
+          didPreviousExecutionEndWithAnr = true;
+        }
         final LogFileManager relevantSessionLogManager = new LogFileManager(fileStore, sessionId);
         final UserMetadata relevantUserMetadata =
             UserMetadata.loadFromExistingSession(sessionId, fileStore, crashlyticsWorkers);
@@ -943,5 +952,11 @@ class CrashlyticsController {
           .v("ANR feature enabled, but device is API " + android.os.Build.VERSION.SDK_INT);
     }
   }
+
+  /** Whether the previous execution ended with an ANR, detected during session finalization. */
+  boolean didPreviousExecutionEndWithAnr() {
+    return didPreviousExecutionEndWithAnr;
+  }
+
   // endregion
 }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -119,10 +119,6 @@ class CrashlyticsController {
   // A token to make sure that checkForUnsentReports only gets called once.
   final AtomicBoolean checkForUnsentReportsCalled = new AtomicBoolean(false);
 
-  // Set during initialization's session finalization when the previous session ended with an ANR,
-  // so didCrashOnPreviousExecution() reports ANRs alongside JVM and native crashes.
-  private volatile boolean didPreviousExecutionEndWithAnr = false;
-
   CrashlyticsController(
       Context context,
       IdManager idManager,
@@ -322,7 +318,8 @@ class CrashlyticsController {
       // Before the first session of this execution is opened, the current session ID still refers
       // to the previous execution's last session, which is what we want.
       final String sessionId = getCurrentSessionId();
-      return sessionId != null && nativeComponent.hasCrashDataForSession(sessionId);
+      return sessionId != null
+          && (nativeComponent.hasCrashDataForSession(sessionId) || hasAnrForSession(sessionId));
     }
 
     Logger.getLogger().v("Found previous crash marker.");
@@ -934,11 +931,6 @@ class CrashlyticsController {
       // Passes the latest applicationExitInfo to ReportCoordinator, which persists it if it
       // happened during the session.
       if (applicationExitInfoList.size() != 0) {
-        // Record whether the previous session ended with an ANR so didCrashOnPreviousExecution()
-        // can report it, without re-querying the system or blocking the main thread.
-        if (reportingCoordinator.didRelevantAnrOccur(sessionId, applicationExitInfoList)) {
-          didPreviousExecutionEndWithAnr = true;
-        }
         final LogFileManager relevantSessionLogManager = new LogFileManager(fileStore, sessionId);
         final UserMetadata relevantUserMetadata =
             UserMetadata.loadFromExistingSession(sessionId, fileStore, crashlyticsWorkers);
@@ -953,9 +945,15 @@ class CrashlyticsController {
     }
   }
 
-  /** Whether the previous execution ended with an ANR, detected during session finalization. */
-  boolean didPreviousExecutionEndWithAnr() {
-    return didPreviousExecutionEndWithAnr;
+  private boolean hasAnrForSession(String sessionId) {
+    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      ActivityManager activityManager =
+          (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+      List<ApplicationExitInfo> applicationExitInfoList =
+          activityManager.getHistoricalProcessExitReasons(null, 0, 0);
+      return reportingCoordinator.didRelevantAnrOccur(sessionId, applicationExitInfoList);
+    }
+    return false;
   }
 
   // endregion

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -507,7 +507,8 @@ public class CrashlyticsCore {
   }
 
   public boolean didCrashOnPreviousExecution() {
-    return didCrashOnPreviousExecution;
+    return didCrashOnPreviousExecution
+        || (controller != null && controller.didPreviousExecutionEndWithAnr());
   }
 
   // endregion

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -507,8 +507,7 @@ public class CrashlyticsCore {
   }
 
   public boolean didCrashOnPreviousExecution() {
-    return didCrashOnPreviousExecution
-        || (controller != null && controller.didPreviousExecutionEndWithAnr());
+    return didCrashOnPreviousExecution;
   }
 
   // endregion

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
@@ -439,6 +439,13 @@ public class SessionReportingCoordinator {
     }
   }
 
+  /** Returns true if an ANR ApplicationExitInfo occurred during the given session. */
+  @RequiresApi(api = Build.VERSION_CODES.R)
+  public boolean didRelevantAnrOccur(
+      String sessionId, List<ApplicationExitInfo> applicationExitInfoList) {
+    return findRelevantApplicationExitInfo(sessionId, applicationExitInfoList) != null;
+  }
+
   /** Finds the first ANR ApplicationExitInfo within the session. */
   @RequiresApi(api = Build.VERSION_CODES.R)
   private @Nullable ApplicationExitInfo findRelevantApplicationExitInfo(

--- a/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerRobolectricTest.java
+++ b/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerRobolectricTest.java
@@ -15,6 +15,8 @@
 package com.google.firebase.crashlytics.internal.common;
 
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -131,6 +133,47 @@ public class CrashlyticsControllerRobolectricTest {
             eq(testApplicationExitInfo),
             any(LogFileManager.class),
             any(UserMetadata.class));
+  }
+
+  @Test
+  public void testFinalizeSessions_relevantAnr_setsDidPreviousExecutionEndWithAnr()
+      throws Exception {
+    final String sessionIdPrevious = "sessionIdPrevious";
+    final String sessionId = "sessionId";
+    final CrashlyticsController controller = createController();
+    addAppExitInfo(ApplicationExitInfo.REASON_ANR);
+    List<ApplicationExitInfo> testApplicationExitInfo = getApplicationExitInfoList();
+
+    when(mockSessionReportingCoordinator.listSortedOpenSessionIds())
+        .thenReturn(new TreeSet<>(Arrays.asList(sessionId, sessionIdPrevious)));
+    when(mockSessionReportingCoordinator.didRelevantAnrOccur(
+            eq(sessionIdPrevious), eq(testApplicationExitInfo)))
+        .thenReturn(true);
+    mockSettingsProvider(true, false);
+    crashlyticsWorkers.common.submit(() -> controller.finalizeSessions(mockSettingsProvider));
+    // cannot use await since it check preconditions if blocking main thread
+    Thread.sleep(100);
+
+    assertTrue(controller.didPreviousExecutionEndWithAnr());
+  }
+
+  @Test
+  public void testFinalizeSessions_noRelevantAnr_leavesDidPreviousExecutionEndWithAnrFalse()
+      throws Exception {
+    final String sessionIdPrevious = "sessionIdPrevious";
+    final String sessionId = "sessionId";
+    final CrashlyticsController controller = createController();
+    addAppExitInfo(ApplicationExitInfo.REASON_EXIT_SELF);
+
+    when(mockSessionReportingCoordinator.listSortedOpenSessionIds())
+        .thenReturn(new TreeSet<>(Arrays.asList(sessionId, sessionIdPrevious)));
+    // didRelevantAnrOccur returns false by default for the mock.
+    mockSettingsProvider(true, false);
+    crashlyticsWorkers.common.submit(() -> controller.finalizeSessions(mockSettingsProvider));
+    // cannot use await since it check preconditions if blocking main thread
+    Thread.sleep(100);
+
+    assertFalse(controller.didPreviousExecutionEndWithAnr());
   }
 
   @Test

--- a/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerRobolectricTest.java
+++ b/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerRobolectricTest.java
@@ -49,6 +49,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -136,44 +137,42 @@ public class CrashlyticsControllerRobolectricTest {
   }
 
   @Test
-  public void testFinalizeSessions_relevantAnr_setsDidPreviousExecutionEndWithAnr()
-      throws Exception {
-    final String sessionIdPrevious = "sessionIdPrevious";
-    final String sessionId = "sessionId";
+  public void testDidCrashOnPreviousExecution_relevantAnr_returnsTrue() throws Exception {
+    final String previousSessionId = "previousSessionId";
     final CrashlyticsController controller = createController();
     addAppExitInfo(ApplicationExitInfo.REASON_ANR);
-    List<ApplicationExitInfo> testApplicationExitInfo = getApplicationExitInfoList();
 
     when(mockSessionReportingCoordinator.listSortedOpenSessionIds())
-        .thenReturn(new TreeSet<>(Arrays.asList(sessionId, sessionIdPrevious)));
-    when(mockSessionReportingCoordinator.didRelevantAnrOccur(
-            eq(sessionIdPrevious), eq(testApplicationExitInfo)))
+        .thenReturn(new TreeSet<>(Collections.singletonList(previousSessionId)));
+    when(mockSessionReportingCoordinator.didRelevantAnrOccur(eq(previousSessionId), any()))
         .thenReturn(true);
-    mockSettingsProvider(true, false);
-    crashlyticsWorkers.common.submit(() -> controller.finalizeSessions(mockSettingsProvider));
+
+    AtomicBoolean didCrashOnPrevious = new AtomicBoolean(false);
+    crashlyticsWorkers.common.submit(
+        () -> didCrashOnPrevious.set(controller.didCrashOnPreviousExecution()));
     // cannot use await since it check preconditions if blocking main thread
     Thread.sleep(100);
 
-    assertTrue(controller.didPreviousExecutionEndWithAnr());
+    assertTrue(didCrashOnPrevious.get());
   }
 
   @Test
-  public void testFinalizeSessions_noRelevantAnr_leavesDidPreviousExecutionEndWithAnrFalse()
-      throws Exception {
-    final String sessionIdPrevious = "sessionIdPrevious";
-    final String sessionId = "sessionId";
+  public void testDidCrashOnPreviousExecution_noRelevantAnr_returnsFalse() throws Exception {
+    final String previousSessionId = "previousSessionId";
     final CrashlyticsController controller = createController();
     addAppExitInfo(ApplicationExitInfo.REASON_EXIT_SELF);
 
     when(mockSessionReportingCoordinator.listSortedOpenSessionIds())
-        .thenReturn(new TreeSet<>(Arrays.asList(sessionId, sessionIdPrevious)));
+        .thenReturn(new TreeSet<>(Collections.singletonList(previousSessionId)));
     // didRelevantAnrOccur returns false by default for the mock.
-    mockSettingsProvider(true, false);
-    crashlyticsWorkers.common.submit(() -> controller.finalizeSessions(mockSettingsProvider));
+
+    AtomicBoolean didCrashOnPrevious = new AtomicBoolean(false);
+    crashlyticsWorkers.common.submit(
+        () -> didCrashOnPrevious.set(controller.didCrashOnPreviousExecution()));
     // cannot use await since it check preconditions if blocking main thread
     Thread.sleep(100);
 
-    assertFalse(controller.didPreviousExecutionEndWithAnr());
+    assertFalse(didCrashOnPrevious.get());
   }
 
   @Test

--- a/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinatorRobolectricTest.java
+++ b/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinatorRobolectricTest.java
@@ -165,6 +165,55 @@ public class SessionReportingCoordinatorRobolectricTest {
   }
 
   @Test
+  @SdkSuppress(minSdkVersion = VERSION_CODES.R)
+  public void testDidRelevantAnrOccur_returnsTrueForAnrWithinSession() {
+    final long sessionStartTimestamp = 0;
+    final String sessionId = "testSessionId";
+    when(reportPersistence.getStartTimestampMillis(sessionId)).thenReturn(sessionStartTimestamp);
+
+    addAppExitInfo(ApplicationExitInfo.REASON_ANR);
+    List<ApplicationExitInfo> testApplicationExitInfoList = getAppExitInfoList();
+
+    assertTrue(reportingCoordinator.didRelevantAnrOccur(sessionId, testApplicationExitInfoList));
+  }
+
+  @Test
+  @SdkSuppress(minSdkVersion = VERSION_CODES.R)
+  public void testDidRelevantAnrOccur_returnsFalseForAnrBeforeSession() {
+    // ANR timestamp is 0; session starts at 10, so ANR was before the session.
+    final long sessionStartTimestamp = 10;
+    final String sessionId = "testSessionId";
+    when(reportPersistence.getStartTimestampMillis(sessionId)).thenReturn(sessionStartTimestamp);
+
+    addAppExitInfo(ApplicationExitInfo.REASON_ANR);
+    List<ApplicationExitInfo> testApplicationExitInfoList = getAppExitInfoList();
+
+    assertFalse(reportingCoordinator.didRelevantAnrOccur(sessionId, testApplicationExitInfoList));
+  }
+
+  @Test
+  @SdkSuppress(minSdkVersion = VERSION_CODES.R)
+  public void testDidRelevantAnrOccur_returnsFalseForNonAnrWithinSession() {
+    final long sessionStartTimestamp = 0;
+    final String sessionId = "testSessionId";
+    when(reportPersistence.getStartTimestampMillis(sessionId)).thenReturn(sessionStartTimestamp);
+
+    addAppExitInfo(ApplicationExitInfo.REASON_EXIT_SELF);
+    List<ApplicationExitInfo> testApplicationExitInfoList = getAppExitInfoList();
+
+    assertFalse(reportingCoordinator.didRelevantAnrOccur(sessionId, testApplicationExitInfoList));
+  }
+
+  @Test
+  @SdkSuppress(minSdkVersion = VERSION_CODES.R)
+  public void testDidRelevantAnrOccur_returnsFalseForEmptyList() {
+    final String sessionId = "testSessionId";
+    when(reportPersistence.getStartTimestampMillis(sessionId)).thenReturn(0L);
+
+    assertFalse(reportingCoordinator.didRelevantAnrOccur(sessionId, List.of()));
+  }
+
+  @Test
   public void testconvertInputStreamToString_worksSuccessfully() throws IOException {
     String stackTrace = "-----stacktrace---------";
     InputStream inputStream = new ByteArrayInputStream(stackTrace.getBytes());


### PR DESCRIPTION
# Report previous-run ANRs in didCrashOnPreviousExecution()

Implements [#4201](https://github.com/firebase/firebase-android-sdk/issues/4201).

`FirebaseCrashlytics.didCrashOnPreviousExecution()` now returns `true` when the previous run ended with an ANR, in addition to JVM and native crashes. ANR detection requires API 30+ (`ApplicationExitInfo`); on older devices the ANR contribution is always `false`. No new public API.

## How

On the next launch, Crashlytics already runs `finalizeSessions()` → `writeApplicationExitInfoEventIfRelevant()` on a background worker to attach any ANR from the previous session. This records that result in a `didPreviousExecutionEndWithAnr` flag (via the new `SessionReportingCoordinator.didRelevantAnrOccur(...)`) and ORs it into `didCrashOnPreviousExecution()` — no main-thread blocking and no extra system query.

## Tests

- Unit (Robolectric): `didRelevantAnrOccur` across four branches; `finalizeSessions` sets / leaves the flag; no-ANR `onPreExecute` → `didCrashOnPreviousExecution()` is `false`.

- Verified on a physical device (Galaxy S25 Ultra, API 36): clean launch → `false`; after a real ANR (OS records `reason=6 (ANR)`), relaunch → `true`. Reproducible end-to-end with the sample app at [jrodiz/repro4201](https://github.com/jrodiz/repro4201) (tap-to-ANR, then relaunch).
