### PR TITLE
Revert PR 8248 "Disable integration test checks temporarily"

### DIFF
--- a/.github/workflows/firestore_ci_tests.yml
+++ b/.github/workflows/firestore_ci_tests.yml
@@ -338,14 +338,12 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-  # TODO: Re-enable integ_tests and enterprise_integ_tests when backend error is fixed.
   check-required-tests:
     runs-on: ubuntu-latest
     if: always()
     name: Check all required Firestore tests results
-    # needs: [integ_tests, enterprise_integ_tests]
+    needs: [integ_tests, enterprise_integ_tests]
     steps:
       - name: Check test matrix
-        run: echo "Integration tests are optional"
-        # if: needs.integ_tests.result == 'failure' || needs.enterprise_integ_tests.result == 'failure'
-        # run: exit 1
+        if: needs.integ_tests.result == 'failure' || needs.enterprise_integ_tests.result == 'failure'
+        run: exit 1


### PR DESCRIPTION
This reverts commit 6914dc79b5ed248b8a5b636e2070a8482abe6b57, PR https://github.com/firebase/firebase-android-sdk/pull/8248.

The revert is being done to fix the issue where the required "Check all required Firestore tests results" github action never starts nor completes, blocking PR merging.

<img width="1731" height="1321" alt="image" src="https://github.com/user-attachments/assets/f1d5f29e-9fac-41db-a638-3022f8d04b73" />
