### PR TITLE
dataconnect(chore): add `token` StateFlow to observe token changes

### DIFF
--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAppCheck.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAppCheck.kt
@@ -69,7 +69,7 @@ internal class DataConnectAppCheck(
     private val dataConnectAppCheckRef: WeakReference<DataConnectAppCheck>,
   ) : AppCheckTokenListener {
     override fun onAppCheckTokenChanged(tokenResult: AppCheckTokenResult) {
-      dataConnectAppCheckRef.get()?.onTokenChanged()
+      dataConnectAppCheckRef.get()?.onTokenChanged(tokenResult.token)
     }
   }
 }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAppCheck.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAppCheck.kt
@@ -22,8 +22,8 @@ import com.google.firebase.appcheck.interop.AppCheckTokenListener
 import com.google.firebase.appcheck.interop.InteropAppCheckTokenProvider
 import com.google.firebase.dataconnect.core.DataConnectAppCheck.GetAppCheckTokenResult
 import com.google.firebase.dataconnect.core.Globals.toScrubbedAccessToken
-import com.google.firebase.dataconnect.core.LoggerGlobals.debug
 import com.google.firebase.dataconnect.util.IdStringGenerator
+import java.lang.ref.WeakReference
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.tasks.await
@@ -42,7 +42,10 @@ internal class DataConnectAppCheck(
     blockingDispatcher = blockingDispatcher,
     logger = logger,
   ) {
-  private val appCheckTokenListener = AppCheckTokenListenerImpl(logger)
+
+  @Suppress("LeakingThis") private val weakThis = WeakReference(this)
+
+  private val appCheckTokenListener = AppCheckTokenListenerImpl(weakThis)
 
   @DeferredApi
   override fun addTokenListener(provider: InteropAppCheckTokenProvider) =
@@ -54,11 +57,19 @@ internal class DataConnectAppCheck(
   override suspend fun getToken(provider: InteropAppCheckTokenProvider, forceRefresh: Boolean) =
     provider.getToken(forceRefresh).await().let { GetAppCheckTokenResult(it.token) }
 
-  data class GetAppCheckTokenResult(override val token: String?) : GetTokenResult
+  override fun onClose() {
+    weakThis.clear()
+  }
 
-  private class AppCheckTokenListenerImpl(private val logger: Logger) : AppCheckTokenListener {
+  data class GetAppCheckTokenResult(override val token: String?) : GetTokenResult {
+    override fun toString() = "GetAppCheckTokenResult(token=${token?.toScrubbedAccessToken()})"
+  }
+
+  private class AppCheckTokenListenerImpl(
+    private val dataConnectAppCheckRef: WeakReference<DataConnectAppCheck>,
+  ) : AppCheckTokenListener {
     override fun onAppCheckTokenChanged(tokenResult: AppCheckTokenResult) {
-      logger.debug { "onAppCheckTokenChanged(token=${tokenResult.token.toScrubbedAccessToken()})" }
+      dataConnectAppCheckRef.get()?.onTokenChanged()
     }
   }
 }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAuth.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAuth.kt
@@ -48,13 +48,11 @@ internal class DataConnectAuth(
   private val idTokenListener = IdTokenListenerImpl(weakThis)
 
   @DeferredApi
-  override fun addTokenListener(provider: InternalAuthProvider) {
+  override fun addTokenListener(provider: InternalAuthProvider) =
     provider.addIdTokenListener(idTokenListener)
-  }
 
-  override fun removeTokenListener(provider: InternalAuthProvider) {
+  override fun removeTokenListener(provider: InternalAuthProvider) =
     provider.removeIdTokenListener(idTokenListener)
-  }
 
   override suspend fun getToken(provider: InternalAuthProvider, forceRefresh: Boolean) =
     provider.getAccessToken(forceRefresh).await().let {

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAuth.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAuth.kt
@@ -21,9 +21,9 @@ import com.google.firebase.auth.internal.IdTokenListener
 import com.google.firebase.auth.internal.InternalAuthProvider
 import com.google.firebase.dataconnect.core.DataConnectAuth.GetAuthTokenResult
 import com.google.firebase.dataconnect.core.Globals.toScrubbedAccessToken
-import com.google.firebase.dataconnect.core.LoggerGlobals.debug
 import com.google.firebase.dataconnect.util.IdStringGenerator
 import com.google.firebase.internal.InternalTokenResult
+import java.lang.ref.WeakReference
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.tasks.await
@@ -42,19 +42,28 @@ internal class DataConnectAuth(
     blockingDispatcher = blockingDispatcher,
     logger = logger,
   ) {
-  private val idTokenListener = IdTokenListenerImpl(logger)
+
+  @Suppress("LeakingThis") private val weakThis = WeakReference(this)
+
+  private val idTokenListener = IdTokenListenerImpl(weakThis)
 
   @DeferredApi
-  override fun addTokenListener(provider: InternalAuthProvider) =
+  override fun addTokenListener(provider: InternalAuthProvider) {
     provider.addIdTokenListener(idTokenListener)
+  }
 
-  override fun removeTokenListener(provider: InternalAuthProvider) =
+  override fun removeTokenListener(provider: InternalAuthProvider) {
     provider.removeIdTokenListener(idTokenListener)
+  }
 
   override suspend fun getToken(provider: InternalAuthProvider, forceRefresh: Boolean) =
     provider.getAccessToken(forceRefresh).await().let {
       GetAuthTokenResult(it.token, it.getAuthUid())
     }
+
+  override fun onClose() {
+    weakThis.clear()
+  }
 
   @JvmInline
   value class AuthUid(val string: String) {
@@ -62,11 +71,16 @@ internal class DataConnectAuth(
   }
 
   data class GetAuthTokenResult(override val token: String?, val authUid: AuthUid?) :
-    GetTokenResult
+    GetTokenResult {
+    override fun toString() =
+      "GetAuthTokenResult(authUid=$authUid, token=${token?.toScrubbedAccessToken()})"
+  }
 
-  private class IdTokenListenerImpl(private val logger: Logger) : IdTokenListener {
+  private class IdTokenListenerImpl(
+    private val dataConnectAuthRef: WeakReference<DataConnectAuth>
+  ) : IdTokenListener {
     override fun onIdTokenChanged(tokenResult: InternalTokenResult) {
-      logger.debug { "onIdTokenChanged(token=${tokenResult.token?.toScrubbedAccessToken()})" }
+      dataConnectAuthRef.get()?.onTokenChanged()
     }
   }
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAuth.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAuth.kt
@@ -78,7 +78,7 @@ internal class DataConnectAuth(
     private val dataConnectAuthRef: WeakReference<DataConnectAuth>
   ) : IdTokenListener {
     override fun onIdTokenChanged(tokenResult: InternalTokenResult) {
-      dataConnectAuthRef.get()?.onTokenChanged()
+      dataConnectAuthRef.get()?.onTokenChanged(tokenResult.token)
     }
   }
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectCredentialsTokenManager.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectCredentialsTokenManager.kt
@@ -21,6 +21,7 @@ import com.google.firebase.appcheck.interop.InteropAppCheckTokenProvider
 import com.google.firebase.auth.internal.InternalAuthProvider
 import com.google.firebase.dataconnect.DataConnectException
 import com.google.firebase.dataconnect.core.DataConnectCredentialsTokenManager.GetTokenResult
+import com.google.firebase.dataconnect.core.Globals.toScrubbedAccessToken
 import com.google.firebase.dataconnect.core.LoggerGlobals.debug
 import com.google.firebase.dataconnect.core.LoggerGlobals.warn
 import com.google.firebase.dataconnect.util.CoroutineUtils.createChildSupervisorScope
@@ -397,6 +398,7 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
   private sealed class GetTokenRetry(message: String) : Exception(message)
   private class ForceRefresh(message: String) : GetTokenRetry(message)
   private class NewProvider(message: String) : GetTokenRetry(message)
+  private class NewToken(message: String) : GetTokenRetry(message)
 
   @DeferredApi
   private fun onProviderAvailable(newProvider: T) {
@@ -437,10 +439,34 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
     }
   }
 
-  protected fun onTokenChanged() {
+  protected fun onTokenChanged(newToken: String?) {
+    if (token.value?.token == newToken) {
+      return
+    }
+
     val invocationId = idStringGenerator.next("otc")
-    logger.debug { "$invocationId onTokenChanged()" }
-    forceRefresh() // make sure getToken() gets the *new* token, not an old one
+    logger.debug { "$invocationId onTokenChanged(newToken=${newToken?.toScrubbedAccessToken()})" }
+
+    while (true) {
+      val currentState = state.value
+
+      val activeState =
+        when (currentState) {
+          State.New -> return
+          is State.Initialized -> break
+          is State.Idle -> break
+          is State.Active -> currentState
+          State.Closed -> return
+        }
+
+      val newState = State.Idle(activeState.provider, forceTokenRefresh = false)
+      if (state.compareAndSet(currentState, newState)) {
+        val message = "$invocationId a new token is available (j567n2577q)"
+        activeState.job.cancel(message, NewToken(message))
+        break
+      }
+    }
+
     coroutineScope.launch(CoroutineName(invocationId)) { getToken(invocationId) }
   }
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectCredentialsTokenManager.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectCredentialsTokenManager.kt
@@ -21,7 +21,6 @@ import com.google.firebase.appcheck.interop.InteropAppCheckTokenProvider
 import com.google.firebase.auth.internal.InternalAuthProvider
 import com.google.firebase.dataconnect.DataConnectException
 import com.google.firebase.dataconnect.core.DataConnectCredentialsTokenManager.GetTokenResult
-import com.google.firebase.dataconnect.core.Globals.toScrubbedAccessToken
 import com.google.firebase.dataconnect.core.LoggerGlobals.debug
 import com.google.firebase.dataconnect.core.LoggerGlobals.warn
 import com.google.firebase.dataconnect.util.CoroutineUtils.createChildSupervisorScope
@@ -32,7 +31,6 @@ import com.google.firebase.inject.Deferred.DeferredHandler
 import com.google.firebase.inject.Provider
 import com.google.firebase.internal.api.FirebaseNoSignedInUserException
 import java.lang.ref.WeakReference
-import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineName
@@ -41,8 +39,11 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.getAndUpdate
@@ -110,6 +111,17 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
   /** The current state of this object. */
   private val state = MutableStateFlow<State<T, R>>(State.New)
 
+  private val _token = MutableStateFlow<R?>(null)
+
+  /**
+   * The last token returned from [getToken]
+   *
+   * Returns null if [getToken] has never been called or never completed successfully.
+   *
+   * After [close] the value of this flow is _not_ cleared, and will remain unchanged indefinitely.
+   */
+  val token: StateFlow<R?> = _token.asStateFlow()
+
   /**
    * Adds the token listener to the given provider.
    *
@@ -129,6 +141,9 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
    * refresh if and only if `forceRefresh` is true.
    */
   protected abstract suspend fun getToken(provider: T, forceRefresh: Boolean): R
+
+  /** Invoked synchronously by [close]. */
+  protected abstract fun onClose()
 
   /**
    * Initializes this object.
@@ -173,6 +188,7 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
 
     weakThis.clear()
     coroutineScope.cancel()
+    onClose()
 
     val oldState = state.getAndUpdate { State.Closed }
     when (oldState) {
@@ -339,7 +355,7 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
 
       // Ensure that any exception checking below is due to an exception that happened in the
       // coroutine that called getToken(), not from the calling coroutine being cancelled.
-      coroutineContext.ensureActive()
+      currentCoroutineContext().ensureActive()
 
       val sequencedResult = jobResult.getOrNull()
       if (sequencedResult !== null && sequencedResult.sequenceNumber < attemptSequenceNumber) {
@@ -357,6 +373,7 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
           logger.debug {
             "$invocationId getToken() returns null (FirebaseAuth reports no signed-in user)"
           }
+          _token.value = null
           return null
         } else if (exception is CancellationException) {
           logger.warn(exception) {
@@ -371,10 +388,8 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
       }
 
       val tokenResult: R = sequencedResult!!.ref.getOrThrow()
-      logger.debug {
-        "$invocationId getToken() returns retrieved token: " +
-          tokenResult.token?.toScrubbedAccessToken()
-      }
+      logger.debug { "$invocationId getToken() returns $tokenResult" }
+      _token.value = tokenResult
       return tokenResult
     }
   }
@@ -420,6 +435,13 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
         oldState.job.cancel(message, NewProvider(message))
       }
     }
+  }
+
+  protected fun onTokenChanged() {
+    val invocationId = idStringGenerator.next("otc")
+    logger.debug { "$invocationId onTokenChanged()" }
+    forceRefresh() // make sure getToken() gets the *new* token, not an old one
+    coroutineScope.launch(CoroutineName(invocationId)) { getToken(invocationId) }
   }
 
   /**

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
@@ -694,8 +694,7 @@ class DataConnectAuthUnitTest {
   fun `token should update when IdTokenListener fires`() = runTest {
     checkAll(propTestConfig, Arb.list(Arb.dataConnect.authTokenResult(), 2..5)) { authTokens ->
       val idTokenListenerSlot = slot<IdTokenListener>()
-      every { mockInternalAuthProvider.addIdTokenListener(capture(idTokenListenerSlot)) } returns
-        Unit
+      every { mockInternalAuthProvider.addIdTokenListener(capture(idTokenListenerSlot)) } just runs
       val expectedAuthTokens = mockInternalAuthProvider.setAnswers(authTokens)
 
       val dataConnectAuth = newDataConnectAuth()

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
@@ -17,6 +17,7 @@
 
 package com.google.firebase.dataconnect.core
 
+import app.cash.turbine.test
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.auth.GetTokenResult
@@ -24,6 +25,7 @@ import com.google.firebase.auth.internal.IdTokenListener
 import com.google.firebase.auth.internal.InternalAuthProvider
 import com.google.firebase.dataconnect.DataConnectException
 import com.google.firebase.dataconnect.core.DataConnectAuth.AuthUid
+import com.google.firebase.dataconnect.core.DataConnectAuth.GetAuthTokenResult
 import com.google.firebase.dataconnect.core.Globals.toScrubbedAccessToken
 import com.google.firebase.dataconnect.testutil.DataConnectLogLevelRule
 import com.google.firebase.dataconnect.testutil.DelayedDeferred
@@ -32,6 +34,7 @@ import com.google.firebase.dataconnect.testutil.SuspendingCountDownLatch
 import com.google.firebase.dataconnect.testutil.UnavailableDeferred
 import com.google.firebase.dataconnect.testutil.newBackgroundScopeThatAdvancesLikeForeground
 import com.google.firebase.dataconnect.testutil.newMockLogger
+import com.google.firebase.dataconnect.testutil.property.arbitrary.authTokenResult
 import com.google.firebase.dataconnect.testutil.property.arbitrary.dataConnect
 import com.google.firebase.dataconnect.testutil.shouldContainWithNonAbuttingText
 import com.google.firebase.dataconnect.testutil.shouldContainWithNonAbuttingTextIgnoringCase
@@ -48,6 +51,7 @@ import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.assertions.nondeterministic.eventuallyConfig
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.withClue
+import io.kotest.common.ExperimentalKotest
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldBeNull
@@ -55,15 +59,22 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.kotest.property.Arb
+import io.kotest.property.EdgeConfig
+import io.kotest.property.PropTestConfig
 import io.kotest.property.RandomSource
+import io.kotest.property.ShrinkingMode
+import io.kotest.property.arbitrary.list
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.next
 import io.kotest.property.arbs.products.brand
+import io.kotest.property.checkAll
 import io.mockk.coEvery
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.excludeRecords
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import java.util.concurrent.CopyOnWriteArrayList
@@ -310,9 +321,7 @@ class DataConnectAuthUnitTest {
 
     withClue("result=$result") { result.shouldNotBeNull().token shouldBe accessToken }
     mockLogger.shouldHaveLoggedExactlyOneMessageContaining(requestId)
-    mockLogger.shouldHaveLoggedExactlyOneMessageContaining(
-      "returns retrieved token: ${accessToken.toScrubbedAccessToken()}"
-    )
+    mockLogger.shouldHaveLoggedExactlyOneMessageContaining(accessToken.toScrubbedAccessToken())
     mockLogger.shouldNotHaveLoggedAnyMessagesContaining(accessToken)
   }
 
@@ -414,9 +423,7 @@ class DataConnectAuthUnitTest {
     verify(exactly = 0) { mockInternalAuthProvider.getAccessToken(false) }
     mockLogger.shouldHaveLoggedExactlyOneMessageContaining(requestId)
     mockLogger.shouldHaveLoggedExactlyOneMessageContaining("getToken(forceRefresh=true)")
-    mockLogger.shouldHaveLoggedExactlyOneMessageContaining(
-      "returns retrieved token: ${accessToken.toScrubbedAccessToken()}"
-    )
+    mockLogger.shouldHaveLoggedExactlyOneMessageContaining(accessToken.toScrubbedAccessToken())
     mockLogger.shouldNotHaveLoggedAnyMessagesContaining(accessToken)
   }
 
@@ -638,6 +645,129 @@ class DataConnectAuthUnitTest {
       )
     }
 
+  @Test
+  fun `token should be initially null`() = runTest {
+    val dataConnectAuth = newDataConnectAuth()
+    dataConnectAuth.token.value.shouldBeNull()
+  }
+
+  @Test
+  fun `token should be null after initialize if provider is not available`() = runTest {
+    val dataConnectAuth = newDataConnectAuth(deferredInternalAuthProvider = UnavailableDeferred())
+    dataConnectAuth.initialize()
+    advanceUntilIdle()
+    dataConnectAuth.token.value.shouldBeNull()
+  }
+
+  @Test
+  fun `token should update when getToken is called`() = runTest {
+    val dataConnectAuth = newDataConnectAuth()
+    dataConnectAuth.initialize()
+    advanceUntilIdle()
+    coEvery { mockInternalAuthProvider.getAccessToken(any()) } returns taskForToken(accessToken)
+
+    dataConnectAuth.getToken(requestId)
+
+    dataConnectAuth.token.value.shouldNotBeNull().token shouldBe accessToken
+  }
+
+  @Test
+  fun `token should update to null when no user is signed in`() = runTest {
+    val dataConnectAuth = newDataConnectAuth()
+    dataConnectAuth.initialize()
+    advanceUntilIdle()
+
+    // First successfully get a token to make it non-null
+    coEvery { mockInternalAuthProvider.getAccessToken(any()) } returns taskForToken(accessToken)
+    dataConnectAuth.getToken(requestId)
+    dataConnectAuth.token.value.shouldNotBeNull().token shouldBe accessToken
+
+    // Now simulate getAccessToken failing with FirebaseNoSignedInUserException
+    coEvery { mockInternalAuthProvider.getAccessToken(any()) } returns
+      Tasks.forException(FirebaseNoSignedInUserException("signed-out"))
+
+    dataConnectAuth.getToken(requestId)
+    dataConnectAuth.token.value.shouldBeNull()
+  }
+
+  @Test
+  fun `token should update when IdTokenListener fires`() = runTest {
+    checkAll(propTestConfig, Arb.list(Arb.dataConnect.authTokenResult(), 2..5)) { authTokens ->
+      val idTokenListenerSlot = slot<IdTokenListener>()
+      every { mockInternalAuthProvider.addIdTokenListener(capture(idTokenListenerSlot)) } returns
+        Unit
+      val expectedAuthTokens = mockInternalAuthProvider.setAnswers(authTokens)
+
+      val dataConnectAuth = newDataConnectAuth()
+      dataConnectAuth.initialize()
+      advanceUntilIdle()
+      val listener = idTokenListenerSlot.captured
+
+      dataConnectAuth.token.test {
+        awaitItem().shouldBeNull()
+
+        expectedAuthTokens.forEach { expectedAuthToken ->
+          val oldToken = dataConnectAuth.token.value
+
+          listener.onIdTokenChanged(mockk())
+
+          if (expectedAuthToken != oldToken) {
+            awaitItem() shouldBe expectedAuthToken
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `token should update when getToken() is called`() = runTest {
+    checkAll(propTestConfig, Arb.list(Arb.dataConnect.authTokenResult(), 2..5)) { authTokens ->
+      val idTokenListenerSlot = slot<IdTokenListener>()
+      every { mockInternalAuthProvider.addIdTokenListener(capture(idTokenListenerSlot)) } just runs
+      val expectedAuthTokens = mockInternalAuthProvider.setAnswers(authTokens)
+
+      val dataConnectAuth = newDataConnectAuth()
+      dataConnectAuth.initialize()
+      dataConnectAuth.awaitTokenProvider()
+
+      dataConnectAuth.token.test {
+        awaitItem().shouldBeNull()
+
+        expectedAuthTokens.forEach { expectedAuthToken ->
+          val oldToken = dataConnectAuth.token.value
+
+          dataConnectAuth.getToken("x6bzaxb4k9")
+
+          if (expectedAuthToken != oldToken) {
+            awaitItem() shouldBe expectedAuthToken
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `token should remain unchanged when closed`() = runTest {
+    checkAll(propTestConfig, Arb.list(Arb.dataConnect.authTokenResult(), 0..3)) { authTokens ->
+      val dataConnectAuth = newDataConnectAuth()
+      dataConnectAuth.initialize()
+      dataConnectAuth.awaitTokenProvider()
+
+      val authTokensIterator = authTokens.iterator()
+      every { mockInternalAuthProvider.getAccessToken(any()) } answers
+        {
+          val authToken = synchronized(authTokensIterator) { authTokensIterator.next() }
+          taskForToken(authToken.token, authToken.authUid)
+        }
+
+      repeat(authTokens.size) { dataConnectAuth.getToken(requestId) }
+
+      check(dataConnectAuth.token.value == authTokens.lastOrNull())
+      dataConnectAuth.close()
+      dataConnectAuth.token.value shouldBe authTokens.lastOrNull()
+    }
+  }
+
   private fun TestScope.newDataConnectAuth(
     deferredInternalAuthProvider: DeferredInternalAuthProvider =
       ImmediateDeferred(mockInternalAuthProvider),
@@ -657,8 +787,42 @@ class DataConnectAuthUnitTest {
       duration = 2.seconds
       interval = 100.milliseconds
     }
-
-    fun taskForToken(token: String?, claims: Map<String, Any> = emptyMap()): Task<GetTokenResult> =
-      Tasks.forResult(GetTokenResult(token, claims))
   }
+}
+
+@OptIn(ExperimentalKotest::class)
+private val propTestConfig =
+  PropTestConfig(
+    iterations = 20,
+    edgeConfig = EdgeConfig(edgecasesGenerationProbability = 0.2),
+    shrinkingMode = ShrinkingMode.Off,
+  )
+
+private fun taskForToken(
+  token: String?,
+  claims: Map<String, Any> = emptyMap()
+): Task<GetTokenResult> = Tasks.forResult(GetTokenResult(token, claims))
+
+private fun taskForToken(token: String?, authUid: AuthUid?): Task<GetTokenResult> =
+  taskForToken(token, authUid?.let { mapOf("sub" to it.string) } ?: emptyMap())
+
+private fun InternalAuthProvider.setAnswers(
+  answers: List<GetAuthTokenResult>
+): List<GetAuthTokenResult?> {
+  val expectedGetTokenReturnValues = mutableListOf<GetAuthTokenResult?>()
+  val iterator = answers.iterator()
+  every { getAccessToken(any()) } answers
+    {
+      val result = synchronized(iterator) { iterator.next() }
+      val (token, authUid) = result
+      if (token == null || authUid == null) {
+        expectedGetTokenReturnValues.add(null)
+        Tasks.forException(FirebaseNoSignedInUserException("dy4xfaqm4z"))
+      } else {
+        expectedGetTokenReturnValues.add(result)
+        taskForToken(token, authUid)
+      }
+    }
+
+  return expectedGetTokenReturnValues.toList()
 }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
@@ -19,6 +19,7 @@ package com.google.firebase.dataconnect.core
 
 import app.cash.turbine.test
 import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.TaskCompletionSource
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.auth.GetTokenResult
 import com.google.firebase.auth.internal.IdTokenListener
@@ -31,11 +32,15 @@ import com.google.firebase.dataconnect.testutil.DataConnectLogLevelRule
 import com.google.firebase.dataconnect.testutil.DelayedDeferred
 import com.google.firebase.dataconnect.testutil.ImmediateDeferred
 import com.google.firebase.dataconnect.testutil.SuspendingCountDownLatch
+import com.google.firebase.dataconnect.testutil.SuspendingFlag
 import com.google.firebase.dataconnect.testutil.UnavailableDeferred
+import com.google.firebase.dataconnect.testutil.awaitUntilItem
 import com.google.firebase.dataconnect.testutil.newBackgroundScopeThatAdvancesLikeForeground
 import com.google.firebase.dataconnect.testutil.newMockLogger
 import com.google.firebase.dataconnect.testutil.property.arbitrary.authTokenResult
+import com.google.firebase.dataconnect.testutil.property.arbitrary.authUid
 import com.google.firebase.dataconnect.testutil.property.arbitrary.dataConnect
+import com.google.firebase.dataconnect.testutil.property.arbitrary.distinctPair
 import com.google.firebase.dataconnect.testutil.shouldContainWithNonAbuttingText
 import com.google.firebase.dataconnect.testutil.shouldContainWithNonAbuttingTextIgnoringCase
 import com.google.firebase.dataconnect.testutil.shouldHaveLoggedAtLeastOneMessageContaining
@@ -43,6 +48,7 @@ import com.google.firebase.dataconnect.testutil.shouldHaveLoggedExactlyOneMessag
 import com.google.firebase.dataconnect.testutil.shouldNotHaveLoggedAnyMessagesContaining
 import com.google.firebase.dataconnect.util.IdStringGenerator
 import com.google.firebase.inject.Deferred.DeferredHandler
+import com.google.firebase.internal.InternalTokenResult
 import com.google.firebase.internal.api.FirebaseNoSignedInUserException
 import io.kotest.assertions.asClue
 import io.kotest.assertions.assertSoftly
@@ -66,8 +72,10 @@ import io.kotest.property.ShrinkingMode
 import io.kotest.property.arbitrary.list
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.next
+import io.kotest.property.arbitrary.orNull
 import io.kotest.property.arbs.products.brand
 import io.kotest.property.checkAll
+import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.confirmVerified
 import io.mockk.every
@@ -767,6 +775,77 @@ class DataConnectAuthUnitTest {
     }
   }
 
+  @Test
+  fun `onTokenChanged() should cancel in-flight getToken() requests and retry`() = runTest {
+    val dataConnectAuth = newDataConnectAuth()
+    val idTokenListener = dataConnectAuth.initializeAndGetIdTokenListener()
+
+    val taskCompletionSource1 = TaskCompletionSource<GetTokenResult>()
+    val finalToken = GetAuthTokenResult("test-token", AuthUid("test-user"))
+    val getAccessTokenCalled = SuspendingFlag()
+    run {
+      val tokenTask = taskForToken(finalToken.token, finalToken.authUid)
+      coEvery { mockInternalAuthProvider.getAccessToken(any()) } coAnswers
+        {
+          val isFirstCall = !getAccessTokenCalled.getAndSet()
+          if (isFirstCall) {
+            taskCompletionSource1.task
+          } else {
+            tokenTask
+          }
+        }
+    }
+
+    val getTokenJob = async { dataConnectAuth.getToken(requestId) }
+    getAccessTokenCalled.await()
+
+    idTokenListener.onIdTokenChanged(mockk(relaxed = true))
+    advanceUntilIdle()
+    taskCompletionSource1.setException(Exception("unhang hung test tv8v7pyf6v"))
+    getTokenJob.await() shouldBe finalToken
+    dataConnectAuth.token.value shouldBe finalToken
+  }
+
+  @Test
+  fun `onTokenChanged() should call getToken() if new token is different`() = runTest {
+    val distinctAuthTokenPairArb =
+      Arb.dataConnect.authToken().orNull(nullProbability = 0.2).distinctPair()
+    checkAll(propTestConfig, distinctAuthTokenPairArb, Arb.dataConnect.authUid()) {
+      (authToken1, authToken2),
+      authUid ->
+      val dataConnectAuth = newDataConnectAuth()
+      val idTokenListener = dataConnectAuth.initializeAndGetIdTokenListener()
+      coEvery { mockInternalAuthProvider.getAccessToken(any()) }
+        .returnsMany(taskForToken(authToken1, authUid), taskForToken(authToken2, authUid))
+      val result1 = dataConnectAuth.getToken(requestId)
+      check(checkNotNull(result1).token == authToken1)
+      idTokenListener.onIdTokenChanged(InternalTokenResult(authToken2))
+
+      dataConnectAuth.token.test { awaitUntilItem { it?.token == authToken2 } }
+      verify(exactly = 2) { mockInternalAuthProvider.getAccessToken(any()) }
+      clearMocks(mockInternalAuthProvider)
+    }
+  }
+
+  @Test
+  fun `onTokenChanged() should NOT call getToken() if new token is the same`() = runTest {
+    checkAll(propTestConfig, Arb.dataConnect.authTokenResult()) { (authToken, authUid) ->
+      val dataConnectAuth = newDataConnectAuth()
+      val idTokenListener = dataConnectAuth.initializeAndGetIdTokenListener()
+      coEvery { mockInternalAuthProvider.getAccessToken(any()) } returns
+        taskForToken(authToken, authUid) andThenThrows
+        Exception("should never get here j23s6c4h33")
+      val result1 = dataConnectAuth.getToken(requestId)
+      check(checkNotNull(result1).token == authToken)
+      idTokenListener.onIdTokenChanged(InternalTokenResult(authToken))
+
+      advanceUntilIdle()
+      dataConnectAuth.token.value?.token shouldBe authToken
+      verify(exactly = 1) { mockInternalAuthProvider.getAccessToken(any()) }
+      clearMocks(mockInternalAuthProvider)
+    }
+  }
+
   private fun TestScope.newDataConnectAuth(
     deferredInternalAuthProvider: DeferredInternalAuthProvider =
       ImmediateDeferred(mockInternalAuthProvider),
@@ -780,6 +859,14 @@ class DataConnectAuthUnitTest {
         StandardTestDispatcher(testScheduler, name = "4jg7adscn6_DataConnectAuth_TestDispatcher"),
       logger = logger
     )
+
+  private suspend fun DataConnectAuth.initializeAndGetIdTokenListener(): IdTokenListener {
+    val idTokenListenerSlot = slot<IdTokenListener>()
+    every { mockInternalAuthProvider.addIdTokenListener(capture(idTokenListenerSlot)) } just runs
+    initialize()
+    awaitTokenProvider()
+    return idTokenListenerSlot.captured
+  }
 
   private companion object {
     val `check every 100 milliseconds for 2 seconds` = eventuallyConfig {

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/SuspendingFlag.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/SuspendingFlag.kt
@@ -19,6 +19,7 @@ package com.google.firebase.dataconnect.testutil
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.getAndUpdate
 
 /** Encapsulates a boolean "flag", allowing coroutines to suspend until the flag is set. */
 class SuspendingFlag {
@@ -56,4 +57,17 @@ class SuspendingFlag {
   fun set() {
     _isSet.value = true
   }
+
+  /**
+   * Sets the flag encapsulated by this [SuspendingFlag], returning the old value.
+   *
+   * @return the value of the flag prior to this call; that is, returns `false` if the flag was not
+   * set and was set by this call, or `true` if the flag was already set and this call had no
+   * effect.
+   *
+   * @see set
+   * @see isSet
+   * @see await
+   */
+  fun getAndSet(): Boolean = _isSet.getAndUpdate { true }
 }


### PR DESCRIPTION
Adds a `token` `StateFlow` to `DataConnectAuth` and `DataConnectAppCheck` to allow clients to observe token changes, and updates unit tests to verify the new flow's behavior.

### Highlights

*   Introduced a public `token` `StateFlow` on `DataConnectAuth` and `DataConnectAppCheck` (via `DataConnectCredentialsTokenManager`) which publishes the latest retrieved token.
*   Updated the credentials token listener implementations to trigger `onTokenChanged()` which forces a refresh and launches a coroutine to fetch the new token.
*   Added comprehensive unit tests in `DataConnectAuthUnitTest.kt` to verify the `token` flow's lifecycle and behavior under various states.

### Changelog

<details>
<summary>View Changelog</summary>

*   **DataConnectAppCheck.kt**: Use a `WeakReference` to the class inside `AppCheckTokenListenerImpl` and trigger `onTokenChanged` on token changes.
*   **DataConnectAuth.kt**: Use a `WeakReference` to the class inside `IdTokenListenerImpl` and trigger `onTokenChanged` on token changes.
*   **DataConnectCredentialsTokenManager.kt**: Introduce a `token` `StateFlow` property publishing token results, update `_token` when tokens are retrieved or cleared (e.g., on signed-out exception), and handle token change events by forcing a refresh and fetching the new token.
*   **DataConnectAuthUnitTest.kt**: Add multiple tests verifying the behavior of the `token` StateFlow under different scenarios (initialization, provider unavailable, token updates, user sign-out, listener triggers, and closed manager).

</details>
