### PR TITLE
health-metrics.yml: do not trigger health checks when changes are exclusively to data connect

### DIFF
--- a/.github/workflows/health-metrics.yml
+++ b/.github/workflows/health-metrics.yml
@@ -6,6 +6,11 @@ concurrency:
 
 on:
   pull_request:
+    paths:
+      # Don't trigger health checks on Data Connect since they are not consulted by anyone.
+      - '!.github/workflows/dataconnect.yml'
+      - '!.github/workflows/dataconnect_demo.yml'
+      - '!firebase-dataconnect/**'
   push:
     branches:
       - main


### PR DESCRIPTION
This PR avoids triggering the "Health Checks" github actions for PRs whose changes are limited to Data Connect. As far as I know the "Health Checks" are never consulted by anyone for Data Connect. They also tend to be the most expensive github actions triggered by PRs, especially the "Startup Time" job that takes ~30 minutes.