### PR TITLE
dataconnect(fix): refresh auth token during realtime query subscription

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -10,7 +10,7 @@
   refreshed during the lifetime of the connection, avoiding an UNAUTHENTICATED
   error at the expiry of the original Auth token. It also terminates the Flow
   with an exception if the Firebase Auth user changes.
-  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
+  ([#8278](https://github.com/firebase/firebase-android-sdk/pull/8278))
 
 # 17.3.0
 

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -6,6 +6,11 @@
 - [changed] Realtime query results now update the local cache as query
   results are received.
   ([#8220](https://github.com/firebase/firebase-android-sdk/pull/8220))
+- [fixed] Realtime query subscriptions now update the Firebase Auth token if it
+  refreshed during the lifetime of the connection, avoiding an UNAUTHENTICATED
+  error at the expiry of the original Auth token. It also terminates the Flow
+  with an exception if the Firebase Auth user changes.
+  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
 
 # 17.3.0
 

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/DataConnectGrpcRPCsConnectIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/DataConnectGrpcRPCsConnectIntegrationTest.kt
@@ -29,6 +29,8 @@ import com.google.firebase.dataconnect.testutil.schemas.RealtimeConnector.GetStr
 import com.google.firebase.dataconnect.util.IdStringGenerator
 import com.google.firebase.dataconnect.util.ProtoUtil.decodeFromStruct
 import com.google.firebase.dataconnect.util.ProtoUtil.encodeToStruct
+import com.google.firebase.dataconnect.util.SequencedReference
+import com.google.firebase.dataconnect.util.SequencedReference.Companion.nextSequenceNumber
 import com.google.protobuf.Struct
 import google.firebase.dataconnect.proto.GraphqlError as GraphqlErrorProto
 import io.kotest.assertions.assertSoftly
@@ -114,8 +116,10 @@ class DataConnectGrpcRPCsConnectIntegrationTest : DataConnectIntegrationTestBase
     connect(
       streamId = streamIdArb.sample(),
       callerSdkType = callerSdkTypeArb.sample(),
-      dataConnectAuth = mockk(relaxed = true) { coEvery { getToken(any()) } returns null },
-      dataConnectAppCheck = mockk(relaxed = true) { coEvery { getToken(any()) } returns null },
+      dataConnectAuth =
+        mockk(relaxed = true) { coEvery { getToken(any()) } answers { null.sequenced() } },
+      dataConnectAppCheck =
+        mockk(relaxed = true) { coEvery { getToken(any()) } answers { null.sequenced() } },
       idStringGenerator = IdStringGenerator(Random.Default),
     )
 }
@@ -147,3 +151,6 @@ private fun Struct.shouldBeGetStringByKeyQueryData(expectedName: String?) {
     data.item.shouldNotBeNull() shouldBe GetStringByKeyQuery.Data.Item(expectedName)
   }
 }
+
+private fun <T> T.sequenced(): SequencedReference<T> =
+  SequencedReference(nextSequenceNumber(), this)

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/DataConnectGrpcRPCsConnectIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/DataConnectGrpcRPCsConnectIntegrationTest.kt
@@ -44,6 +44,8 @@ import io.kotest.property.arbitrary.enum
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.string
 import io.kotest.property.arbitrary.uuid
+import io.mockk.coEvery
+import io.mockk.mockk
 import kotlin.random.Random
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.test.runTest
@@ -112,8 +114,8 @@ class DataConnectGrpcRPCsConnectIntegrationTest : DataConnectIntegrationTestBase
     connect(
       streamId = streamIdArb.sample(),
       callerSdkType = callerSdkTypeArb.sample(),
-      authToken = null,
-      appCheckToken = null,
+      dataConnectAuth = mockk(relaxed = true) { coEvery { getToken(any()) } returns null },
+      dataConnectAppCheck = mockk(relaxed = true) { coEvery { getToken(any()) } returns null },
       idStringGenerator = IdStringGenerator(Random.Default),
     )
 }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -25,7 +25,6 @@ import com.google.firebase.dataconnect.util.GrpcBidiFlow
 import com.google.firebase.dataconnect.util.IdStringGenerator
 import com.google.firebase.dataconnect.util.ProtoUtil.toCompactString
 import com.google.firebase.dataconnect.util.SequencedReference
-import com.google.firebase.dataconnect.util.SequencedReference.Companion.asNonNullRefOrNull
 import com.google.firebase.dataconnect.util.coroutines.ConflatedSignal
 import com.google.firebase.dataconnect.util.update
 import com.google.protobuf.Empty as EmptyProto
@@ -458,10 +457,7 @@ private fun mergeGrpcAndAuth(
 ): Flow<GrpcAuthMergedFlowEvent> =
   mergeColdAndHotFlow(
     coldFlow = grpcBidiFlow.map(GrpcAuthMergedFlowEvent::Grpc),
-    hotFlow =
-      dataConnectAuth.token.mapNotNull {
-        it.asNonNullRefOrNull()?.let(GrpcAuthMergedFlowEvent::Auth)
-      }
+    hotFlow = dataConnectAuth.token.map(GrpcAuthMergedFlowEvent::Auth)
   )
 
 private sealed interface GrpcAuthMergedFlowEvent {
@@ -477,7 +473,7 @@ private sealed interface GrpcAuthMergedFlowEvent {
   }
 
   @JvmInline
-  value class Auth(val event: SequencedReference<GetAuthTokenResult>) : GrpcAuthMergedFlowEvent {
+  value class Auth(val event: SequencedReference<GetAuthTokenResult?>) : GrpcAuthMergedFlowEvent {
     override fun toString() = "Auth($event)"
   }
 
@@ -571,7 +567,7 @@ private class ConnectionStateUpdater(private val idStringGenerator: IdStringGene
 
   private fun processAuthEvent(
     currentState: SubscriptionEvent.Connection,
-    sequencedAuthToken: SequencedReference<GetAuthTokenResult>,
+    sequencedAuthToken: SequencedReference<GetAuthTokenResult?>,
   ): SubscriptionEvent.Connection? =
     when (currentState) {
       is SubscriptionEvent.Connected -> processAuthEvent(currentState, sequencedAuthToken)
@@ -580,14 +576,14 @@ private class ConnectionStateUpdater(private val idStringGenerator: IdStringGene
 
   private fun processAuthEvent(
     currentState: SubscriptionEvent.Connected,
-    sequencedAuthToken: SequencedReference<GetAuthTokenResult>,
+    sequencedAuthToken: SequencedReference<GetAuthTokenResult?>,
   ): SubscriptionEvent.Connected? {
     if (sequencedAuthToken.sequenceNumber <= currentState.authToken.sequenceNumber) {
       return null // ignore outdated auth token changes
     }
 
     val oldToken = currentState.authToken.ref?.token
-    val newToken = sequencedAuthToken.ref.token
+    val newToken = sequencedAuthToken.ref?.token
     if (oldToken == newToken) {
       return null // Do not re-send the same token, as that is wasteful.
     }
@@ -596,7 +592,7 @@ private class ConnectionStateUpdater(private val idStringGenerator: IdStringGene
     // The caller will need to re-subscribe with the new authUid as the connection stream does
     // not support changing authUid mid-stream.
     val currentAuthUid = currentState.authToken.ref?.authUid
-    val newAuthUid = sequencedAuthToken.ref.authUid
+    val newAuthUid = sequencedAuthToken.ref?.authUid
     if (currentAuthUid != newAuthUid) {
       throw AuthUidChangedException(currentAuthUid, newAuthUid)
     }
@@ -614,7 +610,7 @@ private class ConnectionStateUpdater(private val idStringGenerator: IdStringGene
 
   private fun processAuthEvent(
     currentState: SubscriptionEvent.Disconnected,
-    sequencedAuthToken: SequencedReference<GetAuthTokenResult>,
+    sequencedAuthToken: SequencedReference<GetAuthTokenResult?>,
   ): SubscriptionEvent.Disconnected? =
     if (
       currentState.pendingAuthToken != null &&
@@ -649,7 +645,7 @@ private class ConnectionStateUpdater(private val idStringGenerator: IdStringGene
       is SubscriptionEvent.Connected -> currentState
       is SubscriptionEvent.Disconnected -> {
         val connectedState = SubscriptionEvent.Connected(event)
-        val pendingAuthToken = currentState.pendingAuthToken?.asNonNullRefOrNull()
+        val pendingAuthToken = currentState.pendingAuthToken
         if (pendingAuthToken == null) {
           connectedState
         } else {

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -20,6 +20,7 @@ import com.google.firebase.dataconnect.core.DataConnectAuth.AuthUid
 import com.google.firebase.dataconnect.core.DataConnectAuth.GetAuthTokenResult
 import com.google.firebase.dataconnect.core.LoggerGlobals.debug
 import com.google.firebase.dataconnect.util.CoroutineUtils.completedFlow
+import com.google.firebase.dataconnect.util.CoroutineUtils.mergeColdAndHotFlow
 import com.google.firebase.dataconnect.util.GrpcBidiFlow
 import com.google.firebase.dataconnect.util.IdStringGenerator
 import com.google.firebase.dataconnect.util.ProtoUtil.toCompactString
@@ -54,7 +55,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onCompletion
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
@@ -96,24 +96,30 @@ internal class DataConnectBidiConnectStream(
 
   private val connectionFlow: Flow<SubscriptionEvent> = run {
     val connectionStateFlow =
-      MutableStateFlow<SubscriptionEvent.Connection>(SubscriptionEvent.Disconnected)
+      MutableStateFlow<SubscriptionEvent.Connection>(
+        SubscriptionEvent.Disconnected(pendingAuthToken = null)
+      )
+    val connectionStateUpdater = ConnectionStateUpdater(idStringGenerator)
 
     val sharedFlow =
-      flow
-        .onEach { event ->
-          if (event is GrpcBidiFlow.Event.ConnectionInfo) {
-            connectionStateFlow.value = SubscriptionEvent.Connected(event)
-          }
-        }
-        .mapNotNull {
-          when (it) {
-            is GrpcBidiFlow.Event.ConnectionInfo -> null
-            is GrpcBidiFlow.Event.Message -> it
+      mergeGrpcAndAuth(flow, dataConnectAuth)
+        .mapNotNull { event ->
+          with(connectionStateUpdater) { connectionStateFlow.update(event) }
+          when (event) {
+            is GrpcAuthMergedFlowEvent.Auth,
+            GrpcAuthMergedFlowEvent.Disconnect -> null
+            is GrpcAuthMergedFlowEvent.Grpc ->
+              when (event.event) {
+                is GrpcBidiFlow.Event.ConnectionInfo -> null
+                is GrpcBidiFlow.Event.Message -> event.event
+              }
           }
         }
         .map(SubscriptionEvent::Message)
         .onCompletion { throwable ->
-          connectionStateFlow.value = SubscriptionEvent.Disconnected
+          with(connectionStateUpdater) {
+            connectionStateFlow.update(GrpcAuthMergedFlowEvent.Disconnect)
+          }
           throw throwable ?: Exception("to be handled by retryWhen")
         }
         .retryWhen { _, attempt ->
@@ -279,44 +285,6 @@ internal class DataConnectBidiConnectStream(
     val extensions: List<DataConnectPropertiesProto>,
   )
 
-  private sealed interface SubscriptionEvent {
-
-    class Message(
-      val connectionId: String,
-      val authUid: AuthUid?,
-      val message: StreamResponseProto,
-    ) : SubscriptionEvent {
-      constructor(
-        event:
-          GrpcBidiFlow.Event.Message<StreamResponseProto, SequencedReference<GetAuthTokenResult?>>
-      ) : this(event.connectionId, event.connectionCookie.ref?.authUid, event.message)
-      override fun toString() =
-        "Message(connectionId=$connectionId, authUid=$authUid, " +
-          "message=${message.toCompactString()})"
-    }
-
-    sealed interface Connection : SubscriptionEvent
-
-    class Connected(
-      val connectionId: String,
-      val authUid: AuthUid?,
-      val outgoingRequests: SendChannel<StreamRequestProto>,
-    ) : Connection {
-      constructor(
-        event:
-          GrpcBidiFlow.Event.ConnectionInfo<
-            StreamRequestProto, SequencedReference<GetAuthTokenResult?>
-          >
-      ) : this(event.connectionId, event.connectionCookie.ref?.authUid, event.outgoingRequests)
-
-      override fun toString() = "Connected(connectionId=$connectionId)"
-    }
-
-    object Disconnected : Connection {
-      override fun toString() = "Disconnected"
-    }
-  }
-
   private fun Flow<SubscriptionEvent>.transformToMessage(
     requestId: String,
     operationName: String,
@@ -365,23 +333,6 @@ internal class DataConnectBidiConnectStream(
     cancelRequest: StreamRequestProto,
   ): Flow<SubscriptionEvent.Message> {
 
-    fun SendChannel<StreamRequestProto>.trySendOrThrow(
-      authUid: AuthUid?,
-      request: StreamRequestProto
-    ) {
-      val sendResult = trySend(request)
-      sendResult.onFailure { exception ->
-        if (!sendResult.isClosed) {
-          throw exception
-            ?: error(
-              "internal error gt2ms5wwby: outgoingRequests.trySend() failed, " +
-                "but should have succeeded because outgoingRequests is created " +
-                "with capacity=UNLIMITED (request=${request.toCompactString(authUid)})"
-            )
-        }
-      }
-    }
-
     suspend fun SendChannel<StreamRequestProto>.subscribeOrResumeLoop(
       authUid: AuthUid?,
       subscribeOrResumeSignal: ConflatedSignal,
@@ -424,7 +375,10 @@ internal class DataConnectBidiConnectStream(
         }
         val subscribeOrResumeJob =
           coroutineScope.launch(start = CoroutineStart.LAZY) {
-            event.outgoingRequests.subscribeOrResumeLoop(event.authUid, subscribeOrResumeSignal)
+            event.outgoingRequests.subscribeOrResumeLoop(
+              event.authToken.ref?.authUid,
+              subscribeOrResumeSignal,
+            )
           }
 
         val newState =
@@ -491,7 +445,7 @@ internal class DataConnectBidiConnectStream(
   }
 }
 
-private fun merge(
+private fun mergeGrpcAndAuth(
   grpcBidiFlow:
     Flow<
       GrpcBidiFlow.Event<
@@ -500,11 +454,12 @@ private fun merge(
     >,
   dataConnectAuth: DataConnectAuth,
 ): Flow<GrpcAuthMergedFlowEvent> =
-  merge(
-    grpcBidiFlow.map(GrpcAuthMergedFlowEvent::Grpc),
-    dataConnectAuth.token.mapNotNull { sequencedReference ->
-      sequencedReference.asNonNullRefOrNull()?.let(GrpcAuthMergedFlowEvent::Auth)
-    }
+  mergeColdAndHotFlow(
+    coldFlow = grpcBidiFlow.map(GrpcAuthMergedFlowEvent::Grpc),
+    hotFlow =
+      dataConnectAuth.token.mapNotNull {
+        it.asNonNullRefOrNull()?.let(GrpcAuthMergedFlowEvent::Auth)
+      }
   )
 
 private sealed interface GrpcAuthMergedFlowEvent {
@@ -515,17 +470,214 @@ private sealed interface GrpcAuthMergedFlowEvent {
       GrpcBidiFlow.Event<
         StreamRequestProto, StreamResponseProto, SequencedReference<GetAuthTokenResult?>
       >
-  ) : GrpcAuthMergedFlowEvent
+  ) : GrpcAuthMergedFlowEvent {
+    override fun toString() = "Grpc($event)"
+  }
 
   @JvmInline
-  value class Auth(val event: SequencedReference<GetAuthTokenResult>) : GrpcAuthMergedFlowEvent
+  value class Auth(val event: SequencedReference<GetAuthTokenResult>) : GrpcAuthMergedFlowEvent {
+    override fun toString() = "Auth($event)"
+  }
+
+  object Disconnect : GrpcAuthMergedFlowEvent {
+    override fun toString() = "Disconnect"
+  }
 }
 
-private fun authTokenStreamRequest(
-  idStringGenerator: IdStringGenerator,
-  authToken: String
-): StreamRequestProto =
-  StreamRequestProto.newBuilder()
-    .setRequestId(idStringGenerator.next("auth"))
-    .putHeaders("x-firebase-auth-token", authToken)
-    .build()
+private sealed interface SubscriptionEvent {
+
+  class Message(
+    val connectionId: String,
+    val authUid: AuthUid?,
+    val message: StreamResponseProto,
+  ) : SubscriptionEvent {
+    constructor(
+      event:
+        GrpcBidiFlow.Event.Message<StreamResponseProto, SequencedReference<GetAuthTokenResult?>>
+    ) : this(event.connectionId, event.connectionCookie.ref?.authUid, event.message)
+    override fun toString() =
+      "Message(connectionId=$connectionId, authUid=$authUid, " +
+        "message=${message.toCompactString()})"
+  }
+
+  sealed interface Connection : SubscriptionEvent
+
+  class Connected(
+    val connectionId: String,
+    val authToken: SequencedReference<GetAuthTokenResult?>,
+    val outgoingRequests: SendChannel<StreamRequestProto>,
+  ) : Connection {
+    constructor(
+      event:
+        GrpcBidiFlow.Event.ConnectionInfo<
+          StreamRequestProto, SequencedReference<GetAuthTokenResult?>
+        >
+    ) : this(event.connectionId, event.connectionCookie, event.outgoingRequests)
+
+    fun withAuthToken(authToken: SequencedReference<GetAuthTokenResult?>) =
+      Connected(
+        connectionId = connectionId,
+        authToken = authToken,
+        outgoingRequests = outgoingRequests,
+      )
+
+    override fun toString() = "Connected(connectionId=$connectionId, authToken=$authToken)"
+  }
+
+  class Disconnected(
+    val pendingAuthToken: SequencedReference<GetAuthTokenResult?>? = null,
+  ) : Connection {
+    override fun toString() = "Disconnected(pendingAuthToken=$pendingAuthToken)"
+  }
+}
+
+private class ConnectionStateUpdater(private val idStringGenerator: IdStringGenerator) {
+
+  fun MutableStateFlow<SubscriptionEvent.Connection>.update(event: GrpcAuthMergedFlowEvent) {
+    update(this, event)
+  }
+
+  @JvmName("updateSubscriptionEventConnectionMutableStateFlow")
+  private fun update(
+    state: MutableStateFlow<SubscriptionEvent.Connection>,
+    event: GrpcAuthMergedFlowEvent,
+  ) {
+    val currentState = state.value
+    val newState = processGrpcAuthMergedFlowEvent(currentState, event) ?: return
+    val updateSuccessful = state.compareAndSet(currentState, newState)
+
+    check(updateSuccessful) {
+      "internal error qen6873hdf: compareAndSet($currentState, $newState) returned false, " +
+        "but expected it to return true because the state should not be updated concurrently"
+    }
+  }
+
+  private fun processGrpcAuthMergedFlowEvent(
+    currentState: SubscriptionEvent.Connection,
+    event: GrpcAuthMergedFlowEvent,
+  ): SubscriptionEvent.Connection? =
+    when (event) {
+      is GrpcAuthMergedFlowEvent.Auth -> processAuthEvent(currentState, event.event)
+      is GrpcAuthMergedFlowEvent.Grpc -> processGrpcEvent(currentState, event.event)
+      is GrpcAuthMergedFlowEvent.Disconnect ->
+        when (currentState) {
+          is SubscriptionEvent.Connected ->
+            SubscriptionEvent.Disconnected(pendingAuthToken = currentState.authToken)
+          is SubscriptionEvent.Disconnected -> currentState
+        }
+    }
+
+  private fun processAuthEvent(
+    currentState: SubscriptionEvent.Connection,
+    sequencedAuthToken: SequencedReference<GetAuthTokenResult>,
+  ): SubscriptionEvent.Connection? =
+    when (currentState) {
+      is SubscriptionEvent.Connected -> processAuthEvent(currentState, sequencedAuthToken)
+      is SubscriptionEvent.Disconnected -> processAuthEvent(currentState, sequencedAuthToken)
+    }
+
+  private fun processAuthEvent(
+    currentState: SubscriptionEvent.Connected,
+    sequencedAuthToken: SequencedReference<GetAuthTokenResult>,
+  ): SubscriptionEvent.Connected? {
+    if (sequencedAuthToken.sequenceNumber <= currentState.authToken.sequenceNumber) {
+      return null // ignore outdated auth token changes
+    }
+
+    val oldToken = currentState.authToken.ref?.token
+    val newToken = sequencedAuthToken.ref.token
+    if (oldToken == newToken) {
+      return null // Do not re-send the same token, as that is wasteful.
+    }
+
+    // Verify that the authUid has not changed; if so, then throw to abort the connection.
+    // The caller will need to re-subscribe with the new authUid as the connection stream does
+    // not support changing authUid mid-stream.
+    val currentAuthUid = currentState.authToken.ref?.authUid
+    val newAuthUid = sequencedAuthToken.ref.authUid
+    if (currentAuthUid != newAuthUid) {
+      throw AuthUidChangedException(currentAuthUid, newAuthUid)
+    }
+
+    if (newToken == null) {
+      return null // Do not send an empty token, as that is wasteful too.
+    }
+
+    // Update the authToken on the stream.
+    val streamRequest = authTokenUpdateStreamRequest(newToken)
+    currentState.outgoingRequests.trySendOrThrow(newAuthUid, streamRequest)
+
+    return currentState.withAuthToken(sequencedAuthToken)
+  }
+
+  private fun processAuthEvent(
+    currentState: SubscriptionEvent.Disconnected,
+    sequencedAuthToken: SequencedReference<GetAuthTokenResult>,
+  ): SubscriptionEvent.Disconnected? =
+    if (
+      currentState.pendingAuthToken != null &&
+        sequencedAuthToken.sequenceNumber <= currentState.pendingAuthToken.sequenceNumber
+    ) {
+      null // ignore outdated auth token changes
+    } else {
+      // TODO: consider if we should throw here also if authUid has changed. Probably?
+      SubscriptionEvent.Disconnected(pendingAuthToken = sequencedAuthToken)
+    }
+
+  private fun processGrpcEvent(
+    currentState: SubscriptionEvent.Connection,
+    event:
+      GrpcBidiFlow.Event<
+        StreamRequestProto, StreamResponseProto, SequencedReference<GetAuthTokenResult?>
+      >,
+  ): SubscriptionEvent.Connected? =
+    when (event) {
+      is GrpcBidiFlow.Event.Message -> null
+      is GrpcBidiFlow.Event.ConnectionInfo -> processGrpcConnectionEvent(currentState, event)
+    }
+
+  private fun processGrpcConnectionEvent(
+    currentState: SubscriptionEvent.Connection,
+    event:
+      GrpcBidiFlow.Event.ConnectionInfo<
+        StreamRequestProto, SequencedReference<GetAuthTokenResult?>
+      >,
+  ): SubscriptionEvent.Connected? =
+    when (currentState) {
+      is SubscriptionEvent.Connected -> currentState
+      is SubscriptionEvent.Disconnected -> {
+        val connectedState = SubscriptionEvent.Connected(event)
+        val pendingAuthToken = currentState.pendingAuthToken?.asNonNullRefOrNull()
+        if (pendingAuthToken == null) {
+          connectedState
+        } else {
+          // Update the auth token on the stream in the rare case that a new auth token was provided
+          // between stream connection and receiving the "connected" event.
+          processAuthEvent(connectedState, pendingAuthToken)
+        }
+      }
+    }
+
+  private fun authTokenUpdateStreamRequest(authToken: String): StreamRequestProto =
+    StreamRequestProto.newBuilder()
+      .setRequestId(idStringGenerator.next("auth"))
+      .putHeaders("x-firebase-auth-token", authToken)
+      .build()
+}
+
+private fun SendChannel<StreamRequestProto>.trySendOrThrow(
+  authUid: AuthUid?,
+  request: StreamRequestProto
+) {
+  val sendResult = trySend(request)
+  sendResult.onFailure { exception ->
+    if (!sendResult.isClosed) {
+      throw exception
+        ?: error(
+          "internal error gt2ms5wwby: outgoingRequests.trySend() failed, " +
+            "but should have succeeded because outgoingRequests is created " +
+            "with capacity=UNLIMITED (request=${request.toCompactString(authUid)})"
+        )
+    }
+  }
+}

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -393,6 +393,8 @@ internal class DataConnectBidiConnectStream(
             subscribeOrResumeJob.start()
           }
           break
+        } else {
+          subscribeOrResumeJob.cancel("state update failed")
         }
       }
     }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -73,7 +73,12 @@ import kotlinx.coroutines.launch
  * @param coroutineScope The [CoroutineScope] to whose lifetime this object belongs.
  */
 internal class DataConnectBidiConnectStream(
-  flow: Flow<GrpcBidiFlow.Event<StreamRequestProto, StreamResponseProto, AuthUid?>>,
+  flow:
+    Flow<
+      GrpcBidiFlow.Event<
+        StreamRequestProto, StreamResponseProto, DataConnectAuth.GetAuthTokenResult?
+      >
+    >,
   private val coroutineScope: CoroutineScope,
   private val logger: Logger,
 ) {
@@ -287,8 +292,9 @@ internal class DataConnectBidiConnectStream(
       val outgoingRequests: SendChannel<StreamRequestProto>,
     ) : Connection {
       constructor(
-        event: GrpcBidiFlow.Event.ConnectionInfo<StreamRequestProto, AuthUid?>
-      ) : this(event.connectionId, event.connectionCookie, event.outgoingRequests)
+        event:
+          GrpcBidiFlow.Event.ConnectionInfo<StreamRequestProto, DataConnectAuth.GetAuthTokenResult?>
+      ) : this(event.connectionId, event.connectionCookie?.authUid, event.outgoingRequests)
 
       override fun toString() = "Connected(connectionId=$connectionId)"
     }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -17,10 +17,12 @@
 package com.google.firebase.dataconnect.core
 
 import com.google.firebase.dataconnect.core.DataConnectAuth.AuthUid
+import com.google.firebase.dataconnect.core.DataConnectAuth.GetAuthTokenResult
 import com.google.firebase.dataconnect.core.LoggerGlobals.debug
 import com.google.firebase.dataconnect.util.CoroutineUtils.completedFlow
 import com.google.firebase.dataconnect.util.GrpcBidiFlow
 import com.google.firebase.dataconnect.util.ProtoUtil.toCompactString
+import com.google.firebase.dataconnect.util.SequencedReference
 import com.google.firebase.dataconnect.util.coroutines.ConflatedSignal
 import com.google.firebase.dataconnect.util.update
 import com.google.protobuf.Empty as EmptyProto
@@ -76,7 +78,7 @@ internal class DataConnectBidiConnectStream(
   flow:
     Flow<
       GrpcBidiFlow.Event<
-        StreamRequestProto, StreamResponseProto, DataConnectAuth.GetAuthTokenResult?
+        StreamRequestProto, StreamResponseProto, SequencedReference<GetAuthTokenResult>?
       >
     >,
   private val coroutineScope: CoroutineScope,
@@ -293,8 +295,10 @@ internal class DataConnectBidiConnectStream(
     ) : Connection {
       constructor(
         event:
-          GrpcBidiFlow.Event.ConnectionInfo<StreamRequestProto, DataConnectAuth.GetAuthTokenResult?>
-      ) : this(event.connectionId, event.connectionCookie?.authUid, event.outgoingRequests)
+          GrpcBidiFlow.Event.ConnectionInfo<
+            StreamRequestProto, SequencedReference<GetAuthTokenResult>?
+          >
+      ) : this(event.connectionId, event.connectionCookie?.ref?.authUid, event.outgoingRequests)
 
       override fun toString() = "Connected(connectionId=$connectionId)"
     }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -653,7 +653,7 @@ private class ConnectionStateUpdater(private val idStringGenerator: IdStringGene
         } else {
           // Update the auth token on the stream in the rare case that a new auth token was provided
           // between stream connection and receiving the "connected" event.
-          processAuthEvent(connectedState, pendingAuthToken)
+          processAuthEvent(connectedState, pendingAuthToken) ?: connectedState
         }
       }
     }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -122,8 +122,8 @@ internal class DataConnectBidiConnectStream(
           }
           throw throwable ?: Exception("to be handled by retryWhen")
         }
-        .retryWhen { _, attempt ->
-          if (attempt > 2) {
+        .retryWhen { cause, attempt ->
+          if (cause is AuthUidChangedException || attempt > 2) {
             false
           } else {
             delay(1.seconds)

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -21,8 +21,10 @@ import com.google.firebase.dataconnect.core.DataConnectAuth.GetAuthTokenResult
 import com.google.firebase.dataconnect.core.LoggerGlobals.debug
 import com.google.firebase.dataconnect.util.CoroutineUtils.completedFlow
 import com.google.firebase.dataconnect.util.GrpcBidiFlow
+import com.google.firebase.dataconnect.util.IdStringGenerator
 import com.google.firebase.dataconnect.util.ProtoUtil.toCompactString
 import com.google.firebase.dataconnect.util.SequencedReference
+import com.google.firebase.dataconnect.util.SequencedReference.Companion.asNonNullRefOrNull
 import com.google.firebase.dataconnect.util.coroutines.ConflatedSignal
 import com.google.firebase.dataconnect.util.update
 import com.google.protobuf.Empty as EmptyProto
@@ -48,7 +50,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.merge
@@ -78,9 +79,11 @@ internal class DataConnectBidiConnectStream(
   flow:
     Flow<
       GrpcBidiFlow.Event<
-        StreamRequestProto, StreamResponseProto, SequencedReference<GetAuthTokenResult>?
+        StreamRequestProto, StreamResponseProto, SequencedReference<GetAuthTokenResult?>
       >
     >,
+  dataConnectAuth: DataConnectAuth,
+  idStringGenerator: IdStringGenerator,
   private val coroutineScope: CoroutineScope,
   private val logger: Logger,
 ) {
@@ -102,7 +105,12 @@ internal class DataConnectBidiConnectStream(
             connectionStateFlow.value = SubscriptionEvent.Connected(event)
           }
         }
-        .filterIsInstance<GrpcBidiFlow.Event.Message<StreamResponseProto, AuthUid?>>()
+        .mapNotNull {
+          when (it) {
+            is GrpcBidiFlow.Event.ConnectionInfo -> null
+            is GrpcBidiFlow.Event.Message -> it
+          }
+        }
         .map(SubscriptionEvent::Message)
         .onCompletion { throwable ->
           connectionStateFlow.value = SubscriptionEvent.Disconnected
@@ -279,8 +287,9 @@ internal class DataConnectBidiConnectStream(
       val message: StreamResponseProto,
     ) : SubscriptionEvent {
       constructor(
-        event: GrpcBidiFlow.Event.Message<StreamResponseProto, AuthUid?>
-      ) : this(event.connectionId, event.connectionCookie, event.message)
+        event:
+          GrpcBidiFlow.Event.Message<StreamResponseProto, SequencedReference<GetAuthTokenResult?>>
+      ) : this(event.connectionId, event.connectionCookie.ref?.authUid, event.message)
       override fun toString() =
         "Message(connectionId=$connectionId, authUid=$authUid, " +
           "message=${message.toCompactString()})"
@@ -296,9 +305,9 @@ internal class DataConnectBidiConnectStream(
       constructor(
         event:
           GrpcBidiFlow.Event.ConnectionInfo<
-            StreamRequestProto, SequencedReference<GetAuthTokenResult>?
+            StreamRequestProto, SequencedReference<GetAuthTokenResult?>
           >
-      ) : this(event.connectionId, event.connectionCookie?.ref?.authUid, event.outgoingRequests)
+      ) : this(event.connectionId, event.connectionCookie.ref?.authUid, event.outgoingRequests)
 
       override fun toString() = "Connected(connectionId=$connectionId)"
     }
@@ -481,3 +490,42 @@ internal class DataConnectBidiConnectStream(
       }
   }
 }
+
+private fun merge(
+  grpcBidiFlow:
+    Flow<
+      GrpcBidiFlow.Event<
+        StreamRequestProto, StreamResponseProto, SequencedReference<GetAuthTokenResult?>
+      >
+    >,
+  dataConnectAuth: DataConnectAuth,
+): Flow<GrpcAuthMergedFlowEvent> =
+  merge(
+    grpcBidiFlow.map(GrpcAuthMergedFlowEvent::Grpc),
+    dataConnectAuth.token.mapNotNull { sequencedReference ->
+      sequencedReference.asNonNullRefOrNull()?.let(GrpcAuthMergedFlowEvent::Auth)
+    }
+  )
+
+private sealed interface GrpcAuthMergedFlowEvent {
+
+  @JvmInline
+  value class Grpc(
+    val event:
+      GrpcBidiFlow.Event<
+        StreamRequestProto, StreamResponseProto, SequencedReference<GetAuthTokenResult?>
+      >
+  ) : GrpcAuthMergedFlowEvent
+
+  @JvmInline
+  value class Auth(val event: SequencedReference<GetAuthTokenResult>) : GrpcAuthMergedFlowEvent
+}
+
+private fun authTokenStreamRequest(
+  idStringGenerator: IdStringGenerator,
+  authToken: String
+): StreamRequestProto =
+  StreamRequestProto.newBuilder()
+    .setRequestId(idStringGenerator.next("auth"))
+    .putHeaders("x-firebase-auth-token", authToken)
+    .build()

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectCredentialsTokenManager.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectCredentialsTokenManager.kt
@@ -112,7 +112,7 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
   /** The current state of this object. */
   private val state = MutableStateFlow<State<T, R>>(State.New)
 
-  private val _token = MutableStateFlow<SequencedReference<R>?>(null)
+  private val _token = MutableStateFlow(SequencedReference<R?>(nextSequenceNumber(), null))
 
   /**
    * The last token returned from [getToken]
@@ -121,7 +121,7 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
    *
    * After [close] the value of this flow is _not_ cleared, and will remain unchanged indefinitely.
    */
-  val token: StateFlow<SequencedReference<R>?> = _token.asStateFlow()
+  val token: StateFlow<SequencedReference<R?>> = _token.asStateFlow()
 
   /**
    * Adds the token listener to the given provider.
@@ -302,7 +302,7 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
    * @throws DataConnectException if [close] has been called or is called while the operation is in
    * progress.
    */
-  suspend fun getToken(requestId: String): SequencedReference<R>? {
+  suspend fun getToken(requestId: String): SequencedReference<R?> {
     val invocationId = idStringGenerator.next("gat")
     logger.debug { "$invocationId getToken(requestId=$requestId)" }
     while (true) {
@@ -324,7 +324,7 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
             logger.debug {
               "$invocationId getToken() returns null (token provider is not (yet?) available)"
             }
-            return null
+            return SequencedReference(attemptSequenceNumber, null)
           }
           is State.Idle -> {
             newActiveState(invocationId, oldState.provider, oldState.forceTokenRefresh)
@@ -358,38 +358,47 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
       // coroutine that called getToken(), not from the calling coroutine being cancelled.
       currentCoroutineContext().ensureActive()
 
-      val sequencedResult = jobResult.getOrNull()
-      if (sequencedResult !== null && sequencedResult.sequenceNumber < attemptSequenceNumber) {
+      val jobSequenceNumber = jobResult.getOrNull()?.sequenceNumber
+      if (jobSequenceNumber != null && jobSequenceNumber < attemptSequenceNumber) {
         logger.debug { "$invocationId getToken() got an old result; retrying" }
         continue
       }
 
-      val exception = jobResult.exceptionOrNull() ?: jobResult.getOrNull()?.ref?.exceptionOrNull()
-      if (exception !== null) {
-        val retryException = exception.getRetryIndicator()
-        if (retryException !== null) {
+      val exception1 = jobResult.exceptionOrNull() ?: jobResult.getOrThrow().ref.exceptionOrNull()
+      if (exception1 != null) {
+        val retryException = exception1.getRetryIndicator()
+        if (retryException != null) {
           logger.debug { "$invocationId getToken() retrying due to ${retryException.message}" }
           continue
-        } else if (exception is FirebaseNoSignedInUserException) {
-          logger.debug {
-            "$invocationId getToken() returns null (FirebaseAuth reports no signed-in user)"
-          }
-          _token.value = null
-          return null
-        } else if (exception is CancellationException) {
-          logger.warn(exception) {
-            "$invocationId getToken() throws GetTokenCancelledException," +
+        } else if (exception1 is CancellationException) {
+          logger.warn(exception1) {
+            "$invocationId getToken() throws CancellationException," +
               " likely due to DataConnectCredentialsTokenManager.close() being called"
           }
-          throw GetTokenCancelledException(exception)
-        } else {
-          logger.warn(exception) { "$invocationId getToken() failed unexpectedly: $exception" }
-          throw exception
+          throw GetTokenCancelledException(exception1)
         }
       }
 
-      val tokenResult: R = sequencedResult!!.ref.getOrThrow()
-      logger.debug { "$invocationId getToken() returns $tokenResult" }
+      val sequencedResult: SequencedReference<Result<R>> = jobResult.getOrThrow()
+      val tokenResult: R? =
+        sequencedResult.ref.fold(
+          onSuccess = { tokenResult ->
+            logger.debug { "$invocationId getToken() returns $tokenResult" }
+            tokenResult
+          },
+          onFailure = { exception ->
+            if (exception is FirebaseNoSignedInUserException) {
+              logger.debug {
+                "$invocationId getToken() returns null (FirebaseAuth reports no signed-in user)"
+              }
+              null
+            } else {
+              logger.warn(exception) { "$invocationId getToken() failed unexpectedly: $exception" }
+              throw exception
+            }
+          }
+        )
+
       val sequencedTokenResult = SequencedReference(sequencedResult.sequenceNumber, tokenResult)
       _token.value = sequencedTokenResult
       return sequencedTokenResult
@@ -441,7 +450,7 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
   }
 
   protected fun onTokenChanged(newToken: String?) {
-    if (token.value?.ref?.token == newToken) {
+    if (token.value.ref?.token == newToken) {
       return
     }
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectCredentialsTokenManager.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectCredentialsTokenManager.kt
@@ -27,6 +27,7 @@ import com.google.firebase.dataconnect.core.LoggerGlobals.warn
 import com.google.firebase.dataconnect.util.CoroutineUtils.createChildSupervisorScope
 import com.google.firebase.dataconnect.util.IdStringGenerator
 import com.google.firebase.dataconnect.util.SequencedReference
+import com.google.firebase.dataconnect.util.SequencedReference.Companion.maxOfBySequenceNumber
 import com.google.firebase.dataconnect.util.SequencedReference.Companion.nextSequenceNumber
 import com.google.firebase.inject.Deferred.DeferredHandler
 import com.google.firebase.inject.Provider
@@ -49,6 +50,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
 
 /** Base class that shares logic for managing the Auth token and AppCheck token. */
@@ -400,8 +402,8 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
         )
 
       val sequencedTokenResult = SequencedReference(sequencedResult.sequenceNumber, tokenResult)
-      _token.value = sequencedTokenResult
-      return sequencedTokenResult
+
+      return _token.updateAndGet { current -> maxOfBySequenceNumber(current, sequencedTokenResult) }
     }
   }
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectCredentialsTokenManager.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectCredentialsTokenManager.kt
@@ -112,7 +112,7 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
   /** The current state of this object. */
   private val state = MutableStateFlow<State<T, R>>(State.New)
 
-  private val _token = MutableStateFlow<R?>(null)
+  private val _token = MutableStateFlow<SequencedReference<R>?>(null)
 
   /**
    * The last token returned from [getToken]
@@ -121,7 +121,7 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
    *
    * After [close] the value of this flow is _not_ cleared, and will remain unchanged indefinitely.
    */
-  val token: StateFlow<R?> = _token.asStateFlow()
+  val token: StateFlow<SequencedReference<R>?> = _token.asStateFlow()
 
   /**
    * Adds the token listener to the given provider.
@@ -302,7 +302,7 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
    * @throws DataConnectException if [close] has been called or is called while the operation is in
    * progress.
    */
-  suspend fun getToken(requestId: String): R? {
+  suspend fun getToken(requestId: String): SequencedReference<R>? {
     val invocationId = idStringGenerator.next("gat")
     logger.debug { "$invocationId getToken(requestId=$requestId)" }
     while (true) {
@@ -390,8 +390,9 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
 
       val tokenResult: R = sequencedResult!!.ref.getOrThrow()
       logger.debug { "$invocationId getToken() returns $tokenResult" }
-      _token.value = tokenResult
-      return tokenResult
+      val sequencedTokenResult = SequencedReference(sequencedResult.sequenceNumber, tokenResult)
+      _token.value = sequencedTokenResult
+      return sequencedTokenResult
     }
   }
 
@@ -440,7 +441,7 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
   }
 
   protected fun onTokenChanged(newToken: String?) {
-    if (token.value?.token == newToken) {
+    if (token.value?.ref?.token == newToken) {
       return
     }
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClient.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClient.kt
@@ -111,8 +111,8 @@ internal class DataConnectGrpcClient(
     kotlinMethodName: String,
     block: T.(GetAuthTokenResult?, GetAppCheckTokenResult?) -> R,
   ): R {
-    val authToken1 = dataConnectAuth.getToken(requestId)?.ref
-    val appCheckToken1 = dataConnectAppCheck.getToken(requestId)?.ref
+    val authToken1 = dataConnectAuth.getToken(requestId).ref
+    val appCheckToken1 = dataConnectAppCheck.getToken(requestId).ref
 
     return try {
       block(authToken1, appCheckToken1)
@@ -130,8 +130,8 @@ internal class DataConnectGrpcClient(
       dataConnectAuth.forceRefresh()
       dataConnectAppCheck.forceRefresh()
 
-      val authToken2 = dataConnectAuth.getToken(requestId)?.ref
-      val appCheckToken2 = dataConnectAppCheck.getToken(requestId)?.ref
+      val authToken2 = dataConnectAuth.getToken(requestId).ref
+      val appCheckToken2 = dataConnectAppCheck.getToken(requestId).ref
 
       block(authToken2, appCheckToken2)
     }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClient.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClient.kt
@@ -111,8 +111,8 @@ internal class DataConnectGrpcClient(
     kotlinMethodName: String,
     block: T.(GetAuthTokenResult?, GetAppCheckTokenResult?) -> R,
   ): R {
-    val authToken1 = dataConnectAuth.getToken(requestId)
-    val appCheckToken1 = dataConnectAppCheck.getToken(requestId)
+    val authToken1 = dataConnectAuth.getToken(requestId)?.ref
+    val appCheckToken1 = dataConnectAppCheck.getToken(requestId)?.ref
 
     return try {
       block(authToken1, appCheckToken1)
@@ -130,8 +130,8 @@ internal class DataConnectGrpcClient(
       dataConnectAuth.forceRefresh()
       dataConnectAppCheck.forceRefresh()
 
-      val authToken2 = dataConnectAuth.getToken(requestId)
-      val appCheckToken2 = dataConnectAppCheck.getToken(requestId)
+      val authToken2 = dataConnectAuth.getToken(requestId)?.ref
+      val appCheckToken2 = dataConnectAppCheck.getToken(requestId)?.ref
 
       block(authToken2, appCheckToken2)
     }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClient.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClient.kt
@@ -98,15 +98,13 @@ internal class DataConnectGrpcClient(
     callerSdkType: FirebaseDataConnect.CallerSdkType,
     idStringGenerator: IdStringGenerator,
   ): DataConnectBidiConnectStream =
-    grpcRPCs.retryOnGrpcUnauthenticatedError(requestId, "connect") { authToken, appCheckToken ->
-      connect(
-        requestId,
-        callerSdkType,
-        authToken,
-        appCheckToken,
-        idStringGenerator,
-      )
-    }
+    grpcRPCs.connect(
+      requestId,
+      callerSdkType,
+      dataConnectAuth,
+      dataConnectAppCheck,
+      idStringGenerator,
+    )
 
   private suspend inline fun <T, R> T.retryOnGrpcUnauthenticatedError(
     requestId: String,

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -74,6 +74,7 @@ import io.grpc.android.AndroidChannelBuilder
 import java.lang.System.currentTimeMillis
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asExecutor
@@ -375,7 +376,8 @@ internal class DataConnectGrpcRPCs(
     dataConnectAppCheck: DataConnectAppCheck,
     idStringGenerator: IdStringGenerator,
   ): DataConnectBidiConnectStream {
-    val connectionAuthUid = dataConnectAuth.getToken(streamId).ref?.authUid
+    val initialAuthToken = AtomicReference(dataConnectAuth.getToken(streamId))
+    val connectionAuthUid = initialAuthToken.get().ref?.authUid
 
     val initRequest =
       StreamRequest.newBuilder().setRequestId("init").setName(connectorResourceName).build()
@@ -393,7 +395,7 @@ internal class DataConnectGrpcRPCs(
     val createHeaders:
       suspend (String) -> GrpcBidiFlow.HeadersResult<SequencedReference<GetAuthTokenResult?>> =
       {
-        val authToken = dataConnectAuth.getToken(streamId)
+        val authToken = initialAuthToken.getAndSet(null) ?: dataConnectAuth.getToken(streamId)
         val authUid = authToken.ref?.authUid
         if (authUid != connectionAuthUid) {
           throw AuthUidChangedException(connectionAuthUid, authUid)
@@ -812,5 +814,5 @@ internal fun List<DataConnectProperties>.getEntityIdForPathFunction(): GetEntity
   return ::getEntityIdForPathFunction
 }
 
-internal class AuthUidChangedException(oldAuthUid: AuthUid?, newAuthUid: AuthUid?) :
-  DataConnectException("Firebase Auth UID changed from $oldAuthUid to $newAuthUid")
+internal class AuthUidChangedException(currentAuthUid: AuthUid?, newAuthUid: AuthUid?) :
+  DataConnectException("Firebase Auth UID changed from $currentAuthUid to $newAuthUid")

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -26,6 +26,7 @@ import com.google.firebase.dataconnect.DataConnectPathSegment
 import com.google.firebase.dataconnect.FirebaseDataConnect
 import com.google.firebase.dataconnect.QueryRef.FetchPolicy
 import com.google.firebase.dataconnect.core.DataConnectAuth.AuthUid
+import com.google.firebase.dataconnect.core.DataConnectAuth.GetAuthTokenResult
 import com.google.firebase.dataconnect.core.DataConnectGrpcMetadata.Companion.toStructProto
 import com.google.firebase.dataconnect.core.LoggerGlobals.Logger
 import com.google.firebase.dataconnect.core.LoggerGlobals.debug
@@ -41,6 +42,7 @@ import com.google.firebase.dataconnect.util.ProtoUtil.buildStructProto
 import com.google.firebase.dataconnect.util.ProtoUtil.toCompactString
 import com.google.firebase.dataconnect.util.ProtoUtil.toDataConnectPath
 import com.google.firebase.dataconnect.util.ProtoUtil.toStructProto
+import com.google.firebase.dataconnect.util.SequencedReference
 import com.google.firebase.dataconnect.util.SuspendingLazy
 import com.google.firebase.dataconnect.util.copy
 import com.google.protobuf.Struct
@@ -152,7 +154,7 @@ internal class DataConnectGrpcRPCs(
     operationName: String,
     variables: Struct,
     callerSdkType: FirebaseDataConnect.CallerSdkType,
-    authToken: DataConnectAuth.GetAuthTokenResult?,
+    authToken: GetAuthTokenResult?,
     appCheckToken: DataConnectAppCheck.GetAppCheckTokenResult?,
   ): ExecuteMutationResponse {
     val metadata = grpcMetadata.get(authToken, appCheckToken, callerSdkType)
@@ -217,7 +219,7 @@ internal class DataConnectGrpcRPCs(
   )
 
   private suspend fun DataConnectCache.queryCacheInfo(
-    authToken: DataConnectAuth.GetAuthTokenResult?,
+    authToken: GetAuthTokenResult?,
     request: ExecuteQueryRequest,
   ): QueryCacheInfo {
     val queryId =
@@ -233,7 +235,7 @@ internal class DataConnectGrpcRPCs(
     variables: Struct,
     callerSdkType: FirebaseDataConnect.CallerSdkType,
     fetchPolicy: FetchPolicy,
-    authToken: DataConnectAuth.GetAuthTokenResult?,
+    authToken: GetAuthTokenResult?,
     appCheckToken: DataConnectAppCheck.GetAppCheckTokenResult?,
   ): SqliteSequencedReference<ExecuteQueryResult> {
     val metadata = grpcMetadata.get(authToken, appCheckToken, callerSdkType)
@@ -373,7 +375,7 @@ internal class DataConnectGrpcRPCs(
     dataConnectAppCheck: DataConnectAppCheck,
     idStringGenerator: IdStringGenerator,
   ): DataConnectBidiConnectStream {
-    val authUid = dataConnectAuth.getToken(streamId)?.authUid
+    val authUid = dataConnectAuth.getToken(streamId)?.ref?.authUid
 
     val initRequest =
       StreamRequest.newBuilder().setRequestId("init").setName(connectorResourceName).build()
@@ -389,16 +391,17 @@ internal class DataConnectGrpcRPCs(
       )
 
     val createHeaders:
-      suspend (String) -> GrpcBidiFlow.HeadersResult<DataConnectAuth.GetAuthTokenResult?> =
+      suspend (String) -> GrpcBidiFlow.HeadersResult<SequencedReference<GetAuthTokenResult>?> =
       {
         val authToken = dataConnectAuth.getToken(streamId)
-        if (authToken?.authUid != authUid) {
+        val authTokenAuthUid = authToken?.ref?.authUid
+        if (authTokenAuthUid != authUid) {
           throw AuthUidChangedException(
-            "Firebase Auth UID changed from $authUid to ${authToken?.authUid}"
+            "Firebase Auth UID changed from $authUid to $authTokenAuthUid"
           )
         }
         val appCheckToken = dataConnectAppCheck.getToken(streamId)
-        val metadata = grpcMetadata.get(authToken, appCheckToken, callerSdkType)
+        val metadata = grpcMetadata.get(authToken?.ref, appCheckToken?.ref, callerSdkType)
         GrpcBidiFlow.HeadersResult(metadata, authToken)
       }
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import androidx.annotation.VisibleForTesting
 import com.google.android.gms.security.ProviderInstaller
 import com.google.firebase.dataconnect.CachedDataNotFoundException
+import com.google.firebase.dataconnect.DataConnectException
 import com.google.firebase.dataconnect.DataConnectPath
 import com.google.firebase.dataconnect.DataConnectPathSegment
 import com.google.firebase.dataconnect.FirebaseDataConnect
@@ -368,11 +369,11 @@ internal class DataConnectGrpcRPCs(
   suspend fun connect(
     streamId: String,
     callerSdkType: FirebaseDataConnect.CallerSdkType,
-    authToken: DataConnectAuth.GetAuthTokenResult?,
-    appCheckToken: DataConnectAppCheck.GetAppCheckTokenResult?,
+    dataConnectAuth: DataConnectAuth,
+    dataConnectAppCheck: DataConnectAppCheck,
     idStringGenerator: IdStringGenerator,
   ): DataConnectBidiConnectStream {
-    val metadata = grpcMetadata.get(authToken, appCheckToken, callerSdkType)
+    val authUid = dataConnectAuth.getToken(streamId)?.authUid
 
     val initRequest =
       StreamRequest.newBuilder().setRequestId("init").setName(connectorResourceName).build()
@@ -382,17 +383,31 @@ internal class DataConnectGrpcRPCs(
     val grpcBidiFlowListener =
       ConnectGrpcBidiFlowListener(
         streamId = streamId,
-        authUid = authToken?.authUid,
+        authUid = authUid,
         initRequest = initRequest,
         kotlinMethodName = "connect()",
       )
+
+    val createHeaders:
+      suspend (String) -> GrpcBidiFlow.HeadersResult<DataConnectAuth.GetAuthTokenResult?> =
+      {
+        val authToken = dataConnectAuth.getToken(streamId)
+        if (authToken?.authUid != authUid) {
+          throw AuthUidChangedException(
+            "Firebase Auth UID changed from $authUid to ${authToken?.authUid}"
+          )
+        }
+        val appCheckToken = dataConnectAppCheck.getToken(streamId)
+        val metadata = grpcMetadata.get(authToken, appCheckToken, callerSdkType)
+        GrpcBidiFlow.HeadersResult(metadata, authToken)
+      }
 
     val flow =
       GrpcBidiFlow.create(
         grpcChannel = lazyGrpcChannel.get(),
         method = ConnectorStreamServiceGrpc.getConnectMethod(),
         callOptions = CallOptions.DEFAULT.withExecutor(blockingCoroutineDispatcher.asExecutor()),
-        headers = { GrpcBidiFlow.HeadersResult(metadata, authToken?.authUid) },
+        headers = createHeaders,
         idStringGenerator = idStringGenerator,
         initRequests = listOf(initRequest),
         listener = grpcBidiFlowListener,
@@ -793,3 +808,5 @@ internal fun List<DataConnectProperties>.getEntityIdForPathFunction(): GetEntity
 
   return ::getEntityIdForPathFunction
 }
+
+internal class AuthUidChangedException(message: String) : DataConnectException(message)

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -375,33 +375,31 @@ internal class DataConnectGrpcRPCs(
     dataConnectAppCheck: DataConnectAppCheck,
     idStringGenerator: IdStringGenerator,
   ): DataConnectBidiConnectStream {
-    val authUid = dataConnectAuth.getToken(streamId)?.ref?.authUid
+    val connectionAuthUid = dataConnectAuth.getToken(streamId).ref?.authUid
 
     val initRequest =
       StreamRequest.newBuilder().setRequestId("init").setName(connectorResourceName).build()
 
     // For low-level debugging, swap this `grpcBidiFlowListener` out for
-    // PrintlnGrpcBidiFlowListener(ConnectGrpcBidiFlowListenerFormatter(authToken?.authUid))
+    // PrintlnGrpcBidiFlowListener(ConnectGrpcBidiFlowListenerFormatter(connectionAuthUid))
     val grpcBidiFlowListener =
       ConnectGrpcBidiFlowListener(
         streamId = streamId,
-        authUid = authUid,
+        authUid = connectionAuthUid,
         initRequest = initRequest,
         kotlinMethodName = "connect()",
       )
 
     val createHeaders:
-      suspend (String) -> GrpcBidiFlow.HeadersResult<SequencedReference<GetAuthTokenResult>?> =
+      suspend (String) -> GrpcBidiFlow.HeadersResult<SequencedReference<GetAuthTokenResult?>> =
       {
         val authToken = dataConnectAuth.getToken(streamId)
-        val authTokenAuthUid = authToken?.ref?.authUid
-        if (authTokenAuthUid != authUid) {
-          throw AuthUidChangedException(
-            "Firebase Auth UID changed from $authUid to $authTokenAuthUid"
-          )
+        val authUid = authToken.ref?.authUid
+        if (authUid != connectionAuthUid) {
+          throw AuthUidChangedException(connectionAuthUid, authUid)
         }
         val appCheckToken = dataConnectAppCheck.getToken(streamId)
-        val metadata = grpcMetadata.get(authToken?.ref, appCheckToken?.ref, callerSdkType)
+        val metadata = grpcMetadata.get(authToken.ref, appCheckToken.ref, callerSdkType)
         GrpcBidiFlow.HeadersResult(metadata, authToken)
       }
 
@@ -418,6 +416,8 @@ internal class DataConnectGrpcRPCs(
 
     return DataConnectBidiConnectStream(
       flow,
+      dataConnectAuth,
+      idStringGenerator,
       connectCoroutineScope,
       Logger("DataConnectBidiConnectStream[sid=$streamId]").also {
         it.debug { "created by ${logger.nameWithId}" }
@@ -812,4 +812,5 @@ internal fun List<DataConnectProperties>.getEntityIdForPathFunction(): GetEntity
   return ::getEntityIdForPathFunction
 }
 
-internal class AuthUidChangedException(message: String) : DataConnectException(message)
+internal class AuthUidChangedException(oldAuthUid: AuthUid?, newAuthUid: AuthUid?) :
+  DataConnectException("Firebase Auth UID changed from $oldAuthUid to $newAuthUid")

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/CoroutineUtils.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/CoroutineUtils.kt
@@ -30,7 +30,9 @@ import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.launch
 
 internal object CoroutineUtils {
 
@@ -185,5 +187,31 @@ internal object CoroutineUtils {
       close()
     }
     awaitClose { disposableHandle.dispose() }
+  }
+
+  /**
+   * Merges two flows into a single flow, where the lifecycle and completion of the returned flow is
+   * strictly determined by the completion of [coldFlow].
+   *
+   * Collection of [hotFlow] is started concurrently when the returned flow is collected. When
+   * [coldFlow] completes (either normally or with an exception), the collection of [hotFlow] is
+   * immediately cancelled, and the merged flow completes.
+   *
+   * This is particularly useful when you want to feed updates from a hot, infinite flow (such as
+   * auth token or configuration changes) into an active session represented by a cold flow, and
+   * ensure that all background collection is cleaned up as soon as the session flow terminates.
+   *
+   * @param T The type of elements emitted by the flows.
+   * @param coldFlow The primary flow whose lifecycle dictates the lifetime of the merged flow.
+   * @param hotFlow The secondary flow whose collection is scoped to the collection of [coldFlow].
+   * @return A merged [Flow] emitting elements from both [coldFlow] and [hotFlow].
+   */
+  fun <T> mergeColdAndHotFlow(coldFlow: Flow<T>, hotFlow: Flow<T>): Flow<T> = channelFlow {
+    val hotJob = launch { hotFlow.collect { send(it) } }
+    try {
+      coldFlow.collect { send(it) }
+    } finally {
+      hotJob.cancel()
+    }
   }
 }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/CoroutineUtils.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/CoroutineUtils.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
@@ -33,6 +34,7 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 internal object CoroutineUtils {
 
@@ -215,7 +217,7 @@ internal object CoroutineUtils {
 
       // Delay returning until `hotJob` is completed; otherwise, the Channel will be closed,
       // potentially causing spurious ClosedSendChannelException if `hotJob` calls send().
-      hotJob.join()
+      withContext(NonCancellable) { hotJob.join() }
     }
   }
 }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/CoroutineUtils.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/CoroutineUtils.kt
@@ -212,6 +212,10 @@ internal object CoroutineUtils {
       coldFlow.collect { send(it) }
     } finally {
       hotJob.cancel()
+
+      // Delay returning until `hotJob` is completed; otherwise, the Channel will be closed,
+      // potentially causing spurious ClosedSendChannelException if `hotJob` calls send().
+      hotJob.join()
     }
   }
 }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/GrpcBidiFlow.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/GrpcBidiFlow.kt
@@ -178,7 +178,7 @@ internal object GrpcBidiFlow {
     grpcChannel: GrpcChannel,
     method: MethodDescriptor<RequestT, ResponseT>,
     callOptions: CallOptions,
-    headers: (connectionId: String) -> HeadersResult<ConnectionCookie>,
+    headers: suspend (connectionId: String) -> HeadersResult<ConnectionCookie>,
     idStringGenerator: IdStringGenerator,
     initRequests: Iterable<RequestT> = emptyList(),
     listener: Listener<RequestT, ResponseT>? = null,

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/SequencedReference.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/SequencedReference.kt
@@ -38,6 +38,9 @@ internal data class SequencedReference<out T>(val sequenceNumber: Long, val ref:
     fun <T, U> SequencedReference<T>.map(block: (T) -> U): SequencedReference<U> =
       SequencedReference(sequenceNumber, block(ref))
 
+    fun <T> SequencedReference<T?>.asNonNullRefOrNull(): SequencedReference<T>? =
+      if (ref == null) null else @Suppress("UNCHECKED_CAST") (this as SequencedReference<T>)
+
     suspend fun <T, U> SequencedReference<T>.mapSuspending(
       block: suspend (T) -> U
     ): SequencedReference<U> = SequencedReference(sequenceNumber, block(ref))

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/SequencedReference.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/SequencedReference.kt
@@ -78,5 +78,10 @@ internal data class SequencedReference<out T>(val sequenceNumber: Long, val ref:
           "expected ref to have type ${U::class.qualifiedName}, " +
             "but got ${ref::class.qualifiedName} ($ref)"
         )
+
+    fun <T> maxOfBySequenceNumber(
+      ref1: SequencedReference<T>,
+      ref2: SequencedReference<T>,
+    ): SequencedReference<T> = if (ref1.sequenceNumber >= ref2.sequenceNumber) ref1 else ref2
   }
 }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
@@ -58,6 +58,8 @@ import io.kotest.assertions.nondeterministic.eventuallyConfig
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.withClue
 import io.kotest.common.ExperimentalKotest
+import io.kotest.matchers.collections.shouldBeSorted
+import io.kotest.matchers.collections.shouldBeUnique
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldBeNull
@@ -69,6 +71,7 @@ import io.kotest.property.EdgeConfig
 import io.kotest.property.PropTestConfig
 import io.kotest.property.RandomSource
 import io.kotest.property.ShrinkingMode
+import io.kotest.property.arbitrary.boolean
 import io.kotest.property.arbitrary.list
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.next
@@ -578,6 +581,29 @@ class DataConnectAuthUnitTest {
     verify(exactly = 2) { mockInternalAuthProvider.getAccessToken(false) }
     verify(exactly = 0) { mockInternalAuthProvider.getAccessToken(true) }
     mockLogger.shouldHaveLoggedExactlyOneMessageContaining("got an old result; retrying")
+  }
+
+  @Test
+  fun `getToken() should return increasing sequence numbers`() = runTest {
+    val dataConnectAuth = newDataConnectAuth()
+    dataConnectAuth.initialize()
+    dataConnectAuth.awaitTokenProvider()
+    val authTokens = Arb.dataConnect.authTokenResult().let { arb -> List(5) { arb.next(rs) } }
+    coEvery { mockInternalAuthProvider.getAccessToken(any()) } returnsMany
+      authTokens.map { taskForToken(it.token, it.authUid) }
+    val forceRefreshFlags = Arb.boolean().let { arb -> List(authTokens.size) { arb.next(rs) } }
+
+    val results =
+      forceRefreshFlags.map { forceRefresh ->
+        if (forceRefresh) {
+          dataConnectAuth.forceRefresh()
+        }
+        dataConnectAuth.getToken(requestId)
+      }
+
+    val sequenceNumbers = results.mapNotNull { it?.sequenceNumber }
+    sequenceNumbers.shouldBeUnique()
+    sequenceNumbers.shouldBeSorted()
   }
 
   @Test

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
@@ -327,7 +327,7 @@ class DataConnectAuthUnitTest {
 
     val result = dataConnectAuth.getToken(requestId)
 
-    withClue("result=$result") { result.shouldNotBeNull().token shouldBe accessToken }
+    withClue("result=$result") { result.shouldNotBeNull().ref.token shouldBe accessToken }
     mockLogger.shouldHaveLoggedExactlyOneMessageContaining(requestId)
     mockLogger.shouldHaveLoggedExactlyOneMessageContaining(accessToken.toScrubbedAccessToken())
     mockLogger.shouldNotHaveLoggedAnyMessagesContaining(accessToken)
@@ -344,7 +344,7 @@ class DataConnectAuthUnitTest {
 
     val result = dataConnectAuth.getToken(requestId)
 
-    result.shouldNotBeNull().authUid shouldBe AuthUid(uid)
+    result.shouldNotBeNull().ref.authUid shouldBe AuthUid(uid)
   }
 
   @Test
@@ -357,7 +357,7 @@ class DataConnectAuthUnitTest {
 
     val result = dataConnectAuth.getToken(requestId)
 
-    result.shouldNotBeNull().authUid.shouldBeNull()
+    result.shouldNotBeNull().ref.authUid.shouldBeNull()
   }
 
   @Test
@@ -370,7 +370,7 @@ class DataConnectAuthUnitTest {
 
     val result = dataConnectAuth.getToken(requestId)
 
-    result.shouldNotBeNull().authUid.shouldBeNull()
+    result.shouldNotBeNull().ref.authUid.shouldBeNull()
   }
 
   @Test
@@ -426,7 +426,7 @@ class DataConnectAuthUnitTest {
     dataConnectAuth.forceRefresh()
     val result = dataConnectAuth.getToken(requestId)
 
-    withClue("result=$result") { result.shouldNotBeNull().token shouldBe accessToken }
+    withClue("result=$result") { result.shouldNotBeNull().ref.token shouldBe accessToken }
     verify(exactly = 1) { mockInternalAuthProvider.getAccessToken(true) }
     verify(exactly = 0) { mockInternalAuthProvider.getAccessToken(false) }
     mockLogger.shouldHaveLoggedExactlyOneMessageContaining(requestId)
@@ -480,7 +480,7 @@ class DataConnectAuthUnitTest {
         taskForToken(accessTokenGenerator.next().also { tokens.add(it) })
       }
 
-    val results = List(5) { dataConnectAuth.getToken(requestId)?.token }
+    val results = List(5) { dataConnectAuth.getToken(requestId)?.ref?.token }
 
     results shouldContainExactly tokens
   }
@@ -508,7 +508,7 @@ class DataConnectAuthUnitTest {
         }
       }
 
-    val actualTokens = jobs.map { it.await()?.token }
+    val actualTokens = jobs.map { it.await()?.ref?.token }
     actualTokens.forEachIndexed { index, token ->
       withClue("actualTokens[$index]") { tokens shouldContain token }
     }
@@ -542,7 +542,7 @@ class DataConnectAuthUnitTest {
 
     val result = dataConnectAuth.getToken(requestId)
 
-    withClue("result=$result") { result.shouldNotBeNull().token shouldBe tokens.last() }
+    withClue("result=$result") { result.shouldNotBeNull().ref.token shouldBe tokens.last() }
     verify(exactly = 2) { mockInternalAuthProvider.getAccessToken(true) }
     verify(exactly = 1) { mockInternalAuthProvider.getAccessToken(false) }
     mockLogger.shouldHaveLoggedAtLeastOneMessageContaining("retrying due to needs token refresh")
@@ -573,8 +573,8 @@ class DataConnectAuthUnitTest {
     withClue("getTokenJob2.isActive") { getTokenJob2.isActive shouldBe true }
     val result2 = getTokenJob2.await()
 
-    withClue("result1=$result1") { result1.shouldNotBeNull().token shouldBe tokens[0] }
-    withClue("result2=$result2") { result2.shouldNotBeNull().token shouldBe tokens[1] }
+    withClue("result1=$result1") { result1.shouldNotBeNull().ref.token shouldBe tokens[0] }
+    withClue("result2=$result2") { result2.shouldNotBeNull().ref.token shouldBe tokens[1] }
     verify(exactly = 2) { mockInternalAuthProvider.getAccessToken(false) }
     verify(exactly = 0) { mockInternalAuthProvider.getAccessToken(true) }
     mockLogger.shouldHaveLoggedExactlyOneMessageContaining("got an old result; retrying")
@@ -676,7 +676,7 @@ class DataConnectAuthUnitTest {
 
     dataConnectAuth.getToken(requestId)
 
-    dataConnectAuth.token.value.shouldNotBeNull().token shouldBe accessToken
+    dataConnectAuth.token.value.shouldNotBeNull().ref.token shouldBe accessToken
   }
 
   @Test
@@ -688,7 +688,7 @@ class DataConnectAuthUnitTest {
     // First successfully get a token to make it non-null
     coEvery { mockInternalAuthProvider.getAccessToken(any()) } returns taskForToken(accessToken)
     dataConnectAuth.getToken(requestId)
-    dataConnectAuth.token.value.shouldNotBeNull().token shouldBe accessToken
+    dataConnectAuth.token.value.shouldNotBeNull().ref.token shouldBe accessToken
 
     // Now simulate getAccessToken failing with FirebaseNoSignedInUserException
     coEvery { mockInternalAuthProvider.getAccessToken(any()) } returns
@@ -818,10 +818,10 @@ class DataConnectAuthUnitTest {
       coEvery { mockInternalAuthProvider.getAccessToken(any()) }
         .returnsMany(taskForToken(authToken1, authUid), taskForToken(authToken2, authUid))
       val result1 = dataConnectAuth.getToken(requestId)
-      check(checkNotNull(result1).token == authToken1)
+      check(checkNotNull(result1).ref.token == authToken1)
       idTokenListener.onIdTokenChanged(InternalTokenResult(authToken2))
 
-      dataConnectAuth.token.test { awaitUntilItem { it?.token == authToken2 } }
+      dataConnectAuth.token.test { awaitUntilItem { it?.ref?.token == authToken2 } }
       verify(exactly = 2) { mockInternalAuthProvider.getAccessToken(any()) }
       clearMocks(mockInternalAuthProvider)
     }
@@ -836,11 +836,11 @@ class DataConnectAuthUnitTest {
         taskForToken(authToken, authUid) andThenThrows
         Exception("should never get here j23s6c4h33")
       val result1 = dataConnectAuth.getToken(requestId)
-      check(checkNotNull(result1).token == authToken)
+      check(checkNotNull(result1).ref.token == authToken)
       idTokenListener.onIdTokenChanged(InternalTokenResult(authToken))
 
       advanceUntilIdle()
-      dataConnectAuth.token.value?.token shouldBe authToken
+      dataConnectAuth.token.value?.ref?.token shouldBe authToken
       verify(exactly = 1) { mockInternalAuthProvider.getAccessToken(any()) }
       clearMocks(mockInternalAuthProvider)
     }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
@@ -203,7 +203,7 @@ class DataConnectAuthUnitTest {
     exception.message shouldContainWithNonAbuttingTextIgnoringCase "getToken() was cancelled"
     exception.message shouldContainWithNonAbuttingTextIgnoringCase "likely by close()"
     mockLogger.shouldHaveLoggedExactlyOneMessageContaining(requestId)
-    mockLogger.shouldHaveLoggedExactlyOneMessageContaining("throws GetTokenCancelledException")
+    mockLogger.shouldHaveLoggedExactlyOneMessageContaining("throws CancellationException")
   }
 
   @Test
@@ -276,18 +276,21 @@ class DataConnectAuthUnitTest {
   }
 
   @Test
-  fun `getToken() should return null if InternalAuthProvider is not available`() = runTest {
-    val dataConnectAuth = newDataConnectAuth(deferredInternalAuthProvider = UnavailableDeferred())
-    dataConnectAuth.initialize()
-    advanceUntilIdle()
+  fun `getToken() should return a result with ref=null if InternalAuthProvider is not available`() =
+    runTest {
+      val dataConnectAuth = newDataConnectAuth(deferredInternalAuthProvider = UnavailableDeferred())
+      dataConnectAuth.initialize()
+      advanceUntilIdle()
 
-    val result = dataConnectAuth.getToken(requestId)
+      val result = dataConnectAuth.getToken(requestId)
 
-    withClue("result=$result") { result.shouldBeNull() }
-    mockLogger.shouldHaveLoggedExactlyOneMessageContaining(requestId)
-    mockLogger.shouldHaveLoggedExactlyOneMessageContaining("returns null")
-    mockLogger.shouldHaveLoggedExactlyOneMessageContaining("token provider is not (yet?) available")
-  }
+      withClue("result=$result") { result.ref.shouldBeNull() }
+      mockLogger.shouldHaveLoggedExactlyOneMessageContaining(requestId)
+      mockLogger.shouldHaveLoggedExactlyOneMessageContaining("returns null")
+      mockLogger.shouldHaveLoggedExactlyOneMessageContaining(
+        "token provider is not (yet?) available"
+      )
+    }
 
   @Test
   fun `getToken() should throw if invoked after close()`() = runTest {
@@ -306,7 +309,7 @@ class DataConnectAuthUnitTest {
   }
 
   @Test
-  fun `getToken() should return null if no user is signed in`() = runTest {
+  fun `getToken() should return a result with ref=null if no user is signed in`() = runTest {
     val dataConnectAuth = newDataConnectAuth()
     dataConnectAuth.initialize()
     advanceUntilIdle()
@@ -315,7 +318,7 @@ class DataConnectAuthUnitTest {
 
     val result = dataConnectAuth.getToken(requestId)
 
-    withClue("result=$result") { result.shouldBeNull() }
+    withClue("result=$result") { result.ref.shouldBeNull() }
     mockLogger.shouldHaveLoggedExactlyOneMessageContaining(requestId)
     mockLogger.shouldHaveLoggedExactlyOneMessageContaining("returns null")
     mockLogger.shouldHaveLoggedExactlyOneMessageContaining("FirebaseAuth reports no signed-in user")
@@ -330,7 +333,7 @@ class DataConnectAuthUnitTest {
 
     val result = dataConnectAuth.getToken(requestId)
 
-    withClue("result=$result") { result.shouldNotBeNull().ref.token shouldBe accessToken }
+    withClue("result=$result") { result.ref.shouldNotBeNull().token shouldBe accessToken }
     mockLogger.shouldHaveLoggedExactlyOneMessageContaining(requestId)
     mockLogger.shouldHaveLoggedExactlyOneMessageContaining(accessToken.toScrubbedAccessToken())
     mockLogger.shouldNotHaveLoggedAnyMessagesContaining(accessToken)
@@ -347,7 +350,7 @@ class DataConnectAuthUnitTest {
 
     val result = dataConnectAuth.getToken(requestId)
 
-    result.shouldNotBeNull().ref.authUid shouldBe AuthUid(uid)
+    result.ref.shouldNotBeNull().authUid shouldBe AuthUid(uid)
   }
 
   @Test
@@ -360,7 +363,7 @@ class DataConnectAuthUnitTest {
 
     val result = dataConnectAuth.getToken(requestId)
 
-    result.shouldNotBeNull().ref.authUid.shouldBeNull()
+    result.ref.shouldNotBeNull().authUid.shouldBeNull()
   }
 
   @Test
@@ -373,7 +376,7 @@ class DataConnectAuthUnitTest {
 
     val result = dataConnectAuth.getToken(requestId)
 
-    result.shouldNotBeNull().ref.authUid.shouldBeNull()
+    result.ref.shouldNotBeNull().authUid.shouldBeNull()
   }
 
   @Test
@@ -429,7 +432,7 @@ class DataConnectAuthUnitTest {
     dataConnectAuth.forceRefresh()
     val result = dataConnectAuth.getToken(requestId)
 
-    withClue("result=$result") { result.shouldNotBeNull().ref.token shouldBe accessToken }
+    withClue("result=$result") { result.ref.shouldNotBeNull().token shouldBe accessToken }
     verify(exactly = 1) { mockInternalAuthProvider.getAccessToken(true) }
     verify(exactly = 0) { mockInternalAuthProvider.getAccessToken(false) }
     mockLogger.shouldHaveLoggedExactlyOneMessageContaining(requestId)
@@ -483,7 +486,7 @@ class DataConnectAuthUnitTest {
         taskForToken(accessTokenGenerator.next().also { tokens.add(it) })
       }
 
-    val results = List(5) { dataConnectAuth.getToken(requestId)?.ref?.token }
+    val results = List(5) { dataConnectAuth.getToken(requestId).ref?.token }
 
     results shouldContainExactly tokens
   }
@@ -511,7 +514,7 @@ class DataConnectAuthUnitTest {
         }
       }
 
-    val actualTokens = jobs.map { it.await()?.ref?.token }
+    val actualTokens = jobs.map { it.await().ref?.token }
     actualTokens.forEachIndexed { index, token ->
       withClue("actualTokens[$index]") { tokens shouldContain token }
     }
@@ -545,7 +548,7 @@ class DataConnectAuthUnitTest {
 
     val result = dataConnectAuth.getToken(requestId)
 
-    withClue("result=$result") { result.shouldNotBeNull().ref.token shouldBe tokens.last() }
+    withClue("result=$result") { result.ref.shouldNotBeNull().token shouldBe tokens.last() }
     verify(exactly = 2) { mockInternalAuthProvider.getAccessToken(true) }
     verify(exactly = 1) { mockInternalAuthProvider.getAccessToken(false) }
     mockLogger.shouldHaveLoggedAtLeastOneMessageContaining("retrying due to needs token refresh")
@@ -576,8 +579,8 @@ class DataConnectAuthUnitTest {
     withClue("getTokenJob2.isActive") { getTokenJob2.isActive shouldBe true }
     val result2 = getTokenJob2.await()
 
-    withClue("result1=$result1") { result1.shouldNotBeNull().ref.token shouldBe tokens[0] }
-    withClue("result2=$result2") { result2.shouldNotBeNull().ref.token shouldBe tokens[1] }
+    withClue("result1=$result1") { result1.ref.shouldNotBeNull().token shouldBe tokens[0] }
+    withClue("result2=$result2") { result2.ref.shouldNotBeNull().token shouldBe tokens[1] }
     verify(exactly = 2) { mockInternalAuthProvider.getAccessToken(false) }
     verify(exactly = 0) { mockInternalAuthProvider.getAccessToken(true) }
     mockLogger.shouldHaveLoggedExactlyOneMessageContaining("got an old result; retrying")
@@ -601,7 +604,7 @@ class DataConnectAuthUnitTest {
         dataConnectAuth.getToken(requestId)
       }
 
-    val sequenceNumbers = results.mapNotNull { it?.sequenceNumber }
+    val sequenceNumbers = results.map { it.sequenceNumber }
     sequenceNumbers.shouldBeUnique()
     sequenceNumbers.shouldBeSorted()
   }
@@ -622,7 +625,7 @@ class DataConnectAuthUnitTest {
     val result = dataConnectAuth.getToken(requestId)
     dataConnectAuth.close()
 
-    withClue("result=$result") { result.shouldBeNull() }
+    withClue("result=$result") { result.ref.shouldBeNull() }
     mockLogger.shouldHaveLoggedExactlyOneMessageContaining("k6rwgqg9gh", testException)
     mockLogger.shouldHaveLoggedExactlyOneMessageContaining(
       "${dataConnectAuth.instanceId} whenAvailable"
@@ -680,52 +683,42 @@ class DataConnectAuthUnitTest {
     }
 
   @Test
-  fun `token should be initially null`() = runTest {
+  fun `token initially has ref=null`() = runTest {
     val dataConnectAuth = newDataConnectAuth()
-    dataConnectAuth.token.value.shouldBeNull()
+    dataConnectAuth.token.value.ref.shouldBeNull()
   }
 
   @Test
-  fun `token should be null after initialize if provider is not available`() = runTest {
+  fun `token when no InternalAuthProvider has ref=null`() = runTest {
     val dataConnectAuth = newDataConnectAuth(deferredInternalAuthProvider = UnavailableDeferred())
     dataConnectAuth.initialize()
     advanceUntilIdle()
-    dataConnectAuth.token.value.shouldBeNull()
+    dataConnectAuth.token.value.ref.shouldBeNull()
   }
 
   @Test
-  fun `token should update when getToken is called`() = runTest {
+  fun `token when user signs out updates to ref=null`() = runTest {
     val dataConnectAuth = newDataConnectAuth()
     dataConnectAuth.initialize()
     advanceUntilIdle()
-    coEvery { mockInternalAuthProvider.getAccessToken(any()) } returns taskForToken(accessToken)
 
-    dataConnectAuth.getToken(requestId)
-
-    dataConnectAuth.token.value.shouldNotBeNull().ref.token shouldBe accessToken
-  }
-
-  @Test
-  fun `token should update to null when no user is signed in`() = runTest {
-    val dataConnectAuth = newDataConnectAuth()
-    dataConnectAuth.initialize()
-    advanceUntilIdle()
+    coEvery { mockInternalAuthProvider.getAccessToken(any()) }
+      .returnsMany(
+        taskForToken(accessToken),
+        Tasks.forException(FirebaseNoSignedInUserException("signed-out")),
+      )
 
     // First successfully get a token to make it non-null
-    coEvery { mockInternalAuthProvider.getAccessToken(any()) } returns taskForToken(accessToken)
     dataConnectAuth.getToken(requestId)
-    dataConnectAuth.token.value.shouldNotBeNull().ref.token shouldBe accessToken
+    dataConnectAuth.token.value.ref.shouldNotBeNull().token shouldBe accessToken
 
-    // Now simulate getAccessToken failing with FirebaseNoSignedInUserException
-    coEvery { mockInternalAuthProvider.getAccessToken(any()) } returns
-      Tasks.forException(FirebaseNoSignedInUserException("signed-out"))
-
+    // Now simulate getAccessToken() failing with FirebaseNoSignedInUserException
     dataConnectAuth.getToken(requestId)
-    dataConnectAuth.token.value.shouldBeNull()
+    dataConnectAuth.token.value.ref.shouldBeNull()
   }
 
   @Test
-  fun `token should update when IdTokenListener fires`() = runTest {
+  fun `token updates in response to IdTokenListener onIdTokenChanged()`() = runTest {
     checkAll(propTestConfig, Arb.list(Arb.dataConnect.authTokenResult(), 2..5)) { authTokens ->
       val idTokenListenerSlot = slot<IdTokenListener>()
       every { mockInternalAuthProvider.addIdTokenListener(capture(idTokenListenerSlot)) } just runs
@@ -737,15 +730,15 @@ class DataConnectAuthUnitTest {
       val listener = idTokenListenerSlot.captured
 
       dataConnectAuth.token.test {
-        awaitItem().shouldBeNull()
+        awaitItem().ref.shouldBeNull()
 
         expectedAuthTokens.forEach { expectedAuthToken ->
           val oldToken = dataConnectAuth.token.value
 
           listener.onIdTokenChanged(mockk())
 
-          if (expectedAuthToken != oldToken) {
-            awaitItem() shouldBe expectedAuthToken
+          if (expectedAuthToken != oldToken.ref) {
+            awaitItem().ref shouldBe expectedAuthToken
           }
         }
       }
@@ -753,7 +746,7 @@ class DataConnectAuthUnitTest {
   }
 
   @Test
-  fun `token should update when getToken() is called`() = runTest {
+  fun `token updates in response to getToken()`() = runTest {
     checkAll(propTestConfig, Arb.list(Arb.dataConnect.authTokenResult(), 2..5)) { authTokens ->
       val idTokenListenerSlot = slot<IdTokenListener>()
       every { mockInternalAuthProvider.addIdTokenListener(capture(idTokenListenerSlot)) } just runs
@@ -764,15 +757,15 @@ class DataConnectAuthUnitTest {
       dataConnectAuth.awaitTokenProvider()
 
       dataConnectAuth.token.test {
-        awaitItem().shouldBeNull()
+        awaitItem().ref.shouldBeNull()
 
         expectedAuthTokens.forEach { expectedAuthToken ->
           val oldToken = dataConnectAuth.token.value
 
           dataConnectAuth.getToken("x6bzaxb4k9")
 
-          if (expectedAuthToken != oldToken) {
-            awaitItem() shouldBe expectedAuthToken
+          if (expectedAuthToken != oldToken.ref) {
+            awaitItem().ref shouldBe expectedAuthToken
           }
         }
       }
@@ -795,9 +788,10 @@ class DataConnectAuthUnitTest {
 
       repeat(authTokens.size) { dataConnectAuth.getToken(requestId) }
 
-      check(dataConnectAuth.token.value == authTokens.lastOrNull())
+      val tokenBeforeClose = dataConnectAuth.token.value
+      check(tokenBeforeClose.ref == authTokens.lastOrNull())
       dataConnectAuth.close()
-      dataConnectAuth.token.value shouldBe authTokens.lastOrNull()
+      dataConnectAuth.token.value shouldBe tokenBeforeClose
     }
   }
 
@@ -828,8 +822,8 @@ class DataConnectAuthUnitTest {
     idTokenListener.onIdTokenChanged(mockk(relaxed = true))
     advanceUntilIdle()
     taskCompletionSource1.setException(Exception("unhang hung test tv8v7pyf6v"))
-    getTokenJob.await() shouldBe finalToken
-    dataConnectAuth.token.value shouldBe finalToken
+    getTokenJob.await().ref shouldBe finalToken
+    dataConnectAuth.token.value.ref shouldBe finalToken
   }
 
   @Test
@@ -844,10 +838,10 @@ class DataConnectAuthUnitTest {
       coEvery { mockInternalAuthProvider.getAccessToken(any()) }
         .returnsMany(taskForToken(authToken1, authUid), taskForToken(authToken2, authUid))
       val result1 = dataConnectAuth.getToken(requestId)
-      check(checkNotNull(result1).ref.token == authToken1)
+      check(checkNotNull(result1.ref).token == authToken1)
       idTokenListener.onIdTokenChanged(InternalTokenResult(authToken2))
 
-      dataConnectAuth.token.test { awaitUntilItem { it?.ref?.token == authToken2 } }
+      dataConnectAuth.token.test { awaitUntilItem { it.ref?.token == authToken2 } }
       verify(exactly = 2) { mockInternalAuthProvider.getAccessToken(any()) }
       clearMocks(mockInternalAuthProvider)
     }
@@ -862,11 +856,11 @@ class DataConnectAuthUnitTest {
         taskForToken(authToken, authUid) andThenThrows
         Exception("should never get here j23s6c4h33")
       val result1 = dataConnectAuth.getToken(requestId)
-      check(checkNotNull(result1).ref.token == authToken)
+      check(checkNotNull(result1.ref).token == authToken)
       idTokenListener.onIdTokenChanged(InternalTokenResult(authToken))
 
       advanceUntilIdle()
-      dataConnectAuth.token.value?.ref?.token shouldBe authToken
+      dataConnectAuth.token.value.ref?.token shouldBe authToken
       verify(exactly = 1) { mockInternalAuthProvider.getAccessToken(any()) }
       clearMocks(mockInternalAuthProvider)
     }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClientUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClientUnitTest.kt
@@ -855,7 +855,7 @@ private fun DataConnectAuth.stubGetTokensSimulatingForceRefresh(
 ) {
   val tokenIterator = tokens.iterator()
   val currentToken = AtomicReference(tokenIterator.next())
-  coEvery { getToken(any()) } answers { currentToken.getSequenced() }
+  coEvery { getToken(any()) } answers { currentToken.get().sequenced() }
   coEvery { forceRefresh() } answers { currentToken.set(tokenIterator.next()) }
 }
 
@@ -864,7 +864,7 @@ private fun DataConnectAppCheck.stubGetTokensSimulatingForceRefresh(
 ) {
   val tokenIterator = tokens.iterator()
   val currentToken = AtomicReference(tokenIterator.next())
-  coEvery { getToken(any()) } answers { currentToken.getSequenced() }
+  coEvery { getToken(any()) } answers { currentToken.get().sequenced() }
   coEvery { forceRefresh() } answers { currentToken.set(tokenIterator.next()) }
 }
 
@@ -883,12 +883,12 @@ private class TestEnvironment(
 
   val mockDataConnectAuth: DataConnectAuth =
     mockk(relaxed = true, name = "mockDataConnectAuth-cr64w58dm5") {
-      coEvery { getToken(any()) } returns authTokenResult.sequenced()
+      coEvery { getToken(any()) } answers { authTokenResult.sequenced() }
     }
 
   val mockDataConnectAppCheck: DataConnectAppCheck =
     mockk(relaxed = true, name = "mockDataConnectAppCheck-e2mv4tpqsy") {
-      coEvery { getToken(any()) } returns appCheckTokenResult.sequenced()
+      coEvery { getToken(any()) } answers { appCheckTokenResult.sequenced() }
     }
 
   val mockDataConnectGrpcRPCs: DataConnectGrpcRPCs =
@@ -938,8 +938,6 @@ private val defaultExecuteQueryResult =
   )
 
 private val defaultExecuteMutationResult = ExecuteMutationResponse.getDefaultInstance()
-
-private fun <T> AtomicReference<T?>.getSequenced(): SequencedReference<T>? = get()?.sequenced()
 
 private fun <T> T.sequenced(): SequencedReference<T> =
   SequencedReference(nextSequenceNumber(), this)

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClientUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcClientUnitTest.kt
@@ -41,6 +41,8 @@ import com.google.firebase.dataconnect.testutil.property.arbitrary.sqliteSequenc
 import com.google.firebase.dataconnect.testutil.property.arbitrary.struct
 import com.google.firebase.dataconnect.testutil.registerDataConnectKotestPrinters
 import com.google.firebase.dataconnect.testutil.shouldHaveLoggedExactlyOneMessageContaining
+import com.google.firebase.dataconnect.util.SequencedReference
+import com.google.firebase.dataconnect.util.SequencedReference.Companion.nextSequenceNumber
 import google.firebase.dataconnect.proto.ExecuteMutationResponse
 import google.firebase.dataconnect.proto.ExecuteQueryResponse
 import io.grpc.Status
@@ -853,7 +855,7 @@ private fun DataConnectAuth.stubGetTokensSimulatingForceRefresh(
 ) {
   val tokenIterator = tokens.iterator()
   val currentToken = AtomicReference(tokenIterator.next())
-  coEvery { getToken(any()) } answers { currentToken.get() }
+  coEvery { getToken(any()) } answers { currentToken.getSequenced() }
   coEvery { forceRefresh() } answers { currentToken.set(tokenIterator.next()) }
 }
 
@@ -862,7 +864,7 @@ private fun DataConnectAppCheck.stubGetTokensSimulatingForceRefresh(
 ) {
   val tokenIterator = tokens.iterator()
   val currentToken = AtomicReference(tokenIterator.next())
-  coEvery { getToken(any()) } answers { currentToken.get() }
+  coEvery { getToken(any()) } answers { currentToken.getSequenced() }
   coEvery { forceRefresh() } answers { currentToken.set(tokenIterator.next()) }
 }
 
@@ -881,12 +883,12 @@ private class TestEnvironment(
 
   val mockDataConnectAuth: DataConnectAuth =
     mockk(relaxed = true, name = "mockDataConnectAuth-cr64w58dm5") {
-      coEvery { getToken(any()) } returns authTokenResult
+      coEvery { getToken(any()) } returns authTokenResult.sequenced()
     }
 
   val mockDataConnectAppCheck: DataConnectAppCheck =
     mockk(relaxed = true, name = "mockDataConnectAppCheck-e2mv4tpqsy") {
-      coEvery { getToken(any()) } returns appCheckTokenResult
+      coEvery { getToken(any()) } returns appCheckTokenResult.sequenced()
     }
 
   val mockDataConnectGrpcRPCs: DataConnectGrpcRPCs =
@@ -936,3 +938,8 @@ private val defaultExecuteQueryResult =
   )
 
 private val defaultExecuteMutationResult = ExecuteMutationResponse.getDefaultInstance()
+
+private fun <T> AtomicReference<T?>.getSequenced(): SequencedReference<T>? = get()?.sequenced()
+
+private fun <T> T.sequenced(): SequencedReference<T> =
+  SequencedReference(nextSequenceNumber(), this)

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
@@ -51,6 +51,8 @@ import com.google.firebase.dataconnect.testutil.shouldContainWithNonAbuttingText
 import com.google.firebase.dataconnect.testutil.toKotlinDuration
 import com.google.firebase.dataconnect.util.IdStringGenerator
 import com.google.firebase.dataconnect.util.ProtoUtil.toValueProto
+import com.google.firebase.dataconnect.util.SequencedReference
+import com.google.firebase.dataconnect.util.SequencedReference.Companion.nextSequenceNumber
 import com.google.firebase.dataconnect.withAddedListIndex
 import com.google.protobuf.Duration as DurationProto
 import com.google.protobuf.ListValue as ListValueProto
@@ -748,12 +750,12 @@ class DataConnectGrpcRPCsUnitTest {
   private suspend fun DataConnectGrpcRPCs.connect(rs: RandomSource): DataConnectBidiConnectStream {
     val dataConnectAuth: DataConnectAuth = mockk {
       val token = Arb.dataConnect.authTokenResult().orNull(nullProbability = 0.2).next(rs)
-      coEvery { getToken(any()) } returns token
+      coEvery { getToken(any()) } returns token?.sequenced()
     }
 
     val dataConnectAppCheck: DataConnectAppCheck = mockk {
       val token = Arb.dataConnect.appCheckTokenResult().orNull(nullProbability = 0.2).next(rs)
-      coEvery { getToken(any()) } returns token
+      coEvery { getToken(any()) } returns token?.sequenced()
     }
 
     return connect(
@@ -918,3 +920,6 @@ private fun listValueFromPath(path: DataConnectPath): ListValueProto {
   }
   return builder.build()
 }
+
+private fun <T> T.sequenced(): SequencedReference<T> =
+  SequencedReference(nextSequenceNumber(), this)

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
@@ -91,6 +91,8 @@ import io.kotest.property.arbitrary.of
 import io.kotest.property.arbitrary.orNull
 import io.kotest.property.arbitrary.pair
 import io.kotest.property.checkAll
+import io.mockk.coEvery
+import io.mockk.mockk
 import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
@@ -743,14 +745,25 @@ class DataConnectGrpcRPCsUnitTest {
     }
   }
 
-  private suspend fun DataConnectGrpcRPCs.connect(rs: RandomSource) =
-    connect(
+  private suspend fun DataConnectGrpcRPCs.connect(rs: RandomSource): DataConnectBidiConnectStream {
+    val dataConnectAuth: DataConnectAuth = mockk {
+      val token = Arb.dataConnect.authTokenResult().orNull(nullProbability = 0.2).next(rs)
+      coEvery { getToken(any()) } returns token
+    }
+
+    val dataConnectAppCheck: DataConnectAppCheck = mockk {
+      val token = Arb.dataConnect.appCheckTokenResult().orNull(nullProbability = 0.2).next(rs)
+      coEvery { getToken(any()) } returns token
+    }
+
+    return connect(
       streamId = streamIdArb.next(rs),
-      callerSdkType = Arb.enum<CallerSdkType>().next(rs),
-      authToken = Arb.dataConnect.authTokenResult().orNull(nullProbability = 0.2).next(rs),
-      appCheckToken = Arb.dataConnect.appCheckTokenResult().orNull(nullProbability = 0.2).next(rs),
-      idStringGenerator = IdStringGenerator(Random.Default),
+      Arb.enum<CallerSdkType>().next(rs),
+      dataConnectAuth,
+      dataConnectAppCheck,
+      IdStringGenerator(Random.Default),
     )
+  }
 
   private fun newDbFile() = File(temporaryFolder.newFolder(), "db.sqlite")
 

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
@@ -750,12 +750,12 @@ class DataConnectGrpcRPCsUnitTest {
   private suspend fun DataConnectGrpcRPCs.connect(rs: RandomSource): DataConnectBidiConnectStream {
     val dataConnectAuth: DataConnectAuth = mockk {
       val token = Arb.dataConnect.authTokenResult().orNull(nullProbability = 0.2).next(rs)
-      coEvery { getToken(any()) } returns token?.sequenced()
+      coEvery { getToken(any()) } answers { token.sequenced() }
     }
 
     val dataConnectAppCheck: DataConnectAppCheck = mockk {
       val token = Arb.dataConnect.appCheckTokenResult().orNull(nullProbability = 0.2).next(rs)
-      coEvery { getToken(any()) } returns token?.sequenced()
+      coEvery { getToken(any()) } answers { token.sequenced() }
     }
 
     return connect(

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
@@ -94,6 +94,7 @@ import io.kotest.property.arbitrary.orNull
 import io.kotest.property.arbitrary.pair
 import io.kotest.property.checkAll
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
@@ -101,7 +102,9 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.random.Random
 import kotlin.time.Duration
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Assume.assumeTrue
@@ -748,15 +751,22 @@ class DataConnectGrpcRPCsUnitTest {
   }
 
   private suspend fun DataConnectGrpcRPCs.connect(rs: RandomSource): DataConnectBidiConnectStream {
-    val dataConnectAuth: DataConnectAuth = mockk {
-      val token = Arb.dataConnect.authTokenResult().orNull(nullProbability = 0.2).next(rs)
-      coEvery { getToken(any()) } answers { token.sequenced() }
-    }
+    val dataConnectAuth: DataConnectAuth =
+      mockk(name = "DataConnectAuth@xjk254qsb3") {
+        val authToken = Arb.dataConnect.authTokenResult().orNull(nullProbability = 0.2).next(rs)
+        val authTokenStateFlow = MutableStateFlow(authToken.sequenced())
+        every { token } returns authTokenStateFlow
+        coEvery { getToken(any()) } answers
+          {
+            authTokenStateFlow.updateAndGet { authToken.sequenced() }
+          }
+      }
 
-    val dataConnectAppCheck: DataConnectAppCheck = mockk {
-      val token = Arb.dataConnect.appCheckTokenResult().orNull(nullProbability = 0.2).next(rs)
-      coEvery { getToken(any()) } answers { token.sequenced() }
-    }
+    val dataConnectAppCheck: DataConnectAppCheck =
+      mockk(name = "DataConnectAppCheck@tye4ewtjzz") {
+        val token = Arb.dataConnect.appCheckTokenResult().orNull(nullProbability = 0.2).next(rs)
+        coEvery { getToken(any()) } answers { token.sequenced() }
+      }
 
     return connect(
       streamId = streamIdArb.next(rs),


### PR DESCRIPTION
This PR ensures that realtime Data Connect query subscriptions dynamically update the Firebase Auth token when it refreshes during the lifetime of a connection. This prevents `UNAUTHENTICATED` errors that occur when the original Auth token expires, and terminates the active stream flow if the signed-in user changes.

### Highlights

* **Mid-Stream Auth Updates**: Realtime query streams now process token refresh events and dynamically update the Auth token on the active gRPC connection without reconnecting.
* **Auth User Change Detection**: The query flow is now terminated with an exception if the signed-in user changes during the lifetime of the connection.
* **Out-of-Order Token Prevention**: Switched token management to use sequence numbers via `SequencedReference` to prevent older token refresh calls from overwriting newer tokens.
* **Flow Merging Utility**: Added a `mergeColdAndHotFlow` coroutine utility to couple the lifecycle of hot token updates to cold stream connections.

<details>
<summary><b>Changelog</b></summary>

* **CHANGELOG.md**
  * Added changelog entry for the realtime query subscription auth token refresh bug fix.
* **DataConnectBidiConnectStream.kt**
  * Implemented support for updating the auth token mid-stream without reconnection.
  * Added validation to throw an exception if the authenticated user (`AuthUid`) changes.
  * Added `GrpcAuthMergedFlowEvent` and `SubscriptionEvent` to model and manage merged gRPC and auth events.
* **DataConnectCredentialsTokenManager.kt**
  * Updated `token` flow and `getToken` method signature to return `SequencedReference<R?>` to prevent out-of-order token updates.
* **DataConnectGrpcClient.kt**
  * Updated `DataConnectGrpcRPCs.connect()` call site to pass `DataConnectAuth` and `DataConnectAppCheck` objects.
* **DataConnectGrpcRPCs.kt**
  * Changed `connect()` signature to accept `DataConnectAuth` and `DataConnectAppCheck` providers directly, enabling reactive token lookup.
* **CoroutineUtils.kt**
  * Added `mergeColdAndHotFlow` utility to automatically cancel hot flow collection when the primary cold flow completes.
* **GrpcBidiFlow.kt**
  * Updated connection cookie types to use `SequencedReference`.
* **SequencedReference.kt**
  * Added `asNonNullRefOrNull()` and `maxOfBySequenceNumber()` helpers.
* **DataConnectGrpcRPCsConnectIntegrationTest.kt**
  * Updated connection integration test setup to match the new `connect()` signature.
* **DataConnectAuthUnitTest.kt**
  * Added unit tests to verify sequence number behavior and token update handling.
* **DataConnectGrpcClientUnitTest.kt**
  * Updated mocks to return sequenced token values.
* **DataConnectGrpcRPCsUnitTest.kt**
  * Updated mocks and tests to reflect `connect()` signature changes.
</details>
