### PR TITLE
Ignore flakey daily AI Logic test

### DIFF
--- a/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/TemplateIntegrationTests.kt
+++ b/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/TemplateIntegrationTests.kt
@@ -29,6 +29,7 @@ import io.kotest.matchers.string.shouldNotContain
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 
 @OptIn(PublicPreviewAPI::class)
@@ -111,6 +112,7 @@ class TemplateIntegrationTests {
   }
 
   @Test
+  @Ignore("Model is prone to return specifically London instead of New York")
   fun testTemplateGroundingCity_googleAI(): Unit = runBlocking {
     val model =
       FirebaseAI.getInstance(AIModels.app(), GenerativeBackend.googleAI())

--- a/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/TemplateIntegrationTests.kt
+++ b/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/TemplateIntegrationTests.kt
@@ -121,7 +121,7 @@ class TemplateIntegrationTests {
           toolConfig =
             TemplateToolConfig(
               RetrievalConfig(
-                latLng = LatLng(latitude = 30.2672, longitude = -97.7431),
+                latLng = LatLng(latitude = 40.72849, longitude = -74.01054),
                 languageCode = "en_US",
               )
             )


### PR DESCRIPTION
As the comment says, the model is prone to return "London" instead of "New York". This is a reasonable test to keep around to base other tests on in the future, but it's introducing noise into our daily testing so we need to disable it.