### PR TITLE
dataconnect(fix): Throw exception when AuthUid changes in realtime query subscriptions instead of silently just going silent

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -11,6 +11,9 @@
   error at the expiry of the original Auth token. It also terminates the Flow
   with an exception if the Firebase Auth user changes.
   ([#8278](https://github.com/firebase/firebase-android-sdk/pull/8278))
+- [fixed] Realtime query subscriptions now correctly throw an exception when
+  the Firebase Auth user changes, instead of silently stopping emitting.
+  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
 
 # 17.3.0
 

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -13,7 +13,7 @@
   ([#8278](https://github.com/firebase/firebase-android-sdk/pull/8278))
 - [fixed] Realtime query subscriptions now correctly throw an exception when
   the Firebase Auth user changes, instead of silently stopping emitting.
-  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
+  ([#8283](https://github.com/firebase/firebase-android-sdk/pull/8283))
 
 # 17.3.0
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -41,14 +41,18 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.onFailure
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
@@ -93,6 +97,17 @@ internal class DataConnectBidiConnectStream(
    */
   private val scopeCompletedFlow = coroutineScope.completedFlow().map { null }
 
+  /**
+   * A flow that emits a [TerminalError] when the connection is permanently failed and an exception
+   * should be thrown by the downstream collectors.
+   */
+  private val _terminalErrorFlow =
+    MutableSharedFlow<TerminalError>(
+      replay = 1,
+      onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+  private val terminalErrorFlow = _terminalErrorFlow.asSharedFlow()
+
   private val connectionFlow: Flow<SubscriptionEvent> = run {
     val connectionStateFlow =
       MutableStateFlow<SubscriptionEvent.Connection>(
@@ -115,6 +130,12 @@ internal class DataConnectBidiConnectStream(
           }
         }
         .map(SubscriptionEvent::Message)
+        .catch { exception ->
+          if (exception is AuthUidChangedException) {
+            _terminalErrorFlow.emit(TerminalError(exception))
+          }
+          throw exception
+        }
         .onCompletion { throwable ->
           with(connectionStateUpdater) {
             connectionStateFlow.update(GrpcAuthMergedFlowEvent.Disconnect)
@@ -204,8 +225,11 @@ internal class DataConnectBidiConnectStream(
         .filter { it.message.requestId == requestId }
         .mapNotNull { it.message.toExecuteResponse(it.authUid) }
 
-    // Configure the returned flow to end gracefully when FirebaseDataConnect.close() is called.
-    return merge(subscriptionFlow, scopeCompletedFlow).transformWhile {
+    // Configure the returned flow to end gracefully when FirebaseDataConnect.close() is called, and
+    // fail if a terminal error occurs.
+    val terminalFlow: Flow<Nothing?> =
+      terminalErrorFlow.transform { error -> throw error.exception }
+    return merge(subscriptionFlow, scopeCompletedFlow, terminalFlow).transformWhile {
       if (it !== null && coroutineScope.isActive) {
         emit(it)
         true
@@ -678,4 +702,8 @@ private fun SendChannel<StreamRequestProto>.trySendOrThrow(
         )
     }
   }
+}
+
+private class TerminalError(val exception: Throwable) {
+  override fun toString() = "TerminalError($exception)"
 }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -91,6 +91,9 @@ internal class DataConnectBidiConnectStream(
   private val logger: Logger,
 ) {
 
+  val isPermanentlyFailedDueToAuthUidChange: Boolean
+    get() = authUidChangedFlow.replayCache.isNotEmpty()
+
   /**
    * A flow that emits `null` when [coroutineScope] is canceled, which happens when
    * [com.google.firebase.dataconnect.FirebaseDataConnect.close] is called.
@@ -98,15 +101,15 @@ internal class DataConnectBidiConnectStream(
   private val scopeCompletedFlow = coroutineScope.completedFlow().map { null }
 
   /**
-   * A flow that emits a [TerminalError] when the connection is permanently failed and an exception
-   * should be thrown by the downstream collectors.
+   * A flow that emits a [AuthUidChangedException] when the connection is permanently failed due to
+   * the Firebase Auth user changing.
    */
-  private val _terminalErrorFlow =
-    MutableSharedFlow<TerminalError>(
+  private val _authUidChangedFlow =
+    MutableSharedFlow<AuthUidChangedException>(
       replay = 1,
       onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
-  private val terminalErrorFlow = _terminalErrorFlow.asSharedFlow()
+  private val authUidChangedFlow = _authUidChangedFlow.asSharedFlow()
 
   private val connectionFlow: Flow<SubscriptionEvent> = run {
     val connectionStateFlow =
@@ -132,7 +135,7 @@ internal class DataConnectBidiConnectStream(
         .map(SubscriptionEvent::Message)
         .catch { exception ->
           if (exception is AuthUidChangedException) {
-            _terminalErrorFlow.emit(TerminalError(exception))
+            _authUidChangedFlow.emit(exception)
           }
           throw exception
         }
@@ -226,17 +229,20 @@ internal class DataConnectBidiConnectStream(
         .mapNotNull { it.message.toExecuteResponse(it.authUid) }
 
     // Configure the returned flow to end gracefully when FirebaseDataConnect.close() is called, and
-    // fail if a terminal error occurs.
-    val terminalFlow: Flow<Nothing?> =
-      terminalErrorFlow.transform { error -> throw error.exception }
-    return merge(subscriptionFlow, scopeCompletedFlow, terminalFlow).transformWhile {
-      if (it !== null && coroutineScope.isActive) {
-        emit(it)
-        true
-      } else {
-        false
+    // fail if the Firebase Auth user changes.
+    return merge(
+        subscriptionFlow,
+        scopeCompletedFlow,
+        authUidChangedFlow.transform { throw it },
+      )
+      .transformWhile {
+        if (it !== null && coroutineScope.isActive) {
+          emit(it)
+          true
+        } else {
+          false
+        }
       }
-    }
   }
 
   private sealed interface MessageOrSubscribe {
@@ -702,8 +708,4 @@ private fun SendChannel<StreamRequestProto>.trySendOrThrow(
         )
     }
   }
-}
-
-private class TerminalError(val exception: Throwable) {
-  override fun toString() = "TerminalError($exception)"
 }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/querymgr/RealtimeQueryManager.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/querymgr/RealtimeQueryManager.kt
@@ -183,7 +183,12 @@ internal class RealtimeQueryManager(
             connectionAttempted = true
           }
         }
-        is State.Connected -> return currentState
+        is State.Connected -> {
+          if (!currentState.stream.isPermanentlyFailedDueToAuthUidChange) {
+            return currentState
+          }
+          state.compareAndSet(currentState, State.Disconnected)
+        }
         State.Closing,
         State.Closed -> return null
       }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthTesting.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthTesting.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.dataconnect.core
+
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.auth.GetTokenResult
+import com.google.firebase.dataconnect.core.DataConnectAuth.AuthUid
+
+internal fun taskForToken(
+  token: String?,
+  claims: Map<String, Any> = emptyMap()
+): Task<GetTokenResult> = Tasks.forResult(GetTokenResult(token, claims))
+
+internal fun taskForToken(token: String?, authUid: AuthUid?): Task<GetTokenResult> =
+  taskForToken(token, authUid?.let { mapOf("sub" to it.string) } ?: emptyMap())

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
@@ -18,7 +18,6 @@
 package com.google.firebase.dataconnect.core
 
 import app.cash.turbine.test
-import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.TaskCompletionSource
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.auth.GetTokenResult
@@ -903,14 +902,6 @@ private val propTestConfig =
     edgeConfig = EdgeConfig(edgecasesGenerationProbability = 0.2),
     shrinkingMode = ShrinkingMode.Off,
   )
-
-private fun taskForToken(
-  token: String?,
-  claims: Map<String, Any> = emptyMap()
-): Task<GetTokenResult> = Tasks.forResult(GetTokenResult(token, claims))
-
-private fun taskForToken(token: String?, authUid: AuthUid?): Task<GetTokenResult> =
-  taskForToken(token, authUid?.let { mapOf("sub" to it.string) } ?: emptyMap())
 
 private fun InternalAuthProvider.setAnswers(
   answers: List<GetAuthTokenResult>

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -21,12 +21,15 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
 import app.cash.turbine.turbineScope
+import com.google.firebase.auth.internal.IdTokenListener
+import com.google.firebase.auth.internal.InternalAuthProvider
 import com.google.firebase.dataconnect.DataConnectSettings
 import com.google.firebase.dataconnect.FirebaseDataConnect.CallerSdkType
 import com.google.firebase.dataconnect.QueryRef
 import com.google.firebase.dataconnect.testutil.CleanupsRule
 import com.google.firebase.dataconnect.testutil.DataConnectLogLevelRule
 import com.google.firebase.dataconnect.testutil.FirebaseAppUnitTestingRule
+import com.google.firebase.dataconnect.testutil.ImmediateDeferred
 import com.google.firebase.dataconnect.testutil.InProcessDataConnectGrpcStreamingServer
 import com.google.firebase.dataconnect.testutil.InProcessDataConnectGrpcStreamingServer.Event.ConnectRpcStarted
 import com.google.firebase.dataconnect.testutil.InProcessDataConnectGrpcStreamingServer.Event.StreamRequestReceived
@@ -43,11 +46,16 @@ import com.google.firebase.dataconnect.testutil.awaitUntilStatusExceptionReceive
 import com.google.firebase.dataconnect.testutil.awaitUntilStreamRequest
 import com.google.firebase.dataconnect.testutil.awaitUntilStreamRequestWithRequestId
 import com.google.firebase.dataconnect.testutil.awaitUntilSubscribeStreamRequest
+import com.google.firebase.dataconnect.testutil.property.arbitrary.authUid
 import com.google.firebase.dataconnect.testutil.property.arbitrary.dataConnect
+import com.google.firebase.dataconnect.testutil.property.arbitrary.distinctPair
 import com.google.firebase.dataconnect.testutil.registerDataConnectKotestPrinters
 import com.google.firebase.dataconnect.testutil.shouldBe
+import com.google.firebase.dataconnect.testutil.shouldContainWithNonAbuttingText
+import com.google.firebase.dataconnect.testutil.shouldContainWithNonAbuttingTextIgnoringCase
 import com.google.firebase.dataconnect.util.IdStringGenerator
 import com.google.firebase.dataconnect.util.ProtoUtil.encodeToStruct
+import com.google.firebase.internal.InternalTokenResult
 import google.firebase.dataconnect.proto.StreamRequest
 import google.firebase.dataconnect.proto.StreamRequest.RequestKindCase
 import google.firebase.dataconnect.proto.StreamResponse
@@ -58,13 +66,17 @@ import io.grpc.stub.StreamObserver
 import io.kotest.assertions.print.print
 import io.kotest.assertions.withClue
 import io.kotest.common.DelicateKotest
+import io.kotest.common.ExperimentalKotest
 import io.kotest.matchers.collections.shouldBeIn
 import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.kotest.property.Arb
+import io.kotest.property.EdgeConfig
+import io.kotest.property.PropTestConfig
 import io.kotest.property.RandomSource
+import io.kotest.property.ShrinkingMode
 import io.kotest.property.arbitrary.Codepoint
 import io.kotest.property.arbitrary.arbitrary
 import io.kotest.property.arbitrary.az
@@ -73,9 +85,15 @@ import io.kotest.property.arbitrary.enum
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.next
+import io.kotest.property.arbitrary.orNull
 import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
+import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
 import io.mockk.spyk
 import kotlin.random.Random
 import kotlinx.coroutines.asExecutor
@@ -531,6 +549,65 @@ class QuerySubscriptionImplUnitTest {
     }
   }
 
+  @Test
+  fun `flow fails with AuthUidChangedException if auth uid changes mid-stream`() = runTest {
+    val server = runningInProcessDataConnectServer()
+
+    checkAll(
+      propTestConfig,
+      Arb.dataConnect.authUid().orNull(nullProbability = 0.3).distinctPair(),
+      Arb.dataConnect.authToken().orNull(nullProbability = 0.3).distinctPair(),
+    ) { (authUid1, authUid2), (authToken1, authToken2) ->
+      check(authUid1 != authUid2)
+      check(authToken1 != authToken2)
+
+      val mockInternalAuthProvider = mockk<InternalAuthProvider>(relaxed = true)
+      val idTokenListenerSlot = slot<IdTokenListener>()
+      every { mockInternalAuthProvider.addIdTokenListener(capture(idTokenListenerSlot)) } just runs
+      val authUidIterator = listOf(authUid1, authUid2).iterator()
+      val authTokenIterator = listOf(authToken1, authToken2).iterator()
+      coEvery { mockInternalAuthProvider.getAccessToken(any()) } answers
+        {
+          val authUid = synchronized(authUidIterator) { authUidIterator.next() }
+          val authToken = synchronized(authTokenIterator) { authTokenIterator.next() }
+          taskForToken(authToken, authUid)
+        }
+
+      val dataConnect =
+        dataConnect(
+          serverLocalBindPort = server.port,
+          deferredAuthProvider = ImmediateDeferred(mockInternalAuthProvider)
+        )
+      try {
+        dataConnect.awaitAuthReady()
+
+        val subscription = querySubscription(dataConnect)
+        turbineScope {
+          val serverCollector = server.events.testIn(backgroundScope, name = "serverCollector")
+          val clientCollector = subscription.flow.testIn(backgroundScope, name = "clientCollector")
+
+          serverCollector.awaitResponseSender()
+          serverCollector.awaitUntilSubscribeStreamRequest()
+
+          // Trigger the auth token update
+          idTokenListenerSlot.captured.onIdTokenChanged(InternalTokenResult(authToken2))
+
+          // The flow should throw AuthUidChangedException and terminate
+          val exception = clientCollector.awaitError()
+          exception.shouldBeInstanceOf<AuthUidChangedException>()
+          exception.message shouldContainWithNonAbuttingTextIgnoringCase "Firebase Auth UID changed"
+          exception.message shouldContainWithNonAbuttingText authUid1.toString()
+          exception.message shouldContainWithNonAbuttingText authUid2.toString()
+
+          serverCollector.cancelAndIgnoreRemainingEvents()
+          clientCollector.cancelAndIgnoreRemainingEvents()
+        }
+      } finally {
+        dataConnect.suspendingClose()
+      }
+    }
+  }
+
   private suspend fun TestScope.testFlowReconnectsUponConnectionClosureWithGrpcFailureStatusCode(
     createException: (Status.Code) -> Throwable
   ) {
@@ -609,11 +686,15 @@ class QuerySubscriptionImplUnitTest {
   private fun TestScope.dataConnect(
     server: InProcessDataConnectGrpcStreamingServer,
     idStringGenerator: IdStringGenerator? = null,
-  ): FirebaseDataConnectImpl = dataConnect(server.port, idStringGenerator)
+    deferredAuthProvider: com.google.firebase.inject.Deferred<InternalAuthProvider> =
+      UnavailableDeferred(),
+  ): FirebaseDataConnectImpl = dataConnect(server.port, idStringGenerator, deferredAuthProvider)
 
   private fun TestScope.dataConnect(
     serverLocalBindPort: Int? = null,
     idStringGenerator: IdStringGenerator? = null,
+    deferredAuthProvider: com.google.firebase.inject.Deferred<InternalAuthProvider> =
+      UnavailableDeferred(),
   ): FirebaseDataConnectImpl {
     val executor = StandardTestDispatcher(testScheduler).asExecutor()
 
@@ -635,7 +716,7 @@ class QuerySubscriptionImplUnitTest {
       config = Arb.dataConnect.connectorConfig().sample(),
       blockingExecutor = executor,
       nonBlockingExecutor = executor,
-      deferredAuthProvider = UnavailableDeferred(),
+      deferredAuthProvider = deferredAuthProvider,
       deferredAppCheckProvider = UnavailableDeferred(),
       creator = mockk(name = "FirebaseDataConnectImpl.creator", relaxed = true),
       settings = settings,
@@ -691,6 +772,14 @@ class QuerySubscriptionImplUnitTest {
 
   private fun <T> Arb<T>.sampleList(size: Int): List<T> = List(size) { sample() }
 }
+
+@OptIn(ExperimentalKotest::class)
+private val propTestConfig =
+  PropTestConfig(
+    iterations = 50,
+    edgeConfig = EdgeConfig(edgecasesGenerationProbability = 0.2),
+    shrinkingMode = ShrinkingMode.Off,
+  )
 
 @Serializable private data class TestVariables(val stringValue: String)
 


### PR DESCRIPTION
This PR resolves a data connect issue where realtime query subscriptions silently stop emitting events when the Firebase Auth user changes mid-stream. It ensures that an `AuthUidChangedException` is propagated downstream to all active subscribers, and that the stream is disconnected so subsequent query subscriptions can establish a new connection.

### Highlights

* **Error Propagation**: Catches `AuthUidChangedException` during connection stream execution and propagates it to all active query subscribers, terminating the flow.
* **Stream Recovery**: Updates the stream manager to reset the connection state if the stream has permanently failed due to an Auth UID change, allowing future requests to recover with a new connection.
* **Improved Test Coverage**: Adds property-based tests verifying that mid-stream Auth user changes correctly terminate active query subscriptions with the expected exception.

<details>
<summary><b>Changelog</b></summary>

* **CHANGELOG.md**
  * Added entry for fixed realtime query subscription behavior on Auth user changes.
* **DataConnectBidiConnectStream.kt**
  * Exposed a property to check if the stream permanently failed due to an Auth UID change.
  * Caught `AuthUidChangedException` during connection execution, emitted it to a shared flow, and merged it with query subscription flows to terminate them.
* **RealtimeQueryManager.kt**
  * Checked if the current stream is permanently failed due to an Auth UID change and, if so, transitioned state back to `Disconnected` to trigger a new connection on next access.
* **DataConnectAuthTesting.kt**
  * Extracted and created shared test token task creation helpers `taskForToken`.
* **DataConnectAuthUnitTest.kt**
  * Removed duplicate test helper functions that were moved to the shared testing utility.
* **QuerySubscriptionImplUnitTest.kt**
  * Added unit test checking that query subscription flow terminates with `AuthUidChangedException` when Auth UID changes mid-stream.
</details>