### PR TITLE
Revert "Disable integration test checks temporarily (#8248)"

### DIFF
--- a/.github/workflows/firestore_ci_tests.yml
+++ b/.github/workflows/firestore_ci_tests.yml
@@ -338,14 +338,12 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-  # TODO: Re-enable integ_tests and enterprise_integ_tests when backend error is fixed.
   check-required-tests:
     runs-on: ubuntu-latest
     if: always()
     name: Check all required Firestore tests results
-    # needs: [integ_tests, enterprise_integ_tests]
+    needs: [integ_tests, enterprise_integ_tests]
     steps:
       - name: Check test matrix
-        run: echo "Integration tests are optional"
-        # if: needs.integ_tests.result == 'failure' || needs.enterprise_integ_tests.result == 'failure'
-        # run: exit 1
+        if: needs.integ_tests.result == 'failure' || needs.enterprise_integ_tests.result == 'failure'
+        run: exit 1


### PR DESCRIPTION
Reverts the temporary change that made integration tests optional in firestore_ci_tests.yml