### PR TITLE
dataconnect(test): unit tests for auth and app check tokens on realtime initial connection and reconnection

### DIFF
--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -37,6 +37,7 @@ import com.google.firebase.dataconnect.testutil.ImmediateDeferred
 import com.google.firebase.dataconnect.testutil.InProcessDataConnectGrpcStreamingServer
 import com.google.firebase.dataconnect.testutil.InProcessDataConnectGrpcStreamingServer.Event.ConnectRpcStarted
 import com.google.firebase.dataconnect.testutil.InProcessDataConnectGrpcStreamingServer.Event.StreamRequestReceived
+import com.google.firebase.dataconnect.testutil.NotLoggedInInternalAuthProvider
 import com.google.firebase.dataconnect.testutil.OperationNameVariablesPair
 import com.google.firebase.dataconnect.testutil.RandomSeedTestRule
 import com.google.firebase.dataconnect.testutil.TestAppCheckTokenResultImpl
@@ -683,39 +684,31 @@ class QuerySubscriptionImplUnitTest {
     }
 
   @Test
-  fun `auth token non-null initial connection header`() = runTest {
+  fun `auth logged in initial connection header`() = runTest {
     val server = runningInProcessDataConnectServer()
 
     checkAll(
       propTestConfig,
-      Arb.dataConnect.authUid(),
-      Arb.dataConnect.authToken(),
+      Arb.dataConnect.loggedInAuthProvider(),
       Arb.dataConnect.deferredAppCheckProvider(),
-    ) { authUid, authToken, deferredAppCheckProvider ->
-      val mockInternalAuthProvider: InternalAuthProvider =
-        mockk(relaxed = true) {
-          every { getAccessToken(any()) } returns taskForToken(authToken, authUid)
-        }
-
+    ) { loggedInInternalAuthProvider, deferredAppCheckProvider ->
       testDataConnectInitialHeader(
         server,
-        deferredAuthProvider = ImmediateDeferred(mockInternalAuthProvider),
+        deferredAuthProvider = ImmediateDeferred(loggedInInternalAuthProvider),
         deferredAppCheckProvider = deferredAppCheckProvider,
         awaitAuthReady = true,
         awaitAppCheckReady = false,
         header = authTokenGrpcMetadataKey,
-        expectedHeaderValue = authToken,
+        expectedHeaderValue = loggedInInternalAuthProvider.token,
       )
     }
   }
 
   @Test
-  fun `auth token null initial connection header`() =
+  fun `auth not logged in initial connection header`() =
     testAuthHeaderOmittedOnInitialConnection(
       awaitAuthReady = true,
-      ImmediateDeferred(
-        mockk(relaxed = true) { every { getAccessToken(any()) } returns taskForToken(null, null) }
-      )
+      ImmediateDeferred(NotLoggedInInternalAuthProvider),
     )
 
   @Test
@@ -749,23 +742,17 @@ class QuerySubscriptionImplUnitTest {
 
     checkAll(
       propTestConfig,
-      Arb.dataConnect.appCheckToken(),
+      Arb.dataConnect.appCheckProvider(),
       Arb.dataConnect.deferredAuthProvider(),
-    ) { appCheckToken, deferredAuthProvider ->
-      val mockInteropAppCheckTokenProvider: InteropAppCheckTokenProvider =
-        mockk(relaxed = true) {
-          every { getToken(any()) } returns
-            Tasks.forResult(TestAppCheckTokenResultImpl(appCheckToken))
-        }
-
+    ) { appCheckTokenProvider, deferredAuthProvider ->
       testDataConnectInitialHeader(
         server,
         deferredAuthProvider = deferredAuthProvider,
-        deferredAppCheckProvider = ImmediateDeferred(mockInteropAppCheckTokenProvider),
+        deferredAppCheckProvider = ImmediateDeferred(appCheckTokenProvider),
         awaitAuthReady = false,
         awaitAppCheckReady = true,
         header = appCheckTokenGrpcMetadataKey,
-        expectedHeaderValue = appCheckToken,
+        expectedHeaderValue = appCheckTokenProvider.token,
       )
     }
   }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -811,7 +811,6 @@ class QuerySubscriptionImplUnitTest {
         deferredAppCheckProvider = deferredAppCheckProvider,
         awaitAuthReady = true,
         awaitAppCheckReady = false,
-        onRetry = {},
         header = authTokenGrpcMetadataKey,
         expectedHeaderValue1 = authProvider.tokens[0],
         expectedHeaderValue2 = authProvider.tokens[1],
@@ -845,7 +844,6 @@ class QuerySubscriptionImplUnitTest {
         deferredAppCheckProvider = deferredAppCheckProvider,
         awaitAuthReady = awaitAuthReady,
         awaitAppCheckReady = false,
-        onRetry = {},
         header = authTokenGrpcMetadataKey,
         expectedHeaderValue1 = null,
         expectedHeaderValue2 = null,
@@ -868,7 +866,6 @@ class QuerySubscriptionImplUnitTest {
         deferredAppCheckProvider = ImmediateDeferred(appCheckProvider),
         awaitAuthReady = false,
         awaitAppCheckReady = true,
-        onRetry = {},
         header = appCheckTokenGrpcMetadataKey,
         expectedHeaderValue1 = appCheckProvider.tokens[0],
         expectedHeaderValue2 = appCheckProvider.tokens[1],
@@ -889,7 +886,6 @@ class QuerySubscriptionImplUnitTest {
         deferredAppCheckProvider = UnavailableDeferred(),
         awaitAuthReady = false,
         awaitAppCheckReady = false,
-        onRetry = {},
         header = appCheckTokenGrpcMetadataKey,
         expectedHeaderValue1 = null,
         expectedHeaderValue2 = null,
@@ -903,7 +899,6 @@ class QuerySubscriptionImplUnitTest {
     deferredAppCheckProvider: com.google.firebase.inject.Deferred<InteropAppCheckTokenProvider>,
     awaitAuthReady: Boolean,
     awaitAppCheckReady: Boolean,
-    onRetry: () -> Unit,
     header: Metadata.Key<String>,
     expectedHeaderValue1: String?,
     expectedHeaderValue2: String?,
@@ -934,14 +929,12 @@ class QuerySubscriptionImplUnitTest {
         val responseSender = serverCollector.awaitResponseSender()
         serverCollector.awaitUntilSubscribeStreamRequest()
 
-        DataConnectBidiConnectStream.withOnRetryForTesting(onRetry) {
-          // Close the connection from the server to force a reconnection attempt
-          responseSender.onCompleted()
+        // Close the connection from the server to force a reconnection attempt
+        responseSender.onCompleted()
 
-          // Verify that reconnection attempt specifies the correct header value.
-          val reconnectionHeaders = serverCollector.awaitCall().headers
-          reconnectionHeaders.get(header) shouldBe expectedHeaderValue2
-        }
+        // Verify that reconnection attempt specifies the correct header value.
+        val reconnectionHeaders = serverCollector.awaitCall().headers
+        reconnectionHeaders.get(header) shouldBe expectedHeaderValue2
 
         serverCollector.cancelAndIgnoreRemainingEvents()
         clientCollector.cancelAndIgnoreRemainingEvents()

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -21,6 +21,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
 import app.cash.turbine.turbineScope
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.appcheck.interop.AppCheckTokenListener
+import com.google.firebase.appcheck.interop.InteropAppCheckTokenProvider
 import com.google.firebase.auth.internal.IdTokenListener
 import com.google.firebase.auth.internal.InternalAuthProvider
 import com.google.firebase.dataconnect.DataConnectSettings
@@ -36,7 +39,11 @@ import com.google.firebase.dataconnect.testutil.InProcessDataConnectGrpcStreamin
 import com.google.firebase.dataconnect.testutil.InProcessDataConnectGrpcStreamingServer.Event.StreamRequestReceived
 import com.google.firebase.dataconnect.testutil.OperationNameVariablesPair
 import com.google.firebase.dataconnect.testutil.RandomSeedTestRule
+import com.google.firebase.dataconnect.testutil.TestAppCheckTokenResultImpl
 import com.google.firebase.dataconnect.testutil.UnavailableDeferred
+import com.google.firebase.dataconnect.testutil.appCheckTokenGrpcMetadataKey
+import com.google.firebase.dataconnect.testutil.authTokenGrpcMetadataKey
+import com.google.firebase.dataconnect.testutil.awaitCall
 import com.google.firebase.dataconnect.testutil.awaitConnectRpcStarted
 import com.google.firebase.dataconnect.testutil.awaitResponseSender
 import com.google.firebase.dataconnect.testutil.awaitUntilCancelStreamRequest
@@ -50,6 +57,7 @@ import com.google.firebase.dataconnect.testutil.awaitUntilSubscribeStreamRequest
 import com.google.firebase.dataconnect.testutil.property.arbitrary.authUid
 import com.google.firebase.dataconnect.testutil.property.arbitrary.dataConnect
 import com.google.firebase.dataconnect.testutil.property.arbitrary.distinctPair
+import com.google.firebase.dataconnect.testutil.property.arbitrary.pair
 import com.google.firebase.dataconnect.testutil.registerDataConnectKotestPrinters
 import com.google.firebase.dataconnect.testutil.shouldBe
 import com.google.firebase.dataconnect.testutil.shouldContainWithNonAbuttingText
@@ -60,6 +68,7 @@ import com.google.firebase.internal.InternalTokenResult
 import google.firebase.dataconnect.proto.StreamRequest
 import google.firebase.dataconnect.proto.StreamRequest.RequestKindCase
 import google.firebase.dataconnect.proto.StreamResponse
+import io.grpc.Metadata
 import io.grpc.Status
 import io.grpc.StatusException
 import io.grpc.StatusRuntimeException
@@ -673,6 +682,335 @@ class QuerySubscriptionImplUnitTest {
       }
     }
 
+  @Test
+  fun `auth token non-null initial connection header`() = runTest {
+    val server = runningInProcessDataConnectServer()
+
+    checkAll(
+      propTestConfig,
+      Arb.dataConnect.authUid(),
+      Arb.dataConnect.authToken(),
+      Arb.dataConnect.deferredAppCheckProvider(),
+    ) { authUid, authToken, deferredAppCheckProvider ->
+      val mockInternalAuthProvider: InternalAuthProvider =
+        mockk(relaxed = true) {
+          every { getAccessToken(any()) } returns taskForToken(authToken, authUid)
+        }
+
+      testDataConnectInitialHeader(
+        server,
+        deferredAuthProvider = ImmediateDeferred(mockInternalAuthProvider),
+        deferredAppCheckProvider = deferredAppCheckProvider,
+        awaitAuthReady = true,
+        awaitAppCheckReady = false,
+        header = authTokenGrpcMetadataKey,
+        expectedHeaderValue = authToken,
+      )
+    }
+  }
+
+  @Test
+  fun `auth token null initial connection header`() =
+    testAuthHeaderOmittedOnInitialConnection(
+      awaitAuthReady = true,
+      ImmediateDeferred(
+        mockk(relaxed = true) { every { getAccessToken(any()) } returns taskForToken(null, null) }
+      )
+    )
+
+  @Test
+  fun `auth provider not available initial connection header`() =
+    testAuthHeaderOmittedOnInitialConnection(awaitAuthReady = false, UnavailableDeferred())
+
+  private fun testAuthHeaderOmittedOnInitialConnection(
+    awaitAuthReady: Boolean,
+    deferredAuthProvider: com.google.firebase.inject.Deferred<InternalAuthProvider>
+  ) = runTest {
+    val server = runningInProcessDataConnectServer()
+    checkAll(
+      propTestConfig,
+      Arb.dataConnect.deferredAppCheckProvider(),
+    ) { deferredAppCheckProvider ->
+      testDataConnectInitialHeader(
+        server,
+        deferredAuthProvider = deferredAuthProvider,
+        deferredAppCheckProvider = deferredAppCheckProvider,
+        awaitAuthReady = awaitAuthReady,
+        awaitAppCheckReady = false,
+        header = authTokenGrpcMetadataKey,
+        expectedHeaderValue = null,
+      )
+    }
+  }
+
+  @Test
+  fun `appCheck token non-null initial connection header`() = runTest {
+    val server = runningInProcessDataConnectServer()
+
+    checkAll(
+      propTestConfig,
+      Arb.dataConnect.appCheckToken(),
+      Arb.dataConnect.deferredAuthProvider(),
+    ) { appCheckToken, deferredAuthProvider ->
+      val mockInteropAppCheckTokenProvider: InteropAppCheckTokenProvider =
+        mockk(relaxed = true) {
+          every { getToken(any()) } returns
+            Tasks.forResult(TestAppCheckTokenResultImpl(appCheckToken))
+        }
+
+      testDataConnectInitialHeader(
+        server,
+        deferredAuthProvider = deferredAuthProvider,
+        deferredAppCheckProvider = ImmediateDeferred(mockInteropAppCheckTokenProvider),
+        awaitAuthReady = false,
+        awaitAppCheckReady = true,
+        header = appCheckTokenGrpcMetadataKey,
+        expectedHeaderValue = appCheckToken,
+      )
+    }
+  }
+
+  @Test
+  fun `appCheck provider not available initial connection header`() = runTest {
+    val server = runningInProcessDataConnectServer()
+    checkAll(
+      propTestConfig,
+      Arb.dataConnect.deferredAuthProvider(),
+    ) { deferredAuthProvider ->
+      testDataConnectInitialHeader(
+        server,
+        deferredAuthProvider = deferredAuthProvider,
+        deferredAppCheckProvider = UnavailableDeferred(),
+        awaitAuthReady = false,
+        awaitAppCheckReady = false,
+        header = appCheckTokenGrpcMetadataKey,
+        expectedHeaderValue = null,
+      )
+    }
+  }
+
+  private suspend fun TestScope.testDataConnectInitialHeader(
+    server: InProcessDataConnectGrpcStreamingServer,
+    deferredAuthProvider: com.google.firebase.inject.Deferred<InternalAuthProvider>,
+    deferredAppCheckProvider: com.google.firebase.inject.Deferred<InteropAppCheckTokenProvider>,
+    awaitAuthReady: Boolean,
+    awaitAppCheckReady: Boolean,
+    header: Metadata.Key<String>,
+    expectedHeaderValue: String?,
+  ) {
+    val dataConnect =
+      dataConnect(
+        serverLocalBindPort = server.port,
+        deferredAuthProvider = deferredAuthProvider,
+        deferredAppCheckProvider = deferredAppCheckProvider,
+      )
+
+    try {
+      if (awaitAuthReady) {
+        dataConnect.awaitAuthReady()
+      }
+      if (awaitAppCheckReady) {
+        dataConnect.awaitAppCheckReady()
+      }
+
+      val subscription = querySubscription(dataConnect)
+      turbineScope {
+        val serverCollector = server.events.testIn(backgroundScope, name = "serverCollector")
+        val clientCollector = subscription.flow.testIn(backgroundScope, name = "clientCollector")
+
+        val callEvent = serverCollector.awaitCall()
+        callEvent.headers.get(header) shouldBe expectedHeaderValue
+
+        serverCollector.cancelAndIgnoreRemainingEvents()
+        clientCollector.cancelAndIgnoreRemainingEvents()
+      }
+    } finally {
+      dataConnect.suspendingClose()
+    }
+  }
+
+  @Test
+  fun `auth token non-null reconnection header`() = runTest {
+    val server = runningInProcessDataConnectServer()
+
+    checkAll(
+      propTestConfig,
+      Arb.dataConnect.authUid(),
+      Arb.dataConnect.authToken().pair(),
+      Arb.dataConnect.deferredAppCheckProvider(),
+    ) { authUid, (authToken1, authToken2), deferredAppCheckProvider ->
+      val idTokenListenerSlot = slot<IdTokenListener>()
+      val mockInternalAuthProvider: InternalAuthProvider =
+        mockk(relaxed = true) {
+          every { addIdTokenListener(capture(idTokenListenerSlot)) } just runs
+          every { getAccessToken(any()) } returnsMany
+            listOf(authToken1, authToken2).map { taskForToken(it, authUid) }
+        }
+
+      testDataConnectReconnectHeader(
+        server,
+        deferredAuthProvider = ImmediateDeferred(mockInternalAuthProvider),
+        deferredAppCheckProvider = deferredAppCheckProvider,
+        awaitAuthReady = true,
+        awaitAppCheckReady = false,
+        onRetry = {
+          idTokenListenerSlot.captured.onIdTokenChanged(InternalTokenResult(authToken2))
+        },
+        header = authTokenGrpcMetadataKey,
+        expectedHeaderValue1 = authToken1,
+        expectedHeaderValue2 = authToken2,
+      )
+    }
+  }
+
+  @Test
+  fun `auth token null reconnection header`() =
+    testAuthHeaderOmittedOnReconnection(
+      awaitAuthReady = true,
+      ImmediateDeferred(
+        mockk(relaxed = true) { every { getAccessToken(any()) } returns taskForToken(null, null) }
+      )
+    )
+
+  @Test
+  fun `auth provider not available reconnection header`() =
+    testAuthHeaderOmittedOnReconnection(awaitAuthReady = false, UnavailableDeferred())
+
+  private fun testAuthHeaderOmittedOnReconnection(
+    awaitAuthReady: Boolean,
+    deferredAuthProvider: com.google.firebase.inject.Deferred<InternalAuthProvider>
+  ) = runTest {
+    val server = runningInProcessDataConnectServer()
+    checkAll(
+      propTestConfig,
+      Arb.dataConnect.deferredAppCheckProvider(),
+    ) { deferredAppCheckProvider ->
+      testDataConnectReconnectHeader(
+        server,
+        deferredAuthProvider = deferredAuthProvider,
+        deferredAppCheckProvider = deferredAppCheckProvider,
+        awaitAuthReady = awaitAuthReady,
+        awaitAppCheckReady = false,
+        onRetry = {},
+        header = authTokenGrpcMetadataKey,
+        expectedHeaderValue1 = null,
+        expectedHeaderValue2 = null,
+      )
+    }
+  }
+
+  @Test
+  fun `app check token reconnection header`() = runTest {
+    val server = runningInProcessDataConnectServer()
+
+    checkAll(
+      propTestConfig,
+      Arb.dataConnect.deferredAuthProvider(),
+      Arb.dataConnect.appCheckToken().pair(),
+    ) { deferredAuthProvider, (appCheckToken1, appCheckToken2) ->
+      val appCheckTokenListenerSlot = slot<AppCheckTokenListener>()
+      val mockInteropAppCheckTokenProvider: InteropAppCheckTokenProvider =
+        mockk(relaxed = true) {
+          every { addAppCheckTokenListener(capture(appCheckTokenListenerSlot)) } just runs
+          every { getToken(any()) } returnsMany
+            listOf(appCheckToken1, appCheckToken2).map {
+              Tasks.forResult(TestAppCheckTokenResultImpl(it))
+            }
+        }
+
+      testDataConnectReconnectHeader(
+        server,
+        deferredAuthProvider = deferredAuthProvider,
+        deferredAppCheckProvider = ImmediateDeferred(mockInteropAppCheckTokenProvider),
+        awaitAuthReady = false,
+        awaitAppCheckReady = true,
+        onRetry = {
+          appCheckTokenListenerSlot.captured.onAppCheckTokenChanged(
+            TestAppCheckTokenResultImpl(appCheckToken2)
+          )
+        },
+        header = appCheckTokenGrpcMetadataKey,
+        expectedHeaderValue1 = appCheckToken1,
+        expectedHeaderValue2 = appCheckToken2,
+      )
+    }
+  }
+
+  @Test
+  fun `appCheck provider not available reconnection header`() = runTest {
+    val server = runningInProcessDataConnectServer()
+    checkAll(
+      propTestConfig,
+      Arb.dataConnect.deferredAuthProvider(),
+    ) { deferredAuthProvider ->
+      testDataConnectReconnectHeader(
+        server,
+        deferredAuthProvider = deferredAuthProvider,
+        deferredAppCheckProvider = UnavailableDeferred(),
+        awaitAuthReady = false,
+        awaitAppCheckReady = false,
+        onRetry = {},
+        header = appCheckTokenGrpcMetadataKey,
+        expectedHeaderValue1 = null,
+        expectedHeaderValue2 = null,
+      )
+    }
+  }
+
+  private suspend fun TestScope.testDataConnectReconnectHeader(
+    server: InProcessDataConnectGrpcStreamingServer,
+    deferredAuthProvider: com.google.firebase.inject.Deferred<InternalAuthProvider>,
+    deferredAppCheckProvider: com.google.firebase.inject.Deferred<InteropAppCheckTokenProvider>,
+    awaitAuthReady: Boolean,
+    awaitAppCheckReady: Boolean,
+    onRetry: () -> Unit,
+    header: Metadata.Key<String>,
+    expectedHeaderValue1: String?,
+    expectedHeaderValue2: String?,
+  ) {
+    val dataConnect =
+      dataConnect(
+        serverLocalBindPort = server.port,
+        deferredAuthProvider = deferredAuthProvider,
+        deferredAppCheckProvider = deferredAppCheckProvider,
+      )
+
+    try {
+      if (awaitAuthReady) {
+        dataConnect.awaitAuthReady()
+      }
+      if (awaitAppCheckReady) {
+        dataConnect.awaitAppCheckReady()
+      }
+
+      val subscription = querySubscription(dataConnect)
+      turbineScope {
+        val serverCollector = server.events.testIn(backgroundScope, name = "serverCollector")
+        val clientCollector = subscription.flow.testIn(backgroundScope, name = "clientCollector")
+
+        val originalHeaders = serverCollector.awaitCall().headers
+        check(originalHeaders.get(header) == expectedHeaderValue1)
+
+        val responseSender = serverCollector.awaitResponseSender()
+        serverCollector.awaitUntilSubscribeStreamRequest()
+
+        DataConnectBidiConnectStream.withOnRetryForTesting(onRetry) {
+          // Close the connection from the server to force a reconnection attempt
+          responseSender.onCompleted()
+
+          // Verify that reconnection attempt specifies the correct header value.
+          val reconnectionHeaders = serverCollector.awaitCall().headers
+          reconnectionHeaders.get(header) shouldBe expectedHeaderValue2
+        }
+
+        serverCollector.cancelAndIgnoreRemainingEvents()
+        clientCollector.cancelAndIgnoreRemainingEvents()
+      }
+    } finally {
+      dataConnect.suspendingClose()
+    }
+  }
+
   private suspend fun TestScope.testFlowReconnectsUponConnectionClosureWithGrpcFailureStatusCode(
     createException: (Status.Code) -> Throwable
   ) {
@@ -753,12 +1091,22 @@ class QuerySubscriptionImplUnitTest {
     idStringGenerator: IdStringGenerator? = null,
     deferredAuthProvider: com.google.firebase.inject.Deferred<InternalAuthProvider> =
       UnavailableDeferred(),
-  ): FirebaseDataConnectImpl = dataConnect(server.port, idStringGenerator, deferredAuthProvider)
+    deferredAppCheckProvider: com.google.firebase.inject.Deferred<InteropAppCheckTokenProvider> =
+      UnavailableDeferred(),
+  ): FirebaseDataConnectImpl =
+    dataConnect(
+      server.port,
+      idStringGenerator,
+      deferredAuthProvider,
+      deferredAppCheckProvider,
+    )
 
   private fun TestScope.dataConnect(
     serverLocalBindPort: Int? = null,
     idStringGenerator: IdStringGenerator? = null,
     deferredAuthProvider: com.google.firebase.inject.Deferred<InternalAuthProvider> =
+      UnavailableDeferred(),
+    deferredAppCheckProvider: com.google.firebase.inject.Deferred<InteropAppCheckTokenProvider> =
       UnavailableDeferred(),
   ): FirebaseDataConnectImpl {
     val executor = StandardTestDispatcher(testScheduler).asExecutor()
@@ -782,7 +1130,7 @@ class QuerySubscriptionImplUnitTest {
       blockingExecutor = executor,
       nonBlockingExecutor = executor,
       deferredAuthProvider = deferredAuthProvider,
-      deferredAppCheckProvider = UnavailableDeferred(),
+      deferredAppCheckProvider = deferredAppCheckProvider,
       creator = mockk(name = "FirebaseDataConnectImpl.creator", relaxed = true),
       settings = settings,
       idStringGenerator = idStringGenerator ?: IdStringGenerator(Random.Default),

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -21,10 +21,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
 import app.cash.turbine.turbineScope
-import com.google.android.gms.tasks.Tasks
-import com.google.firebase.appcheck.interop.AppCheckTokenListener
 import com.google.firebase.appcheck.interop.InteropAppCheckTokenProvider
-import com.google.firebase.auth.internal.IdTokenListener
 import com.google.firebase.auth.internal.InternalAuthProvider
 import com.google.firebase.dataconnect.DataConnectSettings
 import com.google.firebase.dataconnect.FirebaseDataConnect.CallerSdkType
@@ -37,10 +34,10 @@ import com.google.firebase.dataconnect.testutil.ImmediateDeferred
 import com.google.firebase.dataconnect.testutil.InProcessDataConnectGrpcStreamingServer
 import com.google.firebase.dataconnect.testutil.InProcessDataConnectGrpcStreamingServer.Event.ConnectRpcStarted
 import com.google.firebase.dataconnect.testutil.InProcessDataConnectGrpcStreamingServer.Event.StreamRequestReceived
+import com.google.firebase.dataconnect.testutil.LoggedInMultiTokenAndUidAuthProvider
 import com.google.firebase.dataconnect.testutil.NotLoggedInInternalAuthProvider
 import com.google.firebase.dataconnect.testutil.OperationNameVariablesPair
 import com.google.firebase.dataconnect.testutil.RandomSeedTestRule
-import com.google.firebase.dataconnect.testutil.TestAppCheckTokenResultImpl
 import com.google.firebase.dataconnect.testutil.UnavailableDeferred
 import com.google.firebase.dataconnect.testutil.appCheckTokenGrpcMetadataKey
 import com.google.firebase.dataconnect.testutil.authTokenGrpcMetadataKey
@@ -58,7 +55,6 @@ import com.google.firebase.dataconnect.testutil.awaitUntilSubscribeStreamRequest
 import com.google.firebase.dataconnect.testutil.property.arbitrary.authUid
 import com.google.firebase.dataconnect.testutil.property.arbitrary.dataConnect
 import com.google.firebase.dataconnect.testutil.property.arbitrary.distinctPair
-import com.google.firebase.dataconnect.testutil.property.arbitrary.pair
 import com.google.firebase.dataconnect.testutil.registerDataConnectKotestPrinters
 import com.google.firebase.dataconnect.testutil.shouldBe
 import com.google.firebase.dataconnect.testutil.shouldContainWithNonAbuttingText
@@ -99,13 +95,8 @@ import io.kotest.property.arbitrary.next
 import io.kotest.property.arbitrary.orNull
 import io.kotest.property.arbitrary.string
 import io.kotest.property.checkAll
-import io.mockk.CapturingSlot
-import io.mockk.coEvery
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.runs
-import io.mockk.slot
 import io.mockk.spyk
 import kotlin.random.Random
 import kotlinx.coroutines.asExecutor
@@ -568,22 +559,19 @@ class QuerySubscriptionImplUnitTest {
     checkAll(
       propTestConfig,
       Arb.dataConnect.authUid().orNull(nullProbability = 0.3).distinctPair(),
-      Arb.dataConnect.authToken().orNull(nullProbability = 0.3).distinctPair(),
+      Arb.dataConnect.authToken().distinctPair(),
     ) { (authUid1, authUid2), (authToken1, authToken2) ->
       check(authUid1 != authUid2)
       check(authToken1 != authToken2)
 
-      val (mockInternalAuthProvider, idTokenListenerSlot) =
-        createMockInternalAuthProviderReturning(
-          authUid1,
-          authUid2,
-          authToken1,
-          authToken2,
-        )
+      val tokenUidPair1 = tokenUidPairOrNullIfUidNull(authToken1, authUid1)
+      val tokenUidPair2 = tokenUidPairOrNullIfUidNull(authToken2, authUid2)
+      val authProvider = LoggedInMultiTokenAndUidAuthProvider(listOf(tokenUidPair1, tokenUidPair2))
+
       val dataConnect =
         dataConnect(
           serverLocalBindPort = server.port,
-          deferredAuthProvider = ImmediateDeferred(mockInternalAuthProvider)
+          deferredAuthProvider = ImmediateDeferred(authProvider)
         )
       try {
         dataConnect.awaitAuthReady()
@@ -597,7 +585,8 @@ class QuerySubscriptionImplUnitTest {
           serverCollector.awaitUntilSubscribeStreamRequest()
 
           // Trigger the auth token update
-          idTokenListenerSlot.captured.onIdTokenChanged(InternalTokenResult(authToken2))
+          checkNotNull(authProvider.idTokenListener)
+            .onIdTokenChanged(InternalTokenResult(authToken2))
 
           // The flow should throw AuthUidChangedException and terminate
           val exception = clientCollector.awaitError()
@@ -624,22 +613,20 @@ class QuerySubscriptionImplUnitTest {
       checkAll(
         propTestConfig,
         Arb.dataConnect.authUid().orNull(nullProbability = 0.3).distinctPair(),
-        Arb.dataConnect.authToken().orNull(nullProbability = 0.3).distinctPair(),
+        Arb.dataConnect.authToken().distinctPair(),
       ) { (authUid1, authUid2), (authToken1, authToken2) ->
         check(authUid1 != authUid2)
         check(authToken1 != authToken2)
 
-        val (mockInternalAuthProvider, idTokenListenerSlot) =
-          createMockInternalAuthProviderReturning(
-            authUid1,
-            authUid2,
-            authToken1,
-            authToken2,
-          )
+        val tokenUidPair1 = tokenUidPairOrNullIfUidNull(authToken1, authUid1)
+        val tokenUidPair2 = tokenUidPairOrNullIfUidNull(authToken2, authUid2)
+        val authProvider =
+          LoggedInMultiTokenAndUidAuthProvider(listOf(tokenUidPair1, tokenUidPair2))
+
         val dataConnect =
           dataConnect(
             serverLocalBindPort = server.port,
-            deferredAuthProvider = ImmediateDeferred(mockInternalAuthProvider)
+            deferredAuthProvider = ImmediateDeferred(authProvider)
           )
         try {
           dataConnect.awaitAuthReady()
@@ -653,18 +640,11 @@ class QuerySubscriptionImplUnitTest {
             val responseSender = serverCollector.awaitResponseSender()
             serverCollector.awaitUntilSubscribeStreamRequest()
 
-            val exception =
-              DataConnectBidiConnectStream.withOnRetryForTesting(
-                onRetry = {
-                  idTokenListenerSlot.captured.onIdTokenChanged(InternalTokenResult(authToken2))
-                }
-              ) {
-                // Close the connection from the server to force a reconnection attempt
-                responseSender.onCompleted()
+            // Close the connection from the server to force a reconnection attempt
+            responseSender.onCompleted()
 
-                // The flow should throw AuthUidChangedException and terminate
-                clientCollector.awaitError()
-              }
+            // The flow should throw AuthUidChangedException and terminate
+            val exception = clientCollector.awaitError()
 
             // The flow should throw AuthUidChangedException and terminate
             exception.shouldBeInstanceOf<AuthUidChangedException>()
@@ -822,30 +802,19 @@ class QuerySubscriptionImplUnitTest {
 
     checkAll(
       propTestConfig,
-      Arb.dataConnect.authUid(),
-      Arb.dataConnect.authToken().pair(),
+      Arb.dataConnect.loggedInMultiTokenAuthProvider(count = 2),
       Arb.dataConnect.deferredAppCheckProvider(),
-    ) { authUid, (authToken1, authToken2), deferredAppCheckProvider ->
-      val idTokenListenerSlot = slot<IdTokenListener>()
-      val mockInternalAuthProvider: InternalAuthProvider =
-        mockk(relaxed = true) {
-          every { addIdTokenListener(capture(idTokenListenerSlot)) } just runs
-          every { getAccessToken(any()) } returnsMany
-            listOf(authToken1, authToken2).map { taskForToken(it, authUid) }
-        }
-
+    ) { authProvider, deferredAppCheckProvider ->
       testDataConnectReconnectHeader(
         server,
-        deferredAuthProvider = ImmediateDeferred(mockInternalAuthProvider),
+        deferredAuthProvider = ImmediateDeferred(authProvider),
         deferredAppCheckProvider = deferredAppCheckProvider,
         awaitAuthReady = true,
         awaitAppCheckReady = false,
-        onRetry = {
-          idTokenListenerSlot.captured.onIdTokenChanged(InternalTokenResult(authToken2))
-        },
+        onRetry = {},
         header = authTokenGrpcMetadataKey,
-        expectedHeaderValue1 = authToken1,
-        expectedHeaderValue2 = authToken2,
+        expectedHeaderValue1 = authProvider.tokens[0],
+        expectedHeaderValue2 = authProvider.tokens[1],
       )
     }
   }
@@ -854,9 +823,7 @@ class QuerySubscriptionImplUnitTest {
   fun `auth token null reconnection header`() =
     testAuthHeaderOmittedOnReconnection(
       awaitAuthReady = true,
-      ImmediateDeferred(
-        mockk(relaxed = true) { every { getAccessToken(any()) } returns taskForToken(null, null) }
-      )
+      ImmediateDeferred(NotLoggedInInternalAuthProvider),
     )
 
   @Test
@@ -893,32 +860,18 @@ class QuerySubscriptionImplUnitTest {
     checkAll(
       propTestConfig,
       Arb.dataConnect.deferredAuthProvider(),
-      Arb.dataConnect.appCheckToken().pair(),
-    ) { deferredAuthProvider, (appCheckToken1, appCheckToken2) ->
-      val appCheckTokenListenerSlot = slot<AppCheckTokenListener>()
-      val mockInteropAppCheckTokenProvider: InteropAppCheckTokenProvider =
-        mockk(relaxed = true) {
-          every { addAppCheckTokenListener(capture(appCheckTokenListenerSlot)) } just runs
-          every { getToken(any()) } returnsMany
-            listOf(appCheckToken1, appCheckToken2).map {
-              Tasks.forResult(TestAppCheckTokenResultImpl(it))
-            }
-        }
-
+      Arb.dataConnect.appCheckMultiTokenProvider(count = 2),
+    ) { deferredAuthProvider, appCheckProvider ->
       testDataConnectReconnectHeader(
         server,
         deferredAuthProvider = deferredAuthProvider,
-        deferredAppCheckProvider = ImmediateDeferred(mockInteropAppCheckTokenProvider),
+        deferredAppCheckProvider = ImmediateDeferred(appCheckProvider),
         awaitAuthReady = false,
         awaitAppCheckReady = true,
-        onRetry = {
-          appCheckTokenListenerSlot.captured.onAppCheckTokenChanged(
-            TestAppCheckTokenResultImpl(appCheckToken2)
-          )
-        },
+        onRetry = {},
         header = appCheckTokenGrpcMetadataKey,
-        expectedHeaderValue1 = appCheckToken1,
-        expectedHeaderValue2 = appCheckToken2,
+        expectedHeaderValue1 = appCheckProvider.tokens[0],
+        expectedHeaderValue2 = appCheckProvider.tokens[1],
       )
     }
   }
@@ -1257,22 +1210,9 @@ private fun StreamObserver<StreamResponse>.onNext(requestId: String, data: TestD
 private val failureGrpcStatusCodes: List<Status.Code> =
   Status.Code.entries.filterNot { it == Status.Code.OK }
 
-private fun createMockInternalAuthProviderReturning(
-  authUid1: AuthUid?,
-  authUid2: AuthUid?,
-  authToken1: String?,
-  authToken2: String?,
-): Pair<InternalAuthProvider, CapturingSlot<IdTokenListener>> {
-  val mockInternalAuthProvider = mockk<InternalAuthProvider>(relaxed = true)
-  val idTokenListenerSlot = slot<IdTokenListener>()
-  every { mockInternalAuthProvider.addIdTokenListener(capture(idTokenListenerSlot)) } just runs
-
-  val iterator = listOf(authUid1, authUid2).zip(listOf(authToken1, authToken2)).iterator()
-  coEvery { mockInternalAuthProvider.getAccessToken(any()) } answers
-    {
-      val (authUid, authToken) = synchronized(iterator) { iterator.next() }
-      taskForToken(authToken, authUid)
-    }
-
-  return Pair(mockInternalAuthProvider, idTokenListenerSlot)
-}
+private fun tokenUidPairOrNullIfUidNull(
+  token: String,
+  uid: AuthUid?
+): LoggedInMultiTokenAndUidAuthProvider.TokenUidPair? =
+  if (uid == null) null
+  else LoggedInMultiTokenAndUidAuthProvider.TokenUidPair(token = token, uid = uid.string)

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/testutil/InProcessDataConnectGrpcStreamingServer.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/testutil/InProcessDataConnectGrpcStreamingServer.kt
@@ -419,3 +419,6 @@ suspend fun ReceiveTurbine<InProcessDataConnectGrpcStreamingServer.Event>.awaitR
 
 suspend fun ReceiveTurbine<InProcessDataConnectGrpcStreamingServer.Event>.awaitConnectRpcStarted():
   InProcessDataConnectGrpcStreamingServer.Event.ConnectRpcStarted = awaitUntilItemIsInstance()
+
+suspend fun ReceiveTurbine<InProcessDataConnectGrpcStreamingServer.Event>.awaitCall():
+  InProcessDataConnectGrpcStreamingServer.Event.Call = awaitUntilItemIsInstance()

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/AccessTokenTestUtils.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/AccessTokenTestUtils.kt
@@ -16,6 +16,8 @@
 
 package com.google.firebase.dataconnect.testutil
 
+import io.grpc.Metadata
+
 // This is a copy of the function of the same name in DataConnectCredentialsTokenManager.kt.
 fun String.toScrubbedAccessToken(): String =
   if (length < 30) {
@@ -31,3 +33,21 @@ fun String.toScrubbedAccessToken(): String =
       )
     }
   }
+
+const val PLACEHOLDER_APP_CHECK_TOKEN = "eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ=="
+
+val authTokenGrpcMetadataKey: Metadata.Key<String> =
+  Metadata.Key.of("x-firebase-auth-token", Metadata.ASCII_STRING_MARSHALLER)
+
+val appCheckTokenGrpcMetadataKey: Metadata.Key<String> =
+  Metadata.Key.of("x-firebase-appcheck", Metadata.ASCII_STRING_MARSHALLER)
+
+class TestAppCheckTokenResultImpl(
+  private val token: String,
+  private val error: Exception? = null,
+) : com.google.firebase.appcheck.AppCheckTokenResult() {
+  override fun getToken() = token
+  override fun getError() = error
+
+  override fun toString() = "TestAppCheckTokenResultImpl(token=$token, error=$error)"
+}

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/AccessTokenTestUtils.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/AccessTokenTestUtils.kt
@@ -150,14 +150,18 @@ class LoggedInMultiTokenAndUidAuthProvider(tokenUidPairs: List<TokenUidPair?>) :
   }
 
   private fun nextTokenUidPair(): TokenUidPair? {
-    val index = index.getAndIncrement()
-    check(index < tokenUidPairs.size) {
-      "internal error k7j9d4dzbk: no more Auth token/uid pairs to produce"
+    while (true) {
+      val currentIndex = index.get()
+      check(currentIndex + 1 <= tokenUidPairs.size) {
+        "internal error k7j9d4dzbk: no more Auth token/uid pairs to produce"
+      }
+      if (index.compareAndSet(currentIndex, currentIndex + 1)) {
+        return tokenUidPairs[currentIndex]
+      }
     }
-    return tokenUidPairs[index]
   }
 
-  override fun getUid() = tokenUidPairs[index.get()]?.uid
+  override fun getUid() = tokenUidPairs[index.get().coerceAtLeast(1) - 1]?.uid
 
   data class TokenUidPair(val token: String, val uid: String)
 

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/AccessTokenTestUtils.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/AccessTokenTestUtils.kt
@@ -16,7 +16,13 @@
 
 package com.google.firebase.dataconnect.testutil
 
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.appcheck.interop.AppCheckTokenListener
+import com.google.firebase.appcheck.interop.InteropAppCheckTokenProvider
+import com.google.firebase.auth.internal.IdTokenListener
+import com.google.firebase.auth.internal.InternalAuthProvider
 import io.grpc.Metadata
+import java.util.concurrent.atomic.AtomicReference
 
 // This is a copy of the function of the same name in DataConnectCredentialsTokenManager.kt.
 fun String.toScrubbedAccessToken(): String =
@@ -50,4 +56,76 @@ class TestAppCheckTokenResultImpl(
   override fun getError() = error
 
   override fun toString() = "TestAppCheckTokenResultImpl(token=$token, error=$error)"
+}
+
+abstract class BaseInternalAuthProvider : InternalAuthProvider {
+
+  private val _idTokenListener = AtomicReference<IdTokenListener>(null)
+  val idTokenListener: IdTokenListener?
+    get() = _idTokenListener.get()
+
+  override fun addIdTokenListener(listener: IdTokenListener) {
+    _idTokenListener.compareAndSet(null, listener).let {
+      check(it) { "addIdTokenListener() has already set a listener [q9zs84tavg]" }
+    }
+  }
+
+  override fun removeIdTokenListener(listener: IdTokenListener) {
+    _idTokenListener.compareAndSet(listener, null).let {
+      check(it) {
+        "removeIdTokenListener() is trying to remove a listener that was not set [z37yytx6ck]"
+      }
+    }
+  }
+}
+
+object NotLoggedInInternalAuthProvider : BaseInternalAuthProvider() {
+  override fun getAccessToken(forceRefresh: Boolean) =
+    Tasks.forResult(com.google.firebase.auth.GetTokenResult(null, emptyMap()))
+
+  override fun getUid() = null
+
+  override fun toString() = "NotLoggedInInternalAuthProvider"
+}
+
+class LoggedInInternalAuthProvider(val token: String, uid: String) : BaseInternalAuthProvider() {
+
+  private val _uid = uid
+
+  override fun getAccessToken(forceRefresh: Boolean) =
+    Tasks.forResult(com.google.firebase.auth.GetTokenResult(token, mapOf("sub" to uid)))
+
+  override fun getUid() = _uid
+
+  override fun toString() = "LoggedInInternalAuthProvider(token=$token, uid=$_uid)"
+}
+
+class TestInteropAppCheckTokenProvider(val token: String) : InteropAppCheckTokenProvider {
+
+  private val _appCheckTokenListener = AtomicReference<AppCheckTokenListener>(null)
+  val appCheckTokenListener: AppCheckTokenListener?
+    get() = _appCheckTokenListener.get()
+
+  override fun getToken(forceRefresh: Boolean) =
+    Tasks.forResult<com.google.firebase.appcheck.AppCheckTokenResult>(
+      TestAppCheckTokenResultImpl(token)
+    )
+
+  override fun getLimitedUseToken() = TODO("not implemented")
+
+  override fun addAppCheckTokenListener(listener: AppCheckTokenListener) {
+    _appCheckTokenListener.compareAndSet(null, listener).let {
+      check(it) { "addAppCheckTokenListener() has already set a listener [dg9chc7wbd]" }
+    }
+  }
+
+  override fun removeAppCheckTokenListener(listener: AppCheckTokenListener) {
+    _appCheckTokenListener.compareAndSet(listener, null).let {
+      check(it) {
+        "removeAppCheckTokenListener() is trying to remove a listener that was not set [hydewbz35a]"
+      }
+    }
+  }
+
+  override fun toString() = "TestInteropAppCheckTokenProvider(token=$token)"
 }

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/AccessTokenTestUtils.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/AccessTokenTestUtils.kt
@@ -22,7 +22,11 @@ import com.google.firebase.appcheck.interop.InteropAppCheckTokenProvider
 import com.google.firebase.auth.internal.IdTokenListener
 import com.google.firebase.auth.internal.InternalAuthProvider
 import io.grpc.Metadata
+import io.kotest.assertions.print.print
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 // This is a copy of the function of the same name in DataConnectCredentialsTokenManager.kt.
 fun String.toScrubbedAccessToken(): String =
@@ -100,18 +104,72 @@ class LoggedInInternalAuthProvider(val token: String, uid: String) : BaseInterna
   override fun toString() = "LoggedInInternalAuthProvider(token=$token, uid=$_uid)"
 }
 
-class TestInteropAppCheckTokenProvider(val token: String) : InteropAppCheckTokenProvider {
+class LoggedInMultiTokenInternalAuthProvider(tokens: List<String>, uid: String) :
+  BaseInternalAuthProvider() {
+
+  val tokens = tokens.toList()
+  private val lock = ReentrantLock()
+  private val iterator = this.tokens.iterator()
+
+  private val _uid = uid
+
+  override fun getAccessToken(forceRefresh: Boolean) =
+    Tasks.forResult(com.google.firebase.auth.GetTokenResult(nextToken(), mapOf("sub" to uid)))
+
+  private fun nextToken(): String =
+    lock.withLock {
+      check(iterator.hasNext()) { "internal error p37nr2p9dk: no more Auth tokens to produce" }
+      iterator.next()
+    }
+
+  override fun getUid() = _uid
+
+  override fun toString() =
+    "LoggedInInternalAuthProvider(tokens=${tokens.print().value}, uid=$_uid)"
+}
+
+class LoggedInMultiTokenAndUidAuthProvider(tokenUidPairs: List<TokenUidPair?>) :
+  BaseInternalAuthProvider() {
+
+  init {
+    require(tokenUidPairs.isNotEmpty()) { "tokenUidPairs must not be empty [jg5879zfs5]" }
+  }
+
+  val tokenUidPairs = tokenUidPairs.toList()
+  private val index = AtomicInteger(0)
+
+  override fun getAccessToken(forceRefresh: Boolean) = Tasks.forResult(nextGetTokenResult())
+
+  private fun nextGetTokenResult(): com.google.firebase.auth.GetTokenResult {
+    val (token, uid) =
+      when (val pair = nextTokenUidPair()) {
+        null -> Pair(null, null)
+        else -> Pair(pair.token, pair.uid)
+      }
+    return com.google.firebase.auth.GetTokenResult(token, mapOf("sub" to uid))
+  }
+
+  private fun nextTokenUidPair(): TokenUidPair? {
+    val index = index.getAndIncrement()
+    check(index < tokenUidPairs.size) {
+      "internal error k7j9d4dzbk: no more Auth token/uid pairs to produce"
+    }
+    return tokenUidPairs[index]
+  }
+
+  override fun getUid() = tokenUidPairs[index.get()]?.uid
+
+  data class TokenUidPair(val token: String, val uid: String)
+
+  override fun toString() =
+    "LoggedInMultiTokenAndUidAuthProvider(tokenUidPairs=${tokenUidPairs.print().value})"
+}
+
+abstract class BaseInteropAppCheckTokenProvider : InteropAppCheckTokenProvider {
 
   private val _appCheckTokenListener = AtomicReference<AppCheckTokenListener>(null)
   val appCheckTokenListener: AppCheckTokenListener?
     get() = _appCheckTokenListener.get()
-
-  override fun getToken(forceRefresh: Boolean) =
-    Tasks.forResult<com.google.firebase.appcheck.AppCheckTokenResult>(
-      TestAppCheckTokenResultImpl(token)
-    )
-
-  override fun getLimitedUseToken() = TODO("not implemented")
 
   override fun addAppCheckTokenListener(listener: AppCheckTokenListener) {
     _appCheckTokenListener.compareAndSet(null, listener).let {
@@ -126,6 +184,40 @@ class TestInteropAppCheckTokenProvider(val token: String) : InteropAppCheckToken
       }
     }
   }
+}
+
+class TestInteropAppCheckTokenProvider(val token: String) : BaseInteropAppCheckTokenProvider() {
+
+  override fun getToken(forceRefresh: Boolean) =
+    Tasks.forResult<com.google.firebase.appcheck.AppCheckTokenResult>(
+      TestAppCheckTokenResultImpl(token)
+    )
+
+  override fun getLimitedUseToken() = TODO("not implemented")
 
   override fun toString() = "TestInteropAppCheckTokenProvider(token=$token)"
+}
+
+class TestMultiTokenInteropAppCheckTokenProvider(tokens: List<String>) :
+  BaseInteropAppCheckTokenProvider() {
+
+  val tokens = tokens.toList()
+  private val lock = ReentrantLock()
+  private val iterator = this.tokens.iterator()
+
+  override fun getToken(forceRefresh: Boolean) =
+    Tasks.forResult<com.google.firebase.appcheck.AppCheckTokenResult>(
+      TestAppCheckTokenResultImpl(nextToken())
+    )
+
+  private fun nextToken(): String =
+    lock.withLock {
+      check(iterator.hasNext()) { "internal error jkgvfsmktg: no more App Check tokens to produce" }
+      iterator.next()
+    }
+
+  override fun getLimitedUseToken() = TODO("not implemented")
+
+  override fun toString() =
+    "TestMultiTokenInteropAppCheckTokenProvider(tokens=${tokens.print().value})"
 }

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/ImmediateDeferred.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/ImmediateDeferred.kt
@@ -28,5 +28,5 @@ class ImmediateDeferred<T>(instance: T, private val name: String? = null) : Defe
     handler.handle(provider)
   }
 
-  override fun toString() = "ImmediateDeferred(name=$name)"
+  override fun toString() = "ImmediateDeferred(name=${name ?: provider})"
 }

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/ImmediateDeferred.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/ImmediateDeferred.kt
@@ -20,11 +20,13 @@ import com.google.firebase.inject.Deferred
 import com.google.firebase.inject.Provider
 
 /** An implementation of {@link Deferred} whose provider is always available. */
-class ImmediateDeferred<T>(instance: T) : Deferred<T> {
+class ImmediateDeferred<T>(instance: T, private val name: String? = null) : Deferred<T> {
 
   private val provider = Provider { instance }
 
   override fun whenAvailable(handler: Deferred.DeferredHandler<T>) {
     handler.handle(provider)
   }
+
+  override fun toString() = "ImmediateDeferred(name=$name)"
 }

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/UnavailableDeferred.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/UnavailableDeferred.kt
@@ -21,4 +21,6 @@ import com.google.firebase.inject.Deferred
 /** An implementation of {@link Deferred} whose provider never becomes available. */
 class UnavailableDeferred<T> : Deferred<T> {
   override fun whenAvailable(handler: Deferred.DeferredHandler<T>) {}
+
+  override fun toString() = "UnavailableDeferred"
 }

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/UnavailableDeferred.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/UnavailableDeferred.kt
@@ -19,8 +19,8 @@ package com.google.firebase.dataconnect.testutil
 import com.google.firebase.inject.Deferred
 
 /** An implementation of {@link Deferred} whose provider never becomes available. */
-class UnavailableDeferred<T> : Deferred<T> {
+class UnavailableDeferred<T>(private val name: String? = null) : Deferred<T> {
   override fun whenAvailable(handler: Deferred.DeferredHandler<T>) {}
 
-  override fun toString() = "UnavailableDeferred"
+  override fun toString() = "UnavailableDeferred(name=$name)"
 }

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/arbs.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/arbs.kt
@@ -18,10 +18,17 @@
 
 package com.google.firebase.dataconnect.testutil.property.arbitrary
 
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.appcheck.interop.InteropAppCheckTokenProvider
+import com.google.firebase.auth.internal.InternalAuthProvider
 import com.google.firebase.dataconnect.CacheSettings
 import com.google.firebase.dataconnect.ConnectorConfig
 import com.google.firebase.dataconnect.DataConnectPathSegment
 import com.google.firebase.dataconnect.DataConnectSettings
+import com.google.firebase.dataconnect.testutil.ImmediateDeferred
+import com.google.firebase.dataconnect.testutil.PLACEHOLDER_APP_CHECK_TOKEN
+import com.google.firebase.dataconnect.testutil.TestAppCheckTokenResultImpl
+import com.google.firebase.dataconnect.testutil.UnavailableDeferred
 import io.kotest.assertions.print.print
 import io.kotest.property.Arb
 import io.kotest.property.RandomSource
@@ -46,8 +53,12 @@ import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.orNull
 import io.kotest.property.arbitrary.string
+import io.kotest.property.arbitrary.withEdgecases
 import io.kotest.property.asSample
+import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import kotlin.random.nextInt
 import kotlin.time.Duration
 import kotlinx.serialization.modules.SerializersModule
@@ -153,9 +164,64 @@ object DataConnectArb {
   fun authToken(string: Arb<String> = Arb.string(size = 8, Codepoint.alphanumeric())): Arb<String> =
     string.map { "authToken_${it.lowercase()}" }
 
+  fun authUidString(
+    string: Arb<String> = Arb.string(size = 8, Codepoint.alphanumeric())
+  ): Arb<String> = string.map { "authUid_${it.lowercase()}" }
+
   fun appCheckToken(
     string: Arb<String> = Arb.string(size = 8, Codepoint.alphanumeric())
-  ): Arb<String> = string.map { "appCheckToken_${it.lowercase()}" }
+  ): Arb<String> =
+    string
+      .map { "appCheckToken_${it.lowercase()}" }
+      .withEdgecases(
+        PLACEHOLDER_APP_CHECK_TOKEN,
+      )
+
+  fun deferredAuthProvider(
+    token: Arb<String?> = authToken().orNull(nullProbability = 0.33),
+    uid: Arb<String?> = authUidString().orNull(nullProbability = 0.33),
+  ): Arb<com.google.firebase.inject.Deferred<InternalAuthProvider>> =
+    Arb.bind(token, uid) { token, uid ->
+      if (token == null && uid == null) {
+        UnavailableDeferred()
+      } else {
+        val claims = buildMap {
+          if (uid != null) {
+            put("sub", uid)
+          }
+        }
+        val mockProvider: InternalAuthProvider = mockk {
+          every { getAccessToken(any()) } returns
+            Tasks.forResult(com.google.firebase.auth.GetTokenResult(token, claims))
+          every { getUid() } returns uid
+          every { addIdTokenListener(any()) } just runs
+          every { removeIdTokenListener(any()) } just runs
+        }
+        ImmediateDeferred(
+          mockProvider,
+          name = "InternalAuthProvider(token=$token uid=$uid) [r73tv2gms7]",
+        )
+      }
+    }
+
+  fun deferredAppCheckProvider(
+    token: Arb<String?> = appCheckToken().orNull(nullProbability = 0.33),
+  ): Arb<com.google.firebase.inject.Deferred<InteropAppCheckTokenProvider>> =
+    token.map {
+      if (it == null) {
+        UnavailableDeferred()
+      } else {
+        val mockProvider: InteropAppCheckTokenProvider = mockk {
+          every { getToken(any()) } returns Tasks.forResult(TestAppCheckTokenResultImpl(it))
+          every { addAppCheckTokenListener(any()) } just runs
+          every { removeAppCheckTokenListener(any()) } just runs
+        }
+        ImmediateDeferred(
+          mockProvider,
+          name = "InteropAppCheckTokenProvider(token=$it) [ag59cv7a57]",
+        )
+      }
+    }
 
   fun requestId(string: Arb<String> = Arb.string(size = 8, Codepoint.alphanumeric())): Arb<String> =
     arbitrary {

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/arbs.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/arbs.kt
@@ -18,7 +18,6 @@
 
 package com.google.firebase.dataconnect.testutil.property.arbitrary
 
-import com.google.android.gms.tasks.Tasks
 import com.google.firebase.appcheck.interop.InteropAppCheckTokenProvider
 import com.google.firebase.auth.internal.InternalAuthProvider
 import com.google.firebase.dataconnect.CacheSettings
@@ -26,8 +25,10 @@ import com.google.firebase.dataconnect.ConnectorConfig
 import com.google.firebase.dataconnect.DataConnectPathSegment
 import com.google.firebase.dataconnect.DataConnectSettings
 import com.google.firebase.dataconnect.testutil.ImmediateDeferred
+import com.google.firebase.dataconnect.testutil.LoggedInInternalAuthProvider
+import com.google.firebase.dataconnect.testutil.NotLoggedInInternalAuthProvider
 import com.google.firebase.dataconnect.testutil.PLACEHOLDER_APP_CHECK_TOKEN
-import com.google.firebase.dataconnect.testutil.TestAppCheckTokenResultImpl
+import com.google.firebase.dataconnect.testutil.TestInteropAppCheckTokenProvider
 import com.google.firebase.dataconnect.testutil.UnavailableDeferred
 import io.kotest.assertions.print.print
 import io.kotest.property.Arb
@@ -42,6 +43,7 @@ import io.kotest.property.arbitrary.bind
 import io.kotest.property.arbitrary.boolean
 import io.kotest.property.arbitrary.choice
 import io.kotest.property.arbitrary.choose
+import io.kotest.property.arbitrary.constant
 import io.kotest.property.arbitrary.cyrillic
 import io.kotest.property.arbitrary.double
 import io.kotest.property.arbitrary.duration
@@ -55,10 +57,7 @@ import io.kotest.property.arbitrary.orNull
 import io.kotest.property.arbitrary.string
 import io.kotest.property.arbitrary.withEdgecases
 import io.kotest.property.asSample
-import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.runs
 import kotlin.random.nextInt
 import kotlin.time.Duration
 import kotlinx.serialization.modules.SerializersModule
@@ -177,51 +176,52 @@ object DataConnectArb {
         PLACEHOLDER_APP_CHECK_TOKEN,
       )
 
-  fun deferredAuthProvider(
-    token: Arb<String?> = authToken().orNull(nullProbability = 0.33),
-    uid: Arb<String?> = authUidString().orNull(nullProbability = 0.33),
-  ): Arb<com.google.firebase.inject.Deferred<InternalAuthProvider>> =
-    Arb.bind(token, uid) { token, uid ->
-      if (token == null && uid == null) {
-        UnavailableDeferred()
-      } else {
-        val claims = buildMap {
-          if (uid != null) {
-            put("sub", uid)
-          }
-        }
-        val mockProvider: InternalAuthProvider = mockk {
-          every { getAccessToken(any()) } returns
-            Tasks.forResult(com.google.firebase.auth.GetTokenResult(token, claims))
-          every { getUid() } returns uid
-          every { addIdTokenListener(any()) } just runs
-          every { removeIdTokenListener(any()) } just runs
-        }
-        ImmediateDeferred(
-          mockProvider,
-          name = "InternalAuthProvider(token=$token uid=$uid) [r73tv2gms7]",
-        )
-      }
-    }
+  fun unavailableDeferredAuthProvider(): Arb<UnavailableDeferred<InternalAuthProvider>> =
+    Arb.constant(UnavailableDeferred(name = "InternalAuthProvider"))
 
-  fun deferredAppCheckProvider(
-    token: Arb<String?> = appCheckToken().orNull(nullProbability = 0.33),
-  ): Arb<com.google.firebase.inject.Deferred<InteropAppCheckTokenProvider>> =
-    token.map {
-      if (it == null) {
-        UnavailableDeferred()
-      } else {
-        val mockProvider: InteropAppCheckTokenProvider = mockk {
-          every { getToken(any()) } returns Tasks.forResult(TestAppCheckTokenResultImpl(it))
-          every { addAppCheckTokenListener(any()) } just runs
-          every { removeAppCheckTokenListener(any()) } just runs
-        }
-        ImmediateDeferred(
-          mockProvider,
-          name = "InteropAppCheckTokenProvider(token=$it) [ag59cv7a57]",
-        )
-      }
-    }
+  fun notLoggedInDeferredAuthProvider(
+    notLoggedInAuthProvider: Arb<NotLoggedInInternalAuthProvider> = notLoggedInAuthProvider()
+  ): Arb<ImmediateDeferred<InternalAuthProvider>> = notLoggedInAuthProvider.map(::ImmediateDeferred)
+
+  fun notLoggedInAuthProvider(): Arb<NotLoggedInInternalAuthProvider> =
+    Arb.constant(NotLoggedInInternalAuthProvider)
+
+  fun loggedInDeferredAuthProvider(
+    loggedInAuthProvider: Arb<LoggedInInternalAuthProvider> = loggedInAuthProvider(),
+  ): Arb<ImmediateDeferred<InternalAuthProvider>> = loggedInAuthProvider.map(::ImmediateDeferred)
+
+  fun loggedInAuthProvider(
+    token: Arb<String> = authToken(),
+    uid: Arb<String> = authUidString(),
+  ): Arb<LoggedInInternalAuthProvider> =
+    Arb.bind(token, uid) { token, uid -> LoggedInInternalAuthProvider(token = token, uid = uid) }
+
+  fun deferredAuthProvider(): Arb<com.google.firebase.inject.Deferred<InternalAuthProvider>> =
+    Arb.choice(
+      unavailableDeferredAuthProvider(),
+      notLoggedInDeferredAuthProvider(),
+      loggedInDeferredAuthProvider(),
+    )
+
+  fun unavailableDeferredAppCheckProvider():
+    Arb<UnavailableDeferred<InteropAppCheckTokenProvider>> =
+    Arb.constant(UnavailableDeferred(name = "InteropAppCheckTokenProvider"))
+
+  fun availableDeferredAppCheckProvider(
+    interopAppCheckTokenProvider: Arb<InteropAppCheckTokenProvider> = appCheckProvider(),
+  ): Arb<ImmediateDeferred<InteropAppCheckTokenProvider>> =
+    interopAppCheckTokenProvider.map(::ImmediateDeferred)
+
+  fun appCheckProvider(
+    token: Arb<String> = appCheckToken(),
+  ): Arb<TestInteropAppCheckTokenProvider> = token.map(::TestInteropAppCheckTokenProvider)
+
+  fun deferredAppCheckProvider():
+    Arb<com.google.firebase.inject.Deferred<InteropAppCheckTokenProvider>> =
+    Arb.choose(
+      1 to unavailableDeferredAppCheckProvider(),
+      2 to availableDeferredAppCheckProvider(),
+    )
 
   fun requestId(string: Arb<String> = Arb.string(size = 8, Codepoint.alphanumeric())): Arb<String> =
     arbitrary {

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/arbs.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/arbs.kt
@@ -26,9 +26,11 @@ import com.google.firebase.dataconnect.DataConnectPathSegment
 import com.google.firebase.dataconnect.DataConnectSettings
 import com.google.firebase.dataconnect.testutil.ImmediateDeferred
 import com.google.firebase.dataconnect.testutil.LoggedInInternalAuthProvider
+import com.google.firebase.dataconnect.testutil.LoggedInMultiTokenInternalAuthProvider
 import com.google.firebase.dataconnect.testutil.NotLoggedInInternalAuthProvider
 import com.google.firebase.dataconnect.testutil.PLACEHOLDER_APP_CHECK_TOKEN
 import com.google.firebase.dataconnect.testutil.TestInteropAppCheckTokenProvider
+import com.google.firebase.dataconnect.testutil.TestMultiTokenInteropAppCheckTokenProvider
 import com.google.firebase.dataconnect.testutil.UnavailableDeferred
 import io.kotest.assertions.print.print
 import io.kotest.property.Arb
@@ -52,6 +54,7 @@ import io.kotest.property.arbitrary.enum
 import io.kotest.property.arbitrary.filterNot
 import io.kotest.property.arbitrary.hex
 import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.list
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.orNull
 import io.kotest.property.arbitrary.string
@@ -193,8 +196,17 @@ object DataConnectArb {
   fun loggedInAuthProvider(
     token: Arb<String> = authToken(),
     uid: Arb<String> = authUidString(),
-  ): Arb<LoggedInInternalAuthProvider> =
-    Arb.bind(token, uid) { token, uid -> LoggedInInternalAuthProvider(token = token, uid = uid) }
+  ): Arb<LoggedInInternalAuthProvider> = Arb.bind(token, uid, ::LoggedInInternalAuthProvider)
+
+  fun loggedInMultiTokenAuthProvider(
+    count: Int,
+    token: Arb<String> = authToken(),
+    uid: Arb<String> = authUidString(),
+  ): Arb<LoggedInMultiTokenInternalAuthProvider> {
+    require(count > 1) { "invalid count: $count [rm3jz5xdhb]" }
+    val tokens = Arb.list(token, count..count)
+    return Arb.bind(tokens, uid, ::LoggedInMultiTokenInternalAuthProvider)
+  }
 
   fun deferredAuthProvider(): Arb<com.google.firebase.inject.Deferred<InternalAuthProvider>> =
     Arb.choice(
@@ -215,6 +227,14 @@ object DataConnectArb {
   fun appCheckProvider(
     token: Arb<String> = appCheckToken(),
   ): Arb<TestInteropAppCheckTokenProvider> = token.map(::TestInteropAppCheckTokenProvider)
+
+  fun appCheckMultiTokenProvider(
+    count: Int,
+    token: Arb<String> = appCheckToken(),
+  ): Arb<TestMultiTokenInteropAppCheckTokenProvider> {
+    require(count > 1) { "invalid count: $count [zmr7sjac4e]" }
+    return Arb.list(token, count..count).map(::TestMultiTokenInteropAppCheckTokenProvider)
+  }
 
   fun deferredAppCheckProvider():
     Arb<com.google.firebase.inject.Deferred<InteropAppCheckTokenProvider>> =


### PR DESCRIPTION
Adds data connect unit tests in `QuerySubscriptionImplUnitTest` to verify that `x-firebase-auth-token` and `x-firebase-appcheck` headers are correctly included in gRPC metadata for the initial connection and reconnection. To support this, it refactors the mocking of Auth and App Check providers by introducing dedicated test provider implementations in `AccessTokenTestUtils.kt` and utilizing them in Kotest property testing generators (`arbs.kt`), removing the need for manual listener trigger overrides in unit tests.

### Highlights

*   **Token Header Verification Tests**: Added tests in `QuerySubscriptionImplUnitTest` covering both initial connection and reconnection scenarios for various Auth states (logged-in, not logged-in, provider unavailable) and App Check states (token available, provider unavailable).
*   **Structured Test Providers**: Introduced dedicated test implementations of `InternalAuthProvider` and `InteropAppCheckTokenProvider` in `AccessTokenTestUtils.kt` to model login states and multi-token rotations sequentially, removing dependency on `mockk` in property generators.
*   **Streaming Server Call Helper**: Added `awaitCall()` extension to `InProcessDataConnectGrpcStreamingServer` to easily capture incoming calls and assert metadata headers.
*   **Descriptive Deferred toStrings**: Updated `ImmediateDeferred` and `UnavailableDeferred` to support custom names and descriptive `toString()` methods for improved test failure messages.

### Changelog

<details>
<summary>Detailed list of file changes</summary>

*   **QuerySubscriptionImplUnitTest.kt**: Added comprehensive unit tests for auth and App Check token headers. Refactored existing token change tests to use the new structured test providers.
*   **InProcessDataConnectGrpcStreamingServer.kt**: Added `awaitCall()` helper to capture incoming calls and their metadata headers.
*   **AccessTokenTestUtils.kt**: Added structured test implementations of `InternalAuthProvider` and `InteropAppCheckTokenProvider` (e.g. `NotLoggedInInternalAuthProvider`, `LoggedInInternalAuthProvider`, `LoggedInMultiTokenInternalAuthProvider`, `TestInteropAppCheckTokenProvider`) to model various authentication states.
*   **ImmediateDeferred.kt**: Added an optional `name` parameter to the constructor and overrode `toString()` for descriptive debugging output.
*   **UnavailableDeferred.kt**: Added an optional `name` parameter to the constructor and overrode `toString()` for descriptive debugging output.
*   **arbs.kt**: Updated `deferredAuthProvider` and `deferredAppCheckProvider` Kotest generators to utilize the new structured test providers, ensuring robust coverage of all login and availability states.
</details>