### PR TITLE
Use `TestParameterInjector` to test various version combinations

### DIFF
--- a/firebase-appdistribution-gradle/firebase-appdistribution-gradle.gradle
+++ b/firebase-appdistribution-gradle/firebase-appdistribution-gradle.gradle
@@ -251,6 +251,7 @@ dependencies {
   integrationTestImplementation(gradleTestKit())
   integrationTestImplementation("com.android.tools.build:gradle:7.2.0")
   integrationTestImplementation(libs.junit)
+  integrationTestImplementation("com.google.testparameterinjector:test-parameter-injector:1.22")
   integrationTestImplementation("com.github.tomakehurst:wiremock:2.26.3")
   integrationTestImplementation("com.google.code.gson:gson:2.10.1")
   integrationTestImplementation("org.jetbrains.kotlin:kotlin-test")

--- a/firebase-appdistribution-gradle/src/integrationTest/java/com/google/firebase/appdistribution/gradle/TestGroovyBuild.kt
+++ b/firebase-appdistribution-gradle/src/integrationTest/java/com/google/firebase/appdistribution/gradle/TestGroovyBuild.kt
@@ -158,12 +158,6 @@ class TestGroovyBuild(private val testGradleProject: TestGradleProject) {
     const val OLDER_AGP_VERSION = "7.0.0" // released in July 2021
     const val OLDER_GOOGLE_SERVICES_VERSION = "4.3.2" // released in September 2019
 
-    // Latest supported versions
-    const val LATEST_COMPILE_SDK_VERSION = "30" // required for Gradle 9
-    val LATEST_GRADLE_VERSION = VersionUtils.fetchLatestGradleVersion()
-    val LATEST_AGP_VERSION = VersionUtils.fetchLatestAgpVersion()
-    val LATEST_GOOGLE_SERVICES_VERSION = VersionUtils.fetchLatestGoogleServicesVersion()
-
     private const val DEFAULT_CUSTOM_ANDROID_BLOCK = ""
   }
 }

--- a/firebase-appdistribution-gradle/src/integrationTest/java/com/google/firebase/appdistribution/gradle/UploadDistributionTaskTest.kt
+++ b/firebase-appdistribution-gradle/src/integrationTest/java/com/google/firebase/appdistribution/gradle/UploadDistributionTaskTest.kt
@@ -28,7 +28,6 @@ import com.google.firebase.appdistribution.gradle.VersionUtils.Stability.STABLE
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.google.testing.junit.testparameterinjector.TestParameterValuesProvider
-import kotlin.jvm.java
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome.FAILED
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -432,7 +431,7 @@ class UploadDistributionTaskTest {
 
   @Test
   fun testGoogleServices440AppIdParsing_forAgp730() {
-    testAabPathParsing_withAab(
+    testGoogleServicesAppIdParsing(
       Versions(
         gradle = "7.4",
         agp = "7.3.0", // Note: this fails with AGP 7.4.0

--- a/firebase-appdistribution-gradle/src/integrationTest/java/com/google/firebase/appdistribution/gradle/UploadDistributionTaskTest.kt
+++ b/firebase-appdistribution-gradle/src/integrationTest/java/com/google/firebase/appdistribution/gradle/UploadDistributionTaskTest.kt
@@ -18,13 +18,17 @@ package com.google.firebase.appdistribution.gradle
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule
 import com.google.firebase.appdistribution.gradle.ApiStubs.Companion.WIRE_MOCK_PORT
-import com.google.firebase.appdistribution.gradle.TestGroovyBuild.Companion.LATEST_AGP_VERSION
-import com.google.firebase.appdistribution.gradle.TestGroovyBuild.Companion.LATEST_COMPILE_SDK_VERSION
-import com.google.firebase.appdistribution.gradle.TestGroovyBuild.Companion.LATEST_GOOGLE_SERVICES_VERSION
-import com.google.firebase.appdistribution.gradle.TestGroovyBuild.Companion.LATEST_GRADLE_VERSION
 import com.google.firebase.appdistribution.gradle.TestGroovyBuild.Companion.OLDER_AGP_VERSION
+import com.google.firebase.appdistribution.gradle.TestGroovyBuild.Companion.OLDER_COMPILE_SDK_VERSION
 import com.google.firebase.appdistribution.gradle.TestGroovyBuild.Companion.OLDER_GOOGLE_SERVICES_VERSION
 import com.google.firebase.appdistribution.gradle.TestGroovyBuild.Companion.OLDER_GRADLE_VERSION
+import com.google.firebase.appdistribution.gradle.VersionUtils.Stability.BLEEDING_EDGE
+import com.google.firebase.appdistribution.gradle.VersionUtils.Stability.RC
+import com.google.firebase.appdistribution.gradle.VersionUtils.Stability.STABLE
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.google.testing.junit.testparameterinjector.TestParameterValuesProvider
+import kotlin.jvm.java
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome.FAILED
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -35,7 +39,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(TestParameterInjector::class)
 class UploadDistributionTaskTest {
   @get:Rule val wireMockRule = WireMockRule(WIRE_MOCK_PORT)
 
@@ -43,81 +49,92 @@ class UploadDistributionTaskTest {
   val testGroovyBuild = TestGroovyBuild(testGradleProject)
   private val apiStubs = ApiStubs(testGradleProject)
 
+  data class Versions(
+    val gradle: String,
+    val agp: String,
+    val compileSdk: String,
+    val googleServices: String,
+    val useConfigurationCache: Boolean,
+  ) {
+    fun additionalGradleArguments(): List<String> =
+      if (useConfigurationCache) listOf("--configuration-cache") else listOf()
+  }
+
+  class VersionsProvider : TestParameterValuesProvider() {
+    override fun provideValues(context: Context): List<Versions> {
+      return listOf(
+        Versions( // oldest supported versions (without configuration cache)
+          OLDER_GRADLE_VERSION,
+          OLDER_AGP_VERSION,
+          OLDER_COMPILE_SDK_VERSION,
+          OLDER_GOOGLE_SERVICES_VERSION,
+          useConfigurationCache = false
+        ),
+        Versions( // latest stable versions (without configuration cache)
+          LATEST_STABLE_GRADLE_VERSION,
+          LATEST_STABLE_AGP_VERSION,
+          COMPILE_SDK_VERSION_FOR_GRADLE9,
+          LATEST_STABLE_GOOGLE_SERVICES_VERSION,
+          useConfigurationCache = false
+        ),
+        Versions( // latest stable versions
+          LATEST_STABLE_GRADLE_VERSION,
+          LATEST_STABLE_AGP_VERSION,
+          COMPILE_SDK_VERSION_FOR_GRADLE9,
+          LATEST_STABLE_GOOGLE_SERVICES_VERSION,
+          useConfigurationCache = true
+        ),
+        Versions( // AGP RC with latest stable version of gradle
+          LATEST_STABLE_GRADLE_VERSION,
+          LATEST_AGP_RC_VERSION,
+          COMPILE_SDK_VERSION_FOR_GRADLE9,
+          LATEST_STABLE_GOOGLE_SERVICES_VERSION,
+          useConfigurationCache = true
+        ),
+        Versions( // Gradle RC with latest stable version of AGP
+          LATEST_GRADLE_RC_VERSION,
+          LATEST_STABLE_AGP_VERSION,
+          COMPILE_SDK_VERSION_FOR_GRADLE9,
+          LATEST_STABLE_GOOGLE_SERVICES_VERSION,
+          useConfigurationCache = true
+        ),
+        Versions( // AGP bleeding-edge with Gradle RC
+          LATEST_GRADLE_RC_VERSION,
+          AGP_BLEEDING_EDGE_VERSION,
+          COMPILE_SDK_VERSION_FOR_GRADLE9,
+          LATEST_STABLE_GOOGLE_SERVICES_VERSION,
+          useConfigurationCache = true
+        ),
+      )
+    }
+  }
+
   @Before
   fun setup() {
     System.setProperty("FIREBASE_APP_DISTRIBUTION_API_URL", "http://localhost:${WIRE_MOCK_PORT}")
   }
 
-  // *************************************************************************
-  // Test matrix cases for testing on the latest and older gradle/AGP versions
-  // *************************************************************************
   @Test
-  fun testApkPathParsing_withApk_onOlderAgpAndGradleVersions() {
+  fun testApkPathParsing_withApk(
+    @TestParameter(valuesProvider = VersionsProvider::class) versions: Versions,
+  ) {
     apiStubs.stubUploadDistributionSuccess()
     apiStubs.stubGetUploadStatusSuccess()
     testGroovyBuild.writeBuildFiles(
-      agpVersion = OLDER_AGP_VERSION,
-      googleServicesVersion = OLDER_GOOGLE_SERVICES_VERSION,
-    )
-
-    val result =
-      GradleRunner.create()
-        .withProjectDir(testGradleProject.projectDir.root)
-        .withArguments("assembleDebug", "appDistributionUploadDebug", "--info", "--stacktrace")
-        .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion(OLDER_GRADLE_VERSION)
-        .build()
-
-    assertEquals(SUCCESS, result.task(":app:appDistributionUploadDebug")?.outcome)
-    assertThat(result.output, containsString("Using APK"))
-    assertThat(result.output, containsString("build/outputs/apk/debug/app-debug.apk"))
-  }
-
-  @Test
-  fun testApkPathParsing_withApk_onLatestAgpAndGradleVersions() {
-    apiStubs.stubUploadDistributionSuccess()
-    apiStubs.stubGetUploadStatusSuccess()
-    testGroovyBuild.writeBuildFiles(
-      agpVersion = LATEST_AGP_VERSION,
-      googleServicesVersion = LATEST_GOOGLE_SERVICES_VERSION,
-      compileSdkVersion = LATEST_COMPILE_SDK_VERSION
-    )
-
-    val result =
-      GradleRunner.create()
-        .withProjectDir(testGradleProject.projectDir.root)
-        .withArguments("assembleDebug", "appDistributionUploadDebug", "--info", "--stacktrace")
-        .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion(LATEST_GRADLE_VERSION)
-        .build()
-
-    assertEquals(SUCCESS, result.task(":app:appDistributionUploadDebug")?.outcome)
-    assertThat(result.output, containsString("Using APK"))
-    assertThat(result.output, containsString("build/outputs/apk/debug/app-debug.apk"))
-  }
-
-  @Test
-  fun testApkPathParsing_withApk_withConfigurationCache_onLatestAgpAndGradleVersions() {
-    apiStubs.stubUploadDistributionSuccess()
-    apiStubs.stubGetUploadStatusSuccess()
-    testGroovyBuild.writeBuildFiles(
-      agpVersion = LATEST_AGP_VERSION,
-      googleServicesVersion = LATEST_GOOGLE_SERVICES_VERSION,
-      compileSdkVersion = LATEST_COMPILE_SDK_VERSION
+      agpVersion = versions.agp,
+      compileSdkVersion = versions.compileSdk,
+      googleServicesVersion = versions.googleServices,
     )
 
     val result =
       GradleRunner.create()
         .withProjectDir(testGradleProject.projectDir.root)
         .withArguments(
-          "assembleDebug",
-          "appDistributionUploadDebug",
-          "--configuration-cache",
-          "--info",
-          "--stacktrace"
+          listOf("assembleDebug", "appDistributionUploadDebug", "--info", "--stacktrace") +
+            versions.additionalGradleArguments()
         )
         .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion(LATEST_GRADLE_VERSION)
+        .withGradleVersion(versions.gradle)
         .build()
 
     assertEquals(SUCCESS, result.task(":app:appDistributionUploadDebug")?.outcome)
@@ -126,42 +143,26 @@ class UploadDistributionTaskTest {
   }
 
   @Test
-  fun testApkPathParsing_noApk_onOlderAgpAndGradleVersions() {
+  fun testApkPathParsing_noApk(
+    @TestParameter(valuesProvider = VersionsProvider::class) versions: Versions,
+  ) {
     apiStubs.stubUploadDistributionSuccess()
     apiStubs.stubGetUploadStatusSuccess()
     testGroovyBuild.writeBuildFiles(
-      agpVersion = OLDER_AGP_VERSION,
-      googleServicesVersion = OLDER_GOOGLE_SERVICES_VERSION,
+      agpVersion = versions.agp,
+      compileSdkVersion = versions.compileSdk,
+      googleServicesVersion = versions.googleServices,
     )
 
     val result =
       GradleRunner.create()
         .withProjectDir(testGradleProject.projectDir.root)
-        .withArguments("appDistributionUploadDebug", "--info", "--stacktrace")
+        .withArguments(
+          listOf("appDistributionUploadDebug", "--info", "--stacktrace") +
+            versions.additionalGradleArguments()
+        )
         .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion(OLDER_GRADLE_VERSION)
-        .buildAndFail()
-
-    assertEquals(FAILED, result.task(":app:appDistributionUploadDebug")?.outcome)
-    assertThat(result.output, containsString("Could not find an APK"))
-  }
-
-  @Test
-  fun testApkPathParsing_noApk_onLatestAgpAndGradleVersions() {
-    apiStubs.stubUploadDistributionSuccess()
-    apiStubs.stubGetUploadStatusSuccess()
-    testGroovyBuild.writeBuildFiles(
-      agpVersion = LATEST_AGP_VERSION,
-      googleServicesVersion = LATEST_GOOGLE_SERVICES_VERSION,
-      compileSdkVersion = LATEST_COMPILE_SDK_VERSION
-    )
-
-    val result =
-      GradleRunner.create()
-        .withProjectDir(testGradleProject.projectDir.root)
-        .withArguments("appDistributionUploadDebug", "--info", "--stacktrace")
-        .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion(LATEST_GRADLE_VERSION)
+        .withGradleVersion(versions.gradle)
         .buildAndFail()
 
     assertEquals(FAILED, result.task(":app:appDistributionUploadDebug")?.outcome)
@@ -170,6 +171,7 @@ class UploadDistributionTaskTest {
 
   @Test
   fun testApkPathParsing_withCustomOutputName_onOlderAgpAndGradleVersions() {
+    // fails with later versions
     apiStubs.stubUploadDistributionSuccess()
     apiStubs.stubGetUploadStatusSuccess()
     testGroovyBuild.writeBuildFiles(
@@ -198,38 +200,16 @@ class UploadDistributionTaskTest {
   }
 
   @Test
-  fun testAabPathParsing_withAab_onOlderAgpAndGradleVersions() {
+  fun testAabPathParsing_withAab(
+    @TestParameter(valuesProvider = VersionsProvider::class) versions: Versions,
+  ) {
     apiStubs.stubGetAabInfoSuccess()
     apiStubs.stubUploadDistributionSuccess()
     apiStubs.stubGetUploadStatusSuccess()
     testGroovyBuild.writeBuildFiles(
-      agpVersion = OLDER_AGP_VERSION,
-      googleServicesVersion = OLDER_GOOGLE_SERVICES_VERSION,
-      artifactType = "AAB"
-    )
-
-    val result =
-      GradleRunner.create()
-        .withProjectDir(testGradleProject.projectDir.root)
-        .withArguments("bundleDebug", "appDistributionUploadDebug", "--info", "--stacktrace")
-        .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion(OLDER_GRADLE_VERSION)
-        .build()
-
-    assertEquals(SUCCESS, result.task(":app:appDistributionUploadDebug")?.outcome)
-    assertThat(result.output, containsString("Using AAB"))
-    assertThat(result.output, containsString("build/outputs/bundle/debug/app-debug.aab"))
-  }
-
-  @Test
-  fun testAabPathParsing_withAab_onLatestAgpAndGradleVersions() {
-    apiStubs.stubGetAabInfoSuccess()
-    apiStubs.stubUploadDistributionSuccess()
-    apiStubs.stubGetUploadStatusSuccess()
-    testGroovyBuild.writeBuildFiles(
-      agpVersion = LATEST_AGP_VERSION,
-      googleServicesVersion = LATEST_GOOGLE_SERVICES_VERSION,
-      compileSdkVersion = LATEST_COMPILE_SDK_VERSION,
+      agpVersion = versions.agp,
+      compileSdkVersion = versions.compileSdk,
+      googleServicesVersion = versions.googleServices,
       artifactType = "AAB"
     )
 
@@ -237,13 +217,11 @@ class UploadDistributionTaskTest {
       GradleRunner.create()
         .withProjectDir(testGradleProject.projectDir.root)
         .withArguments(
-          ":app:bundleDebug",
-          ":app:appDistributionUploadDebug",
-          "--info",
-          "--stacktrace"
+          listOf("bundleDebug", "appDistributionUploadDebug", "--info", "--stacktrace") +
+            versions.additionalGradleArguments()
         )
         .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion(LATEST_GRADLE_VERSION)
+        .withGradleVersion(versions.gradle)
         .build()
 
     assertEquals(SUCCESS, result.task(":app:appDistributionUploadDebug")?.outcome)
@@ -252,14 +230,16 @@ class UploadDistributionTaskTest {
   }
 
   @Test
-  fun testAabPathParsing_withAab_withConfigurationCache_onLatestAgpAndGradleVersions() {
+  fun testAabPathParsing_noAab(
+    @TestParameter(valuesProvider = VersionsProvider::class) versions: Versions,
+  ) {
     apiStubs.stubGetAabInfoSuccess()
     apiStubs.stubUploadDistributionSuccess()
     apiStubs.stubGetUploadStatusSuccess()
     testGroovyBuild.writeBuildFiles(
-      agpVersion = LATEST_AGP_VERSION,
-      googleServicesVersion = LATEST_GOOGLE_SERVICES_VERSION,
-      compileSdkVersion = LATEST_COMPILE_SDK_VERSION,
+      agpVersion = versions.agp,
+      compileSdkVersion = versions.compileSdk,
+      googleServicesVersion = versions.googleServices,
       artifactType = "AAB"
     )
 
@@ -267,38 +247,11 @@ class UploadDistributionTaskTest {
       GradleRunner.create()
         .withProjectDir(testGradleProject.projectDir.root)
         .withArguments(
-          "bundleDebug",
-          "appDistributionUploadDebug",
-          "--configuration-cache",
-          "--info",
-          "--stacktrace"
+          listOf("appDistributionUploadDebug", "--info", "--stacktrace") +
+            versions.additionalGradleArguments()
         )
         .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion(LATEST_GRADLE_VERSION)
-        .build()
-
-    assertEquals(SUCCESS, result.task(":app:appDistributionUploadDebug")?.outcome)
-    assertThat(result.output, containsString("Using AAB"))
-    assertThat(result.output, containsString("build/outputs/bundle/debug/app-debug.aab"))
-  }
-
-  @Test
-  fun testAabPathParsing_noAab_onOlderAgpAndGradleVersions() {
-    apiStubs.stubGetAabInfoSuccess()
-    apiStubs.stubUploadDistributionSuccess()
-    apiStubs.stubGetUploadStatusSuccess()
-    testGroovyBuild.writeBuildFiles(
-      agpVersion = OLDER_AGP_VERSION,
-      googleServicesVersion = OLDER_GOOGLE_SERVICES_VERSION,
-      artifactType = "AAB"
-    )
-
-    val result =
-      GradleRunner.create()
-        .withProjectDir(testGradleProject.projectDir.root)
-        .withArguments("appDistributionUploadDebug", "--info", "--stacktrace")
-        .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion(OLDER_GRADLE_VERSION)
+        .withGradleVersion(versions.gradle)
         .buildAndFail()
 
     assertEquals(FAILED, result.task(":app:appDistributionUploadDebug")?.outcome)
@@ -312,53 +265,32 @@ class UploadDistributionTaskTest {
   }
 
   @Test
-  fun testAabPathParsing_noAab_onLatestAgpAndGradleVersions() {
+  fun testAabPathParsing_withAabCommandLineOverride(
+    @TestParameter(valuesProvider = VersionsProvider::class) versions: Versions,
+  ) {
     apiStubs.stubGetAabInfoSuccess()
     apiStubs.stubUploadDistributionSuccess()
     apiStubs.stubGetUploadStatusSuccess()
     testGroovyBuild.writeBuildFiles(
-      agpVersion = LATEST_AGP_VERSION,
-      googleServicesVersion = LATEST_GOOGLE_SERVICES_VERSION,
-      compileSdkVersion = LATEST_COMPILE_SDK_VERSION,
-      artifactType = "AAB"
-    )
-
-    val result =
-      GradleRunner.create()
-        .withProjectDir(testGradleProject.projectDir.root)
-        .withArguments("appDistributionUploadDebug", "--info", "--stacktrace")
-        .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion(LATEST_GRADLE_VERSION)
-        .buildAndFail()
-
-    assertEquals(FAILED, result.task(":app:appDistributionUploadDebug")?.outcome)
-    assertThat(result.output, containsString("Using AAB"))
-    assertThat(result.output, containsString("build/outputs/bundle/debug/app-debug.aab"))
-    assertThat(result.output, containsString("Could not find the AAB"))
-  }
-
-  @Test
-  fun testAabPathParsing_withAabCommandLineOverride_onOlderAgpAndGradleVersions() {
-    apiStubs.stubGetAabInfoSuccess()
-    apiStubs.stubUploadDistributionSuccess()
-    apiStubs.stubGetUploadStatusSuccess()
-    testGroovyBuild.writeBuildFiles(
-      agpVersion = OLDER_AGP_VERSION,
-      googleServicesVersion = OLDER_GOOGLE_SERVICES_VERSION,
+      agpVersion = versions.agp,
+      compileSdkVersion = versions.compileSdk,
+      googleServicesVersion = versions.googleServices,
     )
 
     val result =
       GradleRunner.create()
         .withProjectDir(testGradleProject.projectDir.root)
         .withArguments(
-          "bundleDebug",
-          "appDistributionUploadDebug",
-          "--artifactType=AAB",
-          "--info",
-          "--stacktrace"
+          listOf(
+            "bundleDebug",
+            "appDistributionUploadDebug",
+            "--artifactType=AAB",
+            "--info",
+            "--stacktrace"
+          ) + versions.additionalGradleArguments()
         )
         .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion(OLDER_GRADLE_VERSION)
+        .withGradleVersion(versions.gradle)
         .build()
 
     assertEquals(SUCCESS, result.task(":app:appDistributionUploadDebug")?.outcome)
@@ -367,70 +299,16 @@ class UploadDistributionTaskTest {
   }
 
   @Test
-  fun testAabPathParsing_withAabCommandLineOverride_onLatestAgpAndGradleVersions() {
+  fun testArtifactPath_withRelativePath(
+    @TestParameter(valuesProvider = VersionsProvider::class) versions: Versions,
+  ) {
     apiStubs.stubGetAabInfoSuccess()
     apiStubs.stubUploadDistributionSuccess()
     apiStubs.stubGetUploadStatusSuccess()
     testGroovyBuild.writeBuildFiles(
-      agpVersion = LATEST_AGP_VERSION,
-      googleServicesVersion = LATEST_GOOGLE_SERVICES_VERSION,
-      compileSdkVersion = LATEST_COMPILE_SDK_VERSION,
-    )
-
-    val result =
-      GradleRunner.create()
-        .withProjectDir(testGradleProject.projectDir.root)
-        .withArguments(
-          "bundleDebug",
-          "appDistributionUploadDebug",
-          "--artifactType=AAB",
-          "--info",
-          "--stacktrace"
-        )
-        .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion(LATEST_GRADLE_VERSION)
-        .build()
-
-    assertEquals(SUCCESS, result.task(":app:appDistributionUploadDebug")?.outcome)
-    assertThat(result.output, containsString("Using AAB"))
-    assertThat(result.output, containsString("build/outputs/bundle/debug/app-debug.aab"))
-  }
-
-  @Test
-  fun testArtifactPath_withRelativePath_onLatestAgpAndGradleVersions() {
-    apiStubs.stubGetAabInfoSuccess()
-    apiStubs.stubUploadDistributionSuccess()
-    apiStubs.stubGetUploadStatusSuccess()
-    testGroovyBuild.writeBuildFiles(
-      agpVersion = LATEST_AGP_VERSION,
-      googleServicesVersion = LATEST_GOOGLE_SERVICES_VERSION,
-      compileSdkVersion = LATEST_COMPILE_SDK_VERSION,
-      artifactType = "APK",
-      artifactPath = "app/build/outputs/apk/debug/app-debug.apk"
-    )
-
-    val result =
-      GradleRunner.create()
-        .withProjectDir(testGradleProject.projectDir.root)
-        .withArguments("assembleDebug", "appDistributionUploadDebug", "--info", "--stacktrace")
-        .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion(LATEST_GRADLE_VERSION)
-        .build()
-
-    assertEquals(SUCCESS, result.task(":app:appDistributionUploadDebug")?.outcome)
-    assertThat(result.output, containsString("Using APK"))
-    assertThat(result.output, containsString("build/outputs/apk/debug/app-debug.apk"))
-  }
-
-  @Test
-  fun testArtifactPath_withRelativePath_withConfigurationCache_onLatestAgpAndGradleVersions() {
-    apiStubs.stubGetAabInfoSuccess()
-    apiStubs.stubUploadDistributionSuccess()
-    apiStubs.stubGetUploadStatusSuccess()
-    testGroovyBuild.writeBuildFiles(
-      agpVersion = LATEST_AGP_VERSION,
-      googleServicesVersion = LATEST_GOOGLE_SERVICES_VERSION,
-      compileSdkVersion = LATEST_COMPILE_SDK_VERSION,
+      agpVersion = versions.agp,
+      compileSdkVersion = versions.compileSdk,
+      googleServicesVersion = versions.googleServices,
       artifactType = "APK",
       artifactPath = "app/build/outputs/apk/debug/app-debug.apk"
     )
@@ -439,14 +317,11 @@ class UploadDistributionTaskTest {
       GradleRunner.create()
         .withProjectDir(testGradleProject.projectDir.root)
         .withArguments(
-          "assembleDebug",
-          "appDistributionUploadDebug",
-          "--configuration-cache",
-          "--info",
-          "--stacktrace"
+          listOf("assembleDebug", "appDistributionUploadDebug", "--info", "--stacktrace") +
+            versions.additionalGradleArguments()
         )
         .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion(LATEST_GRADLE_VERSION)
+        .withGradleVersion(versions.gradle)
         .build()
 
     assertEquals(SUCCESS, result.task(":app:appDistributionUploadDebug")?.outcome)
@@ -455,14 +330,16 @@ class UploadDistributionTaskTest {
   }
 
   @Test
-  fun testArtifactPath_withPathToNonexistentFile_onLatestAgpAndGradleVersions() {
+  fun testArtifactPath_withPathToNonexistentFile(
+    @TestParameter(valuesProvider = VersionsProvider::class) versions: Versions,
+  ) {
     apiStubs.stubGetAabInfoSuccess()
     apiStubs.stubUploadDistributionSuccess()
     apiStubs.stubGetUploadStatusSuccess()
     testGroovyBuild.writeBuildFiles(
-      agpVersion = LATEST_AGP_VERSION,
-      googleServicesVersion = LATEST_GOOGLE_SERVICES_VERSION,
-      compileSdkVersion = LATEST_COMPILE_SDK_VERSION,
+      agpVersion = versions.agp,
+      compileSdkVersion = versions.compileSdk,
+      googleServicesVersion = versions.googleServices,
       artifactType = "APK",
       artifactPath = "bad/artifact/path"
     )
@@ -470,9 +347,12 @@ class UploadDistributionTaskTest {
     val result =
       GradleRunner.create()
         .withProjectDir(testGradleProject.projectDir.root)
-        .withArguments("assembleDebug", "appDistributionUploadDebug", "--info", "--stacktrace")
+        .withArguments(
+          listOf("assembleDebug", "appDistributionUploadDebug", "--info", "--stacktrace") +
+            versions.additionalGradleArguments()
+        )
         .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion(LATEST_GRADLE_VERSION)
+        .withGradleVersion(versions.gradle)
         .buildAndFail()
 
     assertEquals(FAILED, result.task(":app:appDistributionUploadDebug")?.outcome)
@@ -480,14 +360,16 @@ class UploadDistributionTaskTest {
   }
 
   @Test
-  fun testArtifactPath_withPathInvalidPath_onLatestAgpAndGradleVersions() {
+  fun testArtifactPath_withPathInvalidPath(
+    @TestParameter(valuesProvider = VersionsProvider::class) versions: Versions,
+  ) {
     apiStubs.stubGetAabInfoSuccess()
     apiStubs.stubUploadDistributionSuccess()
     apiStubs.stubGetUploadStatusSuccess()
     testGroovyBuild.writeBuildFiles(
-      agpVersion = LATEST_AGP_VERSION,
-      googleServicesVersion = LATEST_GOOGLE_SERVICES_VERSION,
-      compileSdkVersion = LATEST_COMPILE_SDK_VERSION,
+      agpVersion = versions.agp,
+      compileSdkVersion = versions.compileSdk,
+      googleServicesVersion = versions.googleServices,
       artifactType = "APK",
       artifactPath = "\\0"
     )
@@ -495,9 +377,12 @@ class UploadDistributionTaskTest {
     val result =
       GradleRunner.create()
         .withProjectDir(testGradleProject.projectDir.root)
-        .withArguments("assembleDebug", "appDistributionUploadDebug", "--info", "--stacktrace")
+        .withArguments(
+          listOf("assembleDebug", "appDistributionUploadDebug", "--info", "--stacktrace") +
+            versions.additionalGradleArguments()
+        )
         .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion(LATEST_GRADLE_VERSION)
+        .withGradleVersion(versions.gradle)
         .buildAndFail()
 
     assertThat(result.output, containsString("is an invalid path"))
@@ -508,136 +393,81 @@ class UploadDistributionTaskTest {
   // *************************************************************************
   @Test
   fun testAabPathParsing_forAgp713andGradle72() {
-    apiStubs.stubGetAabInfoSuccess()
-    apiStubs.stubUploadDistributionSuccess()
-    apiStubs.stubGetUploadStatusSuccess()
-    testGroovyBuild.writeBuildFiles(
-      agpVersion = "7.1.3",
-      artifactType = "AAB",
+    testAabPathParsing_withAab(
+      Versions(
+        gradle = "7.2",
+        agp = "7.1.3",
+        OLDER_COMPILE_SDK_VERSION,
+        OLDER_GOOGLE_SERVICES_VERSION,
+        useConfigurationCache = false
+      )
     )
-
-    val result =
-      GradleRunner.create()
-        .withProjectDir(testGradleProject.projectDir.root)
-        .withArguments("bundleDebug", "appDistributionUploadDebug", "--info", "--stacktrace")
-        .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion("7.2")
-        .build()
-
-    assertEquals(SUCCESS, result.task(":app:appDistributionUploadDebug")?.outcome)
-    assertThat(result.output, containsString("Using AAB"))
-    assertThat(result.output, containsString("build/outputs/bundle/debug/app-debug.aab"))
   }
 
   @Test
   fun testAabPathParsing_forAgp722andGradle733() {
-    apiStubs.stubGetAabInfoSuccess()
-    apiStubs.stubUploadDistributionSuccess()
-    apiStubs.stubGetUploadStatusSuccess()
-    testGroovyBuild.writeBuildFiles(
-      agpVersion = "7.2.2",
-      artifactType = "AAB",
+    testAabPathParsing_withAab(
+      Versions(
+        gradle = "7.3.3",
+        agp = "7.2.2",
+        OLDER_COMPILE_SDK_VERSION,
+        OLDER_GOOGLE_SERVICES_VERSION,
+        useConfigurationCache = false
+      )
     )
-
-    val result =
-      GradleRunner.create()
-        .withProjectDir(testGradleProject.projectDir.root)
-        .withArguments("bundleDebug", "appDistributionUploadDebug", "--info", "--stacktrace")
-        .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion("7.3.3")
-        .build()
-
-    assertEquals(SUCCESS, result.task(":app:appDistributionUploadDebug")?.outcome)
-    assertThat(result.output, containsString("Using AAB"))
-    assertThat(result.output, containsString("build/outputs/bundle/debug/app-debug.aab"))
   }
 
   @Test
   fun testAabPathParsing_forAgp731andGradle74() {
-    apiStubs.stubGetAabInfoSuccess()
-    apiStubs.stubUploadDistributionSuccess()
-    apiStubs.stubGetUploadStatusSuccess()
-    testGroovyBuild.writeBuildFiles(
-      agpVersion = "7.3.1",
-      googleServicesVersion = LATEST_GOOGLE_SERVICES_VERSION,
-      artifactType = "AAB",
+    testAabPathParsing_withAab(
+      Versions(
+        gradle = "7.4",
+        agp = "7.3.1",
+        OLDER_COMPILE_SDK_VERSION,
+        LATEST_STABLE_GOOGLE_SERVICES_VERSION,
+        useConfigurationCache = false
+      )
     )
-
-    val result =
-      GradleRunner.create()
-        .withProjectDir(testGradleProject.projectDir.root)
-        .withArguments("bundleDebug", "appDistributionUploadDebug", "--info", "--stacktrace")
-        .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion("7.4")
-        .build()
-
-    assertEquals(SUCCESS, result.task(":app:appDistributionUploadDebug")?.outcome)
-    assertThat(result.output, containsString("Using AAB"))
-    assertThat(result.output, containsString("build/outputs/bundle/debug/app-debug.aab"))
   }
 
   @Test
   fun testGoogleServices440AppIdParsing_forAgp730() {
-    apiStubs.stubUploadDistributionSuccess()
-    apiStubs.stubGetUploadStatusSuccess()
-    testGroovyBuild.writeBuildFiles(
-      agpVersion = "7.3.0", // Note: this fails with AGP 7.4.0
-      googleServicesVersion = "4.4.0",
-      useGoogleServicesPlugin = true,
+    testAabPathParsing_withAab(
+      Versions(
+        gradle = "7.4",
+        agp = "7.3.0", // Note: this fails with AGP 7.4.0
+        OLDER_COMPILE_SDK_VERSION,
+        "4.4.0",
+        useConfigurationCache = false
+      )
     )
-
-    val result =
-      GradleRunner.create()
-        .withProjectDir(testGradleProject.projectDir.root)
-        .withArguments("assembleDebug", "appDistributionUploadDebug", "--info", "--stacktrace")
-        .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion("7.4")
-        .build()
-
-    assertEquals(SUCCESS, result.task(":app:appDistributionUploadDebug")?.outcome)
   }
 
   // *************************************************************************
   // Miscellaneous integration tests
   // *************************************************************************
   @Test
-  fun testGoogleServicesAppIdParsing_onLatestAgpAndGradleVersions() {
+  fun testGoogleServicesAppIdParsing(
+    @TestParameter(valuesProvider = VersionsProvider::class) versions: Versions,
+  ) {
     apiStubs.stubUploadDistributionSuccess()
     apiStubs.stubGetUploadStatusSuccess()
     testGroovyBuild.writeBuildFiles(
-      agpVersion = LATEST_AGP_VERSION,
-      googleServicesVersion = LATEST_GOOGLE_SERVICES_VERSION,
-      compileSdkVersion = LATEST_COMPILE_SDK_VERSION,
+      agpVersion = versions.agp,
+      googleServicesVersion = versions.googleServices,
+      compileSdkVersion = versions.compileSdk,
       useGoogleServicesPlugin = true,
     )
 
     val result =
       GradleRunner.create()
         .withProjectDir(testGradleProject.projectDir.root)
-        .withArguments("assembleDebug", "appDistributionUploadDebug", "--info", "--stacktrace")
+        .withArguments(
+          listOf("assembleDebug", "appDistributionUploadDebug", "--info", "--stacktrace") +
+            versions.additionalGradleArguments()
+        )
         .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion(LATEST_GRADLE_VERSION)
-        .build()
-
-    assertEquals(SUCCESS, result.task(":app:appDistributionUploadDebug")?.outcome)
-  }
-
-  @Test
-  fun testGoogleServicesAppIdParsing_onOlderAgpAndGradleVersions() {
-    apiStubs.stubUploadDistributionSuccess()
-    apiStubs.stubGetUploadStatusSuccess()
-    testGroovyBuild.writeBuildFiles(
-      agpVersion = OLDER_AGP_VERSION,
-      googleServicesVersion = OLDER_GOOGLE_SERVICES_VERSION,
-      useGoogleServicesPlugin = true,
-    )
-
-    val result =
-      GradleRunner.create()
-        .withProjectDir(testGradleProject.projectDir.root)
-        .withArguments("assembleDebug", "appDistributionUploadDebug", "--info", "--stacktrace")
-        .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion(OLDER_GRADLE_VERSION)
+        .withGradleVersion(versions.gradle)
         .build()
 
     assertEquals(SUCCESS, result.task(":app:appDistributionUploadDebug")?.outcome)
@@ -677,9 +507,9 @@ class UploadDistributionTaskTest {
     apiStubs.stubDistributeReleaseSuccess()
     val file = testGradleProject.createAndWriteFile("app/src/testers.txt", "a@a.com,b@b.com")
     testGroovyBuild.writeBuildFiles(
-      agpVersion = LATEST_AGP_VERSION,
-      googleServicesVersion = LATEST_GOOGLE_SERVICES_VERSION,
-      compileSdkVersion = LATEST_COMPILE_SDK_VERSION,
+      agpVersion = LATEST_STABLE_AGP_VERSION,
+      googleServicesVersion = LATEST_STABLE_GOOGLE_SERVICES_VERSION,
+      compileSdkVersion = COMPILE_SDK_VERSION_FOR_GRADLE9,
       testersFile = file.absolutePath
     )
 
@@ -688,7 +518,7 @@ class UploadDistributionTaskTest {
         .withProjectDir(testGradleProject.projectDir.root)
         .withArguments("assembleDebug", "appDistributionUploadDebug", "--info", "--stacktrace")
         .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion(LATEST_GRADLE_VERSION)
+        .withGradleVersion(LATEST_STABLE_GRADLE_VERSION)
         .build()
 
     assertEquals(SUCCESS, result.task(":app:appDistributionUploadDebug")?.outcome)
@@ -702,9 +532,9 @@ class UploadDistributionTaskTest {
     apiStubs.stubDistributeReleaseSuccess()
     val file = testGradleProject.createAndWriteFile("app/src/testers.txt", "a@a.com,b@b.com")
     testGroovyBuild.writeBuildFiles(
-      agpVersion = LATEST_AGP_VERSION,
-      compileSdkVersion = LATEST_COMPILE_SDK_VERSION,
-      googleServicesVersion = LATEST_GOOGLE_SERVICES_VERSION
+      agpVersion = LATEST_STABLE_AGP_VERSION,
+      compileSdkVersion = COMPILE_SDK_VERSION_FOR_GRADLE9,
+      googleServicesVersion = LATEST_STABLE_GOOGLE_SERVICES_VERSION
     )
 
     val result =
@@ -718,7 +548,7 @@ class UploadDistributionTaskTest {
           "--stacktrace"
         )
         .withPluginClasspath(testGradleProject.pluginClasspathFiles)
-        .withGradleVersion(LATEST_GRADLE_VERSION)
+        .withGradleVersion(LATEST_STABLE_GRADLE_VERSION)
         .build()
 
     assertEquals(SUCCESS, result.task(":app:appDistributionUploadDebug")?.outcome)
@@ -726,16 +556,30 @@ class UploadDistributionTaskTest {
   }
 
   companion object {
+    const val COMPILE_SDK_VERSION_FOR_GRADLE9 = "30"
+
+    val LATEST_STABLE_GRADLE_VERSION = VersionUtils.fetchLatestGradleVersion(STABLE)
+    val LATEST_STABLE_AGP_VERSION = VersionUtils.fetchLatestAgpVersion(STABLE)
+    val LATEST_STABLE_GOOGLE_SERVICES_VERSION =
+      VersionUtils.fetchLatestGoogleServicesVersion(STABLE)
+
+    val LATEST_GRADLE_RC_VERSION = VersionUtils.fetchLatestGradleVersion(RC)
+    val LATEST_AGP_RC_VERSION = VersionUtils.fetchLatestAgpVersion(RC)
+
+    val AGP_BLEEDING_EDGE_VERSION = VersionUtils.fetchLatestAgpVersion(BLEEDING_EDGE)
+
     private val LOGGER =
       java.util.logging.Logger.getLogger(UploadDistributionTaskTest::class.java.name)
 
     @org.junit.BeforeClass
     @JvmStatic
     fun logVersions() {
-      LOGGER.info("Integration tests using versions:")
-      LOGGER.info("Latest Gradle Version: $LATEST_GRADLE_VERSION")
-      LOGGER.info("Latest AGP Version: $LATEST_AGP_VERSION")
-      LOGGER.info("Latest Google Services Version: $LATEST_GOOGLE_SERVICES_VERSION")
+      LOGGER.info(
+        "Integration tests using versions:\n" +
+          "Gradle (stable: $LATEST_STABLE_GRADLE_VERSION, rc: $LATEST_GRADLE_RC_VERSION)\n" +
+          "AGP (stable: $LATEST_STABLE_AGP_VERSION, rc: $LATEST_AGP_RC_VERSION, bleeding edge: $AGP_BLEEDING_EDGE_VERSION)\n" +
+          "Google Services (stable: $LATEST_STABLE_GOOGLE_SERVICES_VERSION)"
+      )
     }
   }
 }

--- a/firebase-appdistribution-gradle/src/prodTest/java/com/google/firebase/appdistribution/gradle/BeePlusGradleProject.java
+++ b/firebase-appdistribution-gradle/src/prodTest/java/com/google/firebase/appdistribution/gradle/BeePlusGradleProject.java
@@ -66,9 +66,13 @@ class BeePlusGradleProject extends ExternalResource {
   private static final Logger LOGGER = Logger.getLogger(BeePlusGradleProject.class.getName());
 
   static {
-    LOGGER.info("Production compat tests using versions:\n"
-        + "Latest stable Gradle Version: " + LATEST_STABLE_GRADLE_VERSION + "\n"
-        + "Latest stable AGP Version: " + LATEST_STABLE_AGP_VERSION);
+    LOGGER.info(
+        "Production compat tests using versions:\n"
+            + "Latest stable Gradle Version: "
+            + LATEST_STABLE_GRADLE_VERSION
+            + "\n"
+            + "Latest stable AGP Version: "
+            + LATEST_STABLE_AGP_VERSION);
   }
 
   // The project number for App Distro Probes. We need to use this project

--- a/firebase-appdistribution-gradle/src/prodTest/java/com/google/firebase/appdistribution/gradle/BeePlusGradleProject.java
+++ b/firebase-appdistribution-gradle/src/prodTest/java/com/google/firebase/appdistribution/gradle/BeePlusGradleProject.java
@@ -17,6 +17,7 @@
 package com.google.firebase.appdistribution.gradle;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.firebase.appdistribution.gradle.VersionUtils.Stability.STABLE;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.File;
@@ -57,15 +58,17 @@ class BeePlusGradleProject extends ExternalResource {
   }
 
   static final String PACKAGE_NAME = "com.firebase.appdistribution.prober";
-  static final String LATEST_AGP_VERSION = VersionUtils.INSTANCE.fetchLatestAgpVersion();
-  static final String LATEST_GRADLE_VERSION = VersionUtils.INSTANCE.fetchLatestGradleVersion();
+  static final String LATEST_STABLE_AGP_VERSION =
+      VersionUtils.INSTANCE.fetchLatestAgpVersion(STABLE);
+  static final String LATEST_STABLE_GRADLE_VERSION =
+      VersionUtils.INSTANCE.fetchLatestGradleVersion(STABLE);
 
   private static final Logger LOGGER = Logger.getLogger(BeePlusGradleProject.class.getName());
 
   static {
-    LOGGER.info("Production compat tests using versions:");
-    LOGGER.info("Latest Gradle Version: " + LATEST_GRADLE_VERSION);
-    LOGGER.info("Latest AGP Version: " + LATEST_AGP_VERSION);
+    LOGGER.info("Production compat tests using versions:\n"
+        + "Latest stable Gradle Version: " + LATEST_STABLE_GRADLE_VERSION + "\n"
+        + "Latest stable AGP Version: " + LATEST_STABLE_AGP_VERSION);
   }
 
   // The project number for App Distro Probes. We need to use this project
@@ -115,7 +118,7 @@ class BeePlusGradleProject extends ExternalResource {
             "--emails",
             String.join(",", emails))
         .withPluginClasspath(pluginClasspathFiles)
-        .withGradleVersion(LATEST_GRADLE_VERSION)
+        .withGradleVersion(LATEST_STABLE_GRADLE_VERSION)
         .withEnvironment(getEnvironment())
         .build();
   }
@@ -131,7 +134,7 @@ class BeePlusGradleProject extends ExternalResource {
             "--file",
             emailsFile.getAbsolutePath())
         .withPluginClasspath(pluginClasspathFiles)
-        .withGradleVersion(LATEST_GRADLE_VERSION)
+        .withGradleVersion(LATEST_STABLE_GRADLE_VERSION)
         .withEnvironment(getEnvironment())
         .build();
   }
@@ -148,7 +151,7 @@ class BeePlusGradleProject extends ExternalResource {
             String.join(",", emails),
             "--debug")
         .withPluginClasspath(pluginClasspathFiles)
-        .withGradleVersion(LATEST_GRADLE_VERSION)
+        .withGradleVersion(LATEST_STABLE_GRADLE_VERSION)
         .withEnvironment(getEnvironment())
         .build();
   }
@@ -165,7 +168,7 @@ class BeePlusGradleProject extends ExternalResource {
             emailsFile.getAbsolutePath(),
             "--debug")
         .withPluginClasspath(pluginClasspathFiles)
-        .withGradleVersion(LATEST_GRADLE_VERSION)
+        .withGradleVersion(LATEST_STABLE_GRADLE_VERSION)
         .withEnvironment(getEnvironment())
         .build();
   }
@@ -175,7 +178,7 @@ class BeePlusGradleProject extends ExternalResource {
         .withProjectDir(projectDir.getRoot())
         .withArguments("assembleDebug", "appDistributionUploadDebug", "--info")
         .withPluginClasspath(pluginClasspathFiles)
-        .withGradleVersion(LATEST_GRADLE_VERSION)
+        .withGradleVersion(LATEST_STABLE_GRADLE_VERSION)
         .withEnvironment(getEnvironment())
         .build();
   }
@@ -185,7 +188,7 @@ class BeePlusGradleProject extends ExternalResource {
         .withProjectDir(projectDir.getRoot())
         .withArguments("bundleDebug", "appDistributionUploadDebug", "--info")
         .withPluginClasspath(pluginClasspathFiles)
-        .withGradleVersion(LATEST_GRADLE_VERSION)
+        .withGradleVersion(LATEST_STABLE_GRADLE_VERSION)
         .withEnvironment(getEnvironment())
         .build();
   }
@@ -266,7 +269,7 @@ class BeePlusGradleProject extends ExternalResource {
                 + "  }\n"
                 + "\n"
                 + "}\n",
-            LATEST_AGP_VERSION,
+            LATEST_STABLE_AGP_VERSION,
             pluginClasspathString,
             PACKAGE_NAME,
             PACKAGE_NAME,

--- a/firebase-appdistribution-gradle/src/testUtil/java/com/google/firebase/appdistribution/gradle/VersionUtils.kt
+++ b/firebase-appdistribution-gradle/src/testUtil/java/com/google/firebase/appdistribution/gradle/VersionUtils.kt
@@ -30,7 +30,7 @@ object VersionUtils {
 
   enum class Stability(val filteredKeywords: Set<String>) {
     STABLE(setOf("alpha", "beta", "milestone", "canary", "m", "rc")),
-    RC(setOf("alpha", "milestone", "m")),
+    RC(setOf("alpha", "milestone", "canary", "m")),
     BLEEDING_EDGE(setOf());
 
     fun applies(version: String) = !filteredKeywords.any { version.contains(it, ignoreCase = true) }

--- a/firebase-appdistribution-gradle/src/testUtil/java/com/google/firebase/appdistribution/gradle/VersionUtils.kt
+++ b/firebase-appdistribution-gradle/src/testUtil/java/com/google/firebase/appdistribution/gradle/VersionUtils.kt
@@ -16,6 +16,7 @@
 
 package com.google.firebase.appdistribution.gradle
 
+import com.google.firebase.appdistribution.gradle.VersionUtils.Stability.STABLE
 import java.net.HttpURLConnection
 import java.net.URL
 import javax.xml.parsers.DocumentBuilderFactory
@@ -27,15 +28,27 @@ object VersionUtils {
   private const val GOOGLE_SERVICES_METADATA_URL =
     "https://dl.google.com/dl/android/maven2/com/google/gms/google-services/maven-metadata.xml"
 
-  fun fetchLatestAgpVersion(): String {
-    return fetchLatestDependencyVersion(AGP_METADATA_URL, "AGP")
+  enum class Stability(val filteredKeywords: Set<String>) {
+    STABLE(setOf("alpha", "beta", "milestone", "canary", "m", "rc")),
+    RC(setOf("alpha", "milestone", "m")),
+    BLEEDING_EDGE(setOf());
+
+    fun applies(version: String) = !filteredKeywords.any { version.contains(it, ignoreCase = true) }
   }
 
-  fun fetchLatestGoogleServicesVersion(): String {
-    return fetchLatestDependencyVersion(GOOGLE_SERVICES_METADATA_URL, "Google Services")
+  fun fetchLatestAgpVersion(stability: Stability = STABLE): String {
+    return fetchLatestDependencyVersion(AGP_METADATA_URL, "AGP", stability)
   }
 
-  private fun fetchLatestDependencyVersion(url: String, name: String): String {
+  fun fetchLatestGoogleServicesVersion(stability: Stability = STABLE): String {
+    return fetchLatestDependencyVersion(GOOGLE_SERVICES_METADATA_URL, "Google Services", stability)
+  }
+
+  private fun fetchLatestDependencyVersion(
+    url: String,
+    name: String,
+    stability: Stability,
+  ): String {
     val doc =
       try {
         fetchUrl(url) { connection ->
@@ -52,14 +65,14 @@ object VersionUtils {
     // Iterate backwards through all versions to find the first stable one
     for (i in versionsNodeList.length - 1 downTo 0) {
       val version = versionsNodeList.item(i).textContent
-      if (!isUnstable(version)) {
+      if (stability.applies(version)) {
         return version
       }
     }
-    throw RuntimeException("Failed to find any stable version in $name metadata")
+    throw RuntimeException("Failed to find any $stability version in $name metadata")
   }
 
-  fun fetchLatestGradleVersion(): String {
+  fun fetchLatestGradleVersion(stability: Stability = STABLE): String {
     val content =
       try {
         fetchUrl(GRADLE_RELEASES_URL) { connection ->
@@ -71,7 +84,7 @@ object VersionUtils {
 
     val matchResults = Regex("/gradle/gradle/releases/tag/v?([^\"/\\s>]+)").findAll(content)
 
-    val stableVersions =
+    val applicableVersions =
       matchResults
         .map { it.groupValues[1] }
         .map { version ->
@@ -80,14 +93,14 @@ object VersionUtils {
             "-rc-${it.groupValues[1]}"
           }
         }
-        .filter { !isUnstable(it) }
+        .filter { stability.applies(it) }
         .toList()
 
-    if (stableVersions.isEmpty()) {
-      throw RuntimeException("Failed to find any stable Gradle version in HTML")
+    if (applicableVersions.isEmpty()) {
+      throw RuntimeException("Failed to find any $stability Gradle version in HTML")
     }
 
-    return stableVersions.maxWithOrNull(VersionComparator) ?: stableVersions[0]
+    return applicableVersions.maxWithOrNull(VersionComparator) ?: applicableVersions[0]
   }
 
   private object VersionComparator : Comparator<String> {
@@ -118,10 +131,5 @@ object VersionUtils {
     } finally {
       connection.disconnect()
     }
-  }
-
-  private fun isUnstable(version: String): Boolean {
-    val unstableKeywords = listOf("alpha", "beta", "milestone", "canary", "m", "rc")
-    return unstableKeywords.any { version.contains(it, ignoreCase = true) }
   }
 }


### PR DESCRIPTION
Test the oldest supported versions, the latest stable versions, Gradle and AGP release candidates, even AGP alpha versions:

Gradle            | AGP                      | GoogleServices   | configuration cache
------------------|--------------------------|------------------|--------------------
oldest supported  | oldest supported         | oldest supported | no
latest stable     | latest stable            | latest stable    | no
latest stable     | latest stable            | latest stable    | yes
latest stable     | release candidate (beta) | latest stable    | yes
release candidate | latest stable            | latest stable    | yes
release candidate | bleeding-edge (alpha)    | latest stable    | yes

Note: As far as I know, GoogleServices doesn't publish any snapshot, alpha, or RC versions.
