### PR TITLE
[AppCheck] Bump recaptcha version to 19.0.0

### DIFF
--- a/appcheck/firebase-appcheck-recaptcha/gradle.properties
+++ b/appcheck/firebase-appcheck-recaptcha/gradle.properties
@@ -1,1 +1,1 @@
-version=16.0.0
+version=19.0.0


### PR DESCRIPTION
Updated the version property for the firebase-appcheck-recaptcha module from 16.0.0 to 19.0.0 to align with the other providers.