### PR TITLE
dataconnect(test): QuerySubscriptionImplUnitTest.kt: add test: `flow fails with AuthUidChangedException if auth uid changes during reconnection`

### DIFF
--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -16,6 +16,7 @@
 
 package com.google.firebase.dataconnect.core
 
+import androidx.annotation.VisibleForTesting
 import com.google.firebase.dataconnect.core.DataConnectAuth.AuthUid
 import com.google.firebase.dataconnect.core.DataConnectAuth.GetAuthTokenResult
 import com.google.firebase.dataconnect.core.LoggerGlobals.debug
@@ -151,6 +152,7 @@ internal class DataConnectBidiConnectStream(
           } else {
             delay(1.seconds)
             logger.debug { "retrying connection" }
+            onRetryForTesting.get()?.invoke()
             true
           }
         }
@@ -458,9 +460,35 @@ internal class DataConnectBidiConnectStream(
     }
   }
 
-  private companion object {
+  companion object {
 
-    fun StreamResponseProto.toExecuteResponse(authUid: AuthUid?): ExecuteResponse? =
+    private val onRetryForTesting = AtomicReference<() -> Unit>(null)
+
+    @VisibleForTesting
+    fun setOnRetryForTesting(callback: () -> Unit) {
+      if (!onRetryForTesting.compareAndSet(null, callback)) {
+        error("an onRetryForTesting callback is already set [zjp8dv9h6j]")
+      }
+    }
+
+    @VisibleForTesting
+    fun clearOnRetryForTesting(callback: () -> Unit) {
+      if (!onRetryForTesting.compareAndSet(callback, null)) {
+        error("the given onRetryForTesting callback is not set [csems6py9x]")
+      }
+    }
+
+    @VisibleForTesting
+    inline fun <T> withOnRetryForTesting(noinline onRetry: () -> Unit, block: () -> T): T {
+      setOnRetryForTesting(onRetry)
+      return try {
+        block()
+      } finally {
+        clearOnRetryForTesting(onRetry)
+      }
+    }
+
+    private fun StreamResponseProto.toExecuteResponse(authUid: AuthUid?): ExecuteResponse? =
       if (!hasData() && errorsCount == 0) {
         null
       } else {
@@ -624,7 +652,7 @@ private class ConnectionStateUpdater(private val idStringGenerator: IdStringGene
     val currentAuthUid = currentState.authToken.ref?.authUid
     val newAuthUid = sequencedAuthToken.ref?.authUid
     if (currentAuthUid != newAuthUid) {
-      throw AuthUidChangedException(currentAuthUid, newAuthUid)
+      throw AuthUidChangedException("cgvra2bwg3", currentAuthUid, newAuthUid)
     }
 
     if (newToken == null) {

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -398,7 +398,7 @@ internal class DataConnectGrpcRPCs(
         val authToken = initialAuthToken.getAndSet(null) ?: dataConnectAuth.getToken(streamId)
         val authUid = authToken.ref?.authUid
         if (authUid != connectionAuthUid) {
-          throw AuthUidChangedException(connectionAuthUid, authUid)
+          throw AuthUidChangedException("ytd7yf2geh", connectionAuthUid, authUid)
         }
         val appCheckToken = dataConnectAppCheck.getToken(streamId)
         val metadata = grpcMetadata.get(authToken.ref, appCheckToken.ref, callerSdkType)
@@ -814,5 +814,11 @@ internal fun List<DataConnectProperties>.getEntityIdForPathFunction(): GetEntity
   return ::getEntityIdForPathFunction
 }
 
-internal class AuthUidChangedException(currentAuthUid: AuthUid?, newAuthUid: AuthUid?) :
-  DataConnectException("Firebase Auth UID changed from $currentAuthUid to $newAuthUid")
+internal class AuthUidChangedException(
+  errorCode: String,
+  currentAuthUid: AuthUid?,
+  newAuthUid: AuthUid?,
+) :
+  DataConnectException(
+    "Firebase Auth UID changed from $currentAuthUid to $newAuthUid [$errorCode]"
+  )

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -26,6 +26,7 @@ import com.google.firebase.auth.internal.InternalAuthProvider
 import com.google.firebase.dataconnect.DataConnectSettings
 import com.google.firebase.dataconnect.FirebaseDataConnect.CallerSdkType
 import com.google.firebase.dataconnect.QueryRef
+import com.google.firebase.dataconnect.core.DataConnectAuth.AuthUid
 import com.google.firebase.dataconnect.testutil.CleanupsRule
 import com.google.firebase.dataconnect.testutil.DataConnectLogLevelRule
 import com.google.firebase.dataconnect.testutil.FirebaseAppUnitTestingRule
@@ -88,6 +89,7 @@ import io.kotest.property.arbitrary.next
 import io.kotest.property.arbitrary.orNull
 import io.kotest.property.arbitrary.string
 import io.kotest.property.checkAll
+import io.mockk.CapturingSlot
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
@@ -561,18 +563,13 @@ class QuerySubscriptionImplUnitTest {
       check(authUid1 != authUid2)
       check(authToken1 != authToken2)
 
-      val mockInternalAuthProvider = mockk<InternalAuthProvider>(relaxed = true)
-      val idTokenListenerSlot = slot<IdTokenListener>()
-      every { mockInternalAuthProvider.addIdTokenListener(capture(idTokenListenerSlot)) } just runs
-      val authUidIterator = listOf(authUid1, authUid2).iterator()
-      val authTokenIterator = listOf(authToken1, authToken2).iterator()
-      coEvery { mockInternalAuthProvider.getAccessToken(any()) } answers
-        {
-          val authUid = synchronized(authUidIterator) { authUidIterator.next() }
-          val authToken = synchronized(authTokenIterator) { authTokenIterator.next() }
-          taskForToken(authToken, authUid)
-        }
-
+      val (mockInternalAuthProvider, idTokenListenerSlot) =
+        createMockInternalAuthProviderReturning(
+          authUid1,
+          authUid2,
+          authToken1,
+          authToken2,
+        )
       val dataConnect =
         dataConnect(
           serverLocalBindPort = server.port,
@@ -596,6 +593,7 @@ class QuerySubscriptionImplUnitTest {
           val exception = clientCollector.awaitError()
           exception.shouldBeInstanceOf<AuthUidChangedException>()
           exception.message shouldContainWithNonAbuttingTextIgnoringCase "Firebase Auth UID changed"
+          exception.message shouldContainWithNonAbuttingText "cgvra2bwg3"
           exception.message shouldContainWithNonAbuttingText authUid1.toString()
           exception.message shouldContainWithNonAbuttingText authUid2.toString()
 
@@ -607,6 +605,73 @@ class QuerySubscriptionImplUnitTest {
       }
     }
   }
+
+  @Test
+  fun `flow fails with AuthUidChangedException if auth uid changes during reconnection`() =
+    runTest {
+      val server = runningInProcessDataConnectServer()
+
+      checkAll(
+        propTestConfig,
+        Arb.dataConnect.authUid().orNull(nullProbability = 0.3).distinctPair(),
+        Arb.dataConnect.authToken().orNull(nullProbability = 0.3).distinctPair(),
+      ) { (authUid1, authUid2), (authToken1, authToken2) ->
+        check(authUid1 != authUid2)
+        check(authToken1 != authToken2)
+
+        val (mockInternalAuthProvider, idTokenListenerSlot) =
+          createMockInternalAuthProviderReturning(
+            authUid1,
+            authUid2,
+            authToken1,
+            authToken2,
+          )
+        val dataConnect =
+          dataConnect(
+            serverLocalBindPort = server.port,
+            deferredAuthProvider = ImmediateDeferred(mockInternalAuthProvider)
+          )
+        try {
+          dataConnect.awaitAuthReady()
+
+          val subscription = querySubscription(dataConnect)
+          turbineScope {
+            val serverCollector = server.events.testIn(backgroundScope, name = "serverCollector")
+            val clientCollector =
+              subscription.flow.testIn(backgroundScope, name = "clientCollector")
+
+            val responseSender = serverCollector.awaitResponseSender()
+            serverCollector.awaitUntilSubscribeStreamRequest()
+
+            val exception =
+              DataConnectBidiConnectStream.withOnRetryForTesting(
+                onRetry = {
+                  idTokenListenerSlot.captured.onIdTokenChanged(InternalTokenResult(authToken2))
+                }
+              ) {
+                // Close the connection from the server to force a reconnection attempt
+                responseSender.onCompleted()
+
+                // The flow should throw AuthUidChangedException and terminate
+                clientCollector.awaitError()
+              }
+
+            // The flow should throw AuthUidChangedException and terminate
+            exception.shouldBeInstanceOf<AuthUidChangedException>()
+            exception.message shouldContainWithNonAbuttingTextIgnoringCase
+              "Firebase Auth UID changed"
+            exception.message shouldContainWithNonAbuttingText "ytd7yf2geh"
+            exception.message shouldContainWithNonAbuttingText authUid1.toString()
+            exception.message shouldContainWithNonAbuttingText authUid2.toString()
+
+            serverCollector.cancelAndIgnoreRemainingEvents()
+            clientCollector.cancelAndIgnoreRemainingEvents()
+          }
+        } finally {
+          dataConnect.suspendingClose()
+        }
+      }
+    }
 
   private suspend fun TestScope.testFlowReconnectsUponConnectionClosureWithGrpcFailureStatusCode(
     createException: (Status.Code) -> Throwable
@@ -856,3 +921,23 @@ private fun StreamObserver<StreamResponse>.onNext(requestId: String, data: TestD
 
 private val failureGrpcStatusCodes: List<Status.Code> =
   Status.Code.entries.filterNot { it == Status.Code.OK }
+
+private fun createMockInternalAuthProviderReturning(
+  authUid1: AuthUid?,
+  authUid2: AuthUid?,
+  authToken1: String?,
+  authToken2: String?,
+): Pair<InternalAuthProvider, CapturingSlot<IdTokenListener>> {
+  val mockInternalAuthProvider = mockk<InternalAuthProvider>(relaxed = true)
+  val idTokenListenerSlot = slot<IdTokenListener>()
+  every { mockInternalAuthProvider.addIdTokenListener(capture(idTokenListenerSlot)) } just runs
+
+  val iterator = listOf(authUid1, authUid2).zip(listOf(authToken1, authToken2)).iterator()
+  coEvery { mockInternalAuthProvider.getAccessToken(any()) } answers
+    {
+      val (authUid, authToken) = synchronized(iterator) { iterator.next() }
+      taskForToken(authToken, authUid)
+    }
+
+  return Pair(mockInternalAuthProvider, idTokenListenerSlot)
+}


### PR DESCRIPTION
Add a Data Connect test to verify that the query subscription flow fails if the Firebase Auth UID changes during a reconnection attempt.

### Highlights
* **New Reconnection Test**: Verifies that the subscription flow correctly terminates with `AuthUidChangedException` if the Auth UID changes while the stream is reconnecting.
* **Error Diagnostics**: Updates `AuthUidChangedException` to include a unique error code, allowing developers to identify the exact location where the exception was thrown.
* **Testing Helpers**: Introduces `withOnRetryForTesting` in `DataConnectBidiConnectStream` to allow tests to inject actions during reconnection retries, and refactors auth provider mocking in unit tests.

### Changelog
<details>
<summary>Detailed Changes</summary>

* **DataConnectBidiConnectStream.kt**
    * Added `withOnRetryForTesting` and supporting methods to allow tests to run code during reconnection retries.
    * Updated `AuthUidChangedException` instantiation to pass the error code `"cgvra2bwg3"`.
* **DataConnectGrpcRPCs.kt**
    * Updated `AuthUidChangedException` constructor to require an `errorCode` and include it in the detail message.
    * Updated `AuthUidChangedException` instantiation to pass the error code `"ytd7yf2geh"`.
* **QuerySubscriptionImplUnitTest.kt**
    * Added `flow fails with AuthUidChangedException if auth uid changes during reconnection` test.
    * Refactored mock `InternalAuthProvider` setup into `createMockInternalAuthProviderReturning`.
    * Updated existing tests to verify the expected error code.
</details>
