### PR TITLE
[AI] Return `retrievalConfig` entry to the right changelog section

### DIFF
--- a/ai-logic/firebase-ai/CHANGELOG.md
+++ b/ai-logic/firebase-ai/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Unreleased
 
 - [feature] Added [firebase_app_check] as a dependency of the SDK (#8225)
-- [feature] Added the `retrievalConfig` argument to `TemplateToolConfig` (#8107)
 
 # 17.12.1
 
+- [feature] Added the `retrievalConfig` argument to `TemplateToolConfig` (#8107)
 - [fixed] Fixed citation indices to be native UTF-16 instead of UTF-8. (#8056)
 
 # 17.12.0

--- a/ai-logic/firebase-ai/CHANGELOG.md
+++ b/ai-logic/firebase-ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 # 17.12.1
 
-- [feature] Added the `retrievalConfig` argument to `TemplateToolConfig` (#8107)
+- [feature] Added the `retrievalConfig` argument to `TemplateToolConfig` (#8188)
 - [fixed] Fixed citation indices to be native UTF-16 instead of UTF-8. (#8056)
 
 # 17.12.0


### PR DESCRIPTION
It was moved to the `Unreleased` section in #8225 due to a misunderstanding.