### PR TITLE
Show user localized error messages and remove special 404 handling

### DIFF
--- a/firebase-appdistribution-gradle/src/main/java/com/google/firebase/appdistribution/gradle/ApiService.kt
+++ b/firebase-appdistribution-gradle/src/main/java/com/google/firebase/appdistribution/gradle/ApiService.kt
@@ -19,7 +19,6 @@ package com.google.firebase.appdistribution.gradle
 import com.google.api.client.http.ByteArrayContent
 import com.google.api.client.http.HttpResponseException
 import com.google.firebase.appdistribution.gradle.AppDistributionException.Reason.Companion.processingBinaryError
-import com.google.firebase.appdistribution.gradle.AppDistributionException.Reason.TEST_CASE_NOT_FOUND
 import com.google.firebase.appdistribution.gradle.AppDistributionException.Reason.TOO_MANY_TESTER_EMAILS
 import com.google.firebase.appdistribution.gradle.NameUtils.extractResourceId
 import com.google.firebase.appdistribution.gradle.models.AabInfo
@@ -107,35 +106,27 @@ class ApiService(private val httpClient: AuthenticatedHttpClient) {
         testCase = testCaseName,
         resultsBucket = resultsBucketName
       )
-    try {
-      val response =
-        httpClient
-          .newPostRequest(
-            ApiEndpoints.getCreateReleaseTestEndpoint(releaseName),
-            buildHttpContent(Gson().toJsonTree(releaseTest))
-          )
-          .execute()
-
-      return if (response.isSuccessStatusCode) {
-        val prefix =
-          if (testCaseName != null) "Started test case ${extractResourceId(testCaseName)}"
-          else "Started test"
-        logger.lifecycle(
-          "{} successfully [{}]. Note: This feature is in beta.",
-          prefix,
-          response.statusCode
+    val response =
+      httpClient
+        .newPostRequest(
+          ApiEndpoints.getCreateReleaseTestEndpoint(releaseName),
+          buildHttpContent(Gson().toJsonTree(releaseTest))
         )
-        Gson().fromJson(response.parseAsString(), ReleaseTest::class.java)
-      } else {
-        logger.warn("Unable to start test. Response code: {}", response.statusCode)
-        null
-      }
-    } catch (e: HttpResponseException) {
-      if (e.statusCode == 404) {
-        throw AppDistributionException(TEST_CASE_NOT_FOUND, extraInformation = testCaseName)
-      }
+        .execute()
 
-      throw e
+    return if (response.isSuccessStatusCode) {
+      val prefix =
+        if (testCaseName != null) "Started test case ${extractResourceId(testCaseName)}"
+        else "Started test"
+      logger.lifecycle(
+        "{} successfully [{}]. Note: This feature is in beta.",
+        prefix,
+        response.statusCode
+      )
+      Gson().fromJson(response.parseAsString(), ReleaseTest::class.java)
+    } else {
+      logger.warn("Unable to start test. Response code: {}", response.statusCode)
+      null
     }
   }
 

--- a/firebase-appdistribution-gradle/src/main/java/com/google/firebase/appdistribution/gradle/AppDistributionException.kt
+++ b/firebase-appdistribution-gradle/src/main/java/com/google/firebase/appdistribution/gradle/AppDistributionException.kt
@@ -20,7 +20,6 @@ import com.google.api.client.http.HttpResponseException
 import com.google.firebase.appdistribution.gradle.models.AabState
 import com.google.firebase.appdistribution.gradle.models.WrappedErrorResponse
 import com.google.gson.Gson
-import com.google.gson.JsonSyntaxException
 import java.io.IOException
 import org.gradle.api.logging.Logging
 
@@ -136,10 +135,13 @@ constructor(
       var message = exception.statusMessage
       try {
         val response = Gson().fromJson(exception.content, WrappedErrorResponse::class.java)
-        if (response?.error != null) {
-          message = response.error.message
+        val error = response?.error
+        if (error != null) {
+          val localizedMessageDetail =
+            error.details?.find { it.type == "type.googleapis.com/google.rpc.LocalizedMessage" }
+          message = localizedMessageDetail?.message ?: error.message ?: exception.statusMessage
         }
-      } catch (e: JsonSyntaxException) {
+      } catch (e: Exception) {
         logger.warn("Failed to parse error response: {}", exception.content)
       }
       return message

--- a/firebase-appdistribution-gradle/src/main/java/com/google/firebase/appdistribution/gradle/models/ErrorPayload.kt
+++ b/firebase-appdistribution-gradle/src/main/java/com/google/firebase/appdistribution/gradle/models/ErrorPayload.kt
@@ -31,4 +31,11 @@ data class ErrorPayload(
   @SerializedName("message") val message: String? = null,
   @SerializedName("code") val code: Int = 0,
   @SerializedName("status") val status: String? = null,
+  @SerializedName("details") val details: List<ErrorDetail>? = null,
+)
+
+data class ErrorDetail(
+  @SerializedName("@type") val type: String? = null,
+  @SerializedName("message") val message: String? = null,
+  @SerializedName("locale") val locale: String? = null,
 )

--- a/firebase-appdistribution-gradle/src/test/java/com/google/firebase/appdistribution/gradle/ApiServiceTest.kt
+++ b/firebase-appdistribution-gradle/src/test/java/com/google/firebase/appdistribution/gradle/ApiServiceTest.kt
@@ -16,9 +16,9 @@
 
 package com.google.firebase.appdistribution.gradle
 
+import com.google.api.client.http.HttpResponseException
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.Lists
-import com.google.firebase.appdistribution.gradle.AppDistributionException.Reason.TEST_CASE_NOT_FOUND
 import com.google.firebase.appdistribution.gradle.AppDistributionException.Reason.TOO_MANY_TESTER_EMAILS
 import com.google.firebase.appdistribution.gradle.models.AabState
 import com.google.firebase.appdistribution.gradle.models.DeviceExecution
@@ -206,10 +206,7 @@ class ApiServiceTest {
     val httpTransport = AppDistroMockHttpTransport.newBuilder().setCode(404).build()
     val httpClient = AuthenticatedHttpClient(httpTransport)
     val apiService = ApiService(httpClient)
-    assertFailsWith(
-      AppDistributionException::class,
-      AppDistributionException.formatMessage(TEST_CASE_NOT_FOUND, "invalid-test-case-id"),
-    ) {
+    assertFailsWith(HttpResponseException::class) {
       apiService.testRelease(
         RELEASE_NAME,
         listOf(TestDevice(model = "pixel")),

--- a/firebase-appdistribution-gradle/src/test/java/com/google/firebase/appdistribution/gradle/AppDistributionExceptionTest.kt
+++ b/firebase-appdistribution-gradle/src/test/java/com/google/firebase/appdistribution/gradle/AppDistributionExceptionTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.appdistribution.gradle
+
+import com.google.api.client.http.HttpHeaders
+import com.google.api.client.http.HttpResponseException
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import org.junit.Test
+
+class AppDistributionExceptionTest {
+
+  @Test
+  fun fromHttpResponseException_withMessageField_parsesCorrectly() {
+    val errorResponse =
+      "{\"error\":{\"code\":404,\"message\":\"The GCS bucket 'my-bucket' was not found\",\"status\":\"NOT_FOUND\"}}"
+    val httpResponseException = createHttpResponseException(404, errorResponse)
+
+    val exception =
+      AppDistributionException.fromHttpResponseException(
+        AppDistributionException.Reason.STARTING_TEST_FAILED,
+        httpResponseException
+      )
+
+    assertEquals(AppDistributionException.Reason.STARTING_TEST_FAILED, exception.reason)
+    assertContains(exception.message!!, "The GCS bucket 'my-bucket' was not found")
+  }
+
+  @Test
+  fun fromHttpResponseException_withLocalizedMessageDetail_parsesCorrectly() {
+    val errorResponse =
+      "{\"error\":{\"code\":404,\"message\":\"Resource not found\",\"status\":\"NOT_FOUND\"," +
+        "\"details\":[{\"@type\":\"type.googleapis.com/google.rpc.LocalizedMessage\",\"message\":\"User-facing custom error message\"}]}}"
+    val httpResponseException = createHttpResponseException(404, errorResponse)
+
+    val exception =
+      AppDistributionException.fromHttpResponseException(
+        AppDistributionException.Reason.STARTING_TEST_FAILED,
+        httpResponseException
+      )
+
+    assertEquals(AppDistributionException.Reason.STARTING_TEST_FAILED, exception.reason)
+    assertContains(exception.message!!, "User-facing custom error message")
+  }
+
+  @Test
+  fun fromHttpResponseException_withGenericResponse_fallsBackToStatusMessage() {
+    val httpResponseException = createHttpResponseException(404, "")
+
+    val exception =
+      AppDistributionException.fromHttpResponseException(
+        AppDistributionException.Reason.STARTING_TEST_FAILED,
+        httpResponseException
+      )
+
+    assertEquals(AppDistributionException.Reason.STARTING_TEST_FAILED, exception.reason)
+    assertContains(exception.message!!, "Not Found")
+  }
+
+  private fun createHttpResponseException(statusCode: Int, content: String): HttpResponseException {
+    val statusMessage = if (statusCode == 404) "Not Found" else "OK"
+    return HttpResponseException.Builder(statusCode, statusMessage, HttpHeaders())
+      .setContent(content)
+      .build()
+  }
+}


### PR DESCRIPTION
Previously we'd assumed any 404 when calling CreateReleaseTest meant the test case did not exist. Now, 404s can also mean that the results bucket does not exist.

This PR handles this better by simply relaying the best available message from the RPC response.