### PR TITLE
Crashlytics: use R8 r8-map-id on AGP 8.12+

### DIFF
--- a/firebase-crashlytics-gradle/CHANGELOG.md
+++ b/firebase-crashlytics-gradle/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+- [changed] On Android Gradle plugin 8.12 and above, the plugin now uses R8's stable mapping id (`r8_map_id`/`pg_map_id`) for release builds instead of injecting a freshly generated id, so release builds are no longer invalidated on every build. [#6770]
 - [fixed] Fixed an incompatibility between Crashlytics Gradle plugin and Gradle isolated projects when enabling nativeSymbolUploadEnabled. [#8037]
 
 ### Crashlytics Gradle plugin version 3.0.7

--- a/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/CrashlyticsPluginTest.kt
+++ b/firebase-crashlytics-gradle/src/functionalTest/kotlin/com/google/firebase/crashlytics/buildtools/gradle/CrashlyticsPluginTest.kt
@@ -107,9 +107,16 @@ class CrashlyticsPluginTest {
         "--configuration-cache"
       )
 
+    // AGP 8.12+ injects the constant USE_R8_MAP_ID sentinel (the real id comes from R8's
+    // r8-map-id); earlier versions inject a generated id ("test1234" in pretend mode).
+    val (major, minor) = agpVersion.split(".").map(String::toInt)
+    val expectedId =
+      if (major > 8 || (major == 8 && minor >= 12)) "11111111111111111111111111111111"
+      else "test1234"
+
     assertThat(result.output)
       .contains(
-        "injectMappingFileIdIntoResource - com_google_firebase_crashlytics_mappingfileid.xml test1234"
+        "injectMappingFileIdIntoResource - com_google_firebase_crashlytics_mappingfileid.xml $expectedId"
       )
     assertThat(result.task(":injectCrashlyticsMappingFileIdRelease")?.outcome)
       .isEqualTo(TaskOutcome.SUCCESS)

--- a/firebase-crashlytics-gradle/src/main/kotlin/com/google/firebase/crashlytics/buildtools/gradle/CrashlyticsBuildtools.kt
+++ b/firebase-crashlytics-gradle/src/main/kotlin/com/google/firebase/crashlytics/buildtools/gradle/CrashlyticsBuildtools.kt
@@ -35,6 +35,8 @@ import org.gradle.api.logging.Logger
 internal object CrashlyticsBuildtools {
   const val BLANK_MAPPING_FILE_ID = Buildtools.DUMMY_MAPPING_ID
 
+  const val USE_R8_MAP_ID = "11111111111111111111111111111111"
+
   private const val BUILDTOOLS_PROPERTY = "com.google.firebase.crashlytics.buildtools"
   private const val DEBUG_LOG_REDIRECT_PROPERTY = "com.google.firebase.crashlytics.logDebug"
   private const val FAKE_OUTPUT_PROPERTY = "com.google.firebase.crashlytics.fakeOutput"

--- a/firebase-crashlytics-gradle/src/main/kotlin/com/google/firebase/crashlytics/buildtools/gradle/CrashlyticsPlugin.kt
+++ b/firebase-crashlytics-gradle/src/main/kotlin/com/google/firebase/crashlytics/buildtools/gradle/CrashlyticsPlugin.kt
@@ -27,6 +27,7 @@ import com.google.firebase.crashlytics.buildtools.gradle.tasks.GenerateSymbolFil
 import com.google.firebase.crashlytics.buildtools.gradle.tasks.InjectBuildIdsTask
 import com.google.firebase.crashlytics.buildtools.gradle.tasks.InjectMappingFileIdTask
 import com.google.firebase.crashlytics.buildtools.gradle.tasks.InjectVersionControlInfoTask
+import com.google.firebase.crashlytics.buildtools.gradle.tasks.UploadMappingFileForR8MapIdTask
 import com.google.firebase.crashlytics.buildtools.gradle.tasks.UploadMappingFileTask
 import com.google.firebase.crashlytics.buildtools.gradle.tasks.UploadSymbolFileTask
 import org.gradle.api.GradleException
@@ -106,6 +107,11 @@ class CrashlyticsPlugin : Plugin<Project> {
     project: Project,
     androidComponents: ApplicationAndroidComponentsExtension,
   ) {
+    // AGP 8.12 and above embed a stable, content-derived `r8-map-id` (R8's `r8_map_id`/`pg_map_id`)
+    // in the obfuscated output. On those versions we read that id from the mapping file and upload
+    // with it, keeping the release build cache valid across rebuilds (#6770).
+    val useR8MapId = androidComponents.pluginVersion >= AndroidPluginVersion(8, 12)
+
     androidComponents.onVariants { variant ->
       val crashlyticsExtension: CrashlyticsVariantExtension =
         variant.getExtension(CrashlyticsVariantExtension::class.java)
@@ -113,11 +119,23 @@ class CrashlyticsPlugin : Plugin<Project> {
 
       InjectVersionControlInfoTask.register(project, variant)
 
-      val injectMappingFileIdTask: TaskProvider<InjectMappingFileIdTask> =
-        InjectMappingFileIdTask.register(project, variant, crashlyticsExtension)
+      val mappingFileUploadEnabled =
+        crashlyticsExtension.mappingFileUploadEnabled.getOrElse(variant.isMinifyEnabled)
 
-      if (crashlyticsExtension.mappingFileUploadEnabled.getOrElse(variant.isMinifyEnabled)) {
-        UploadMappingFileTask.register(project, variant, injectMappingFileIdTask)
+      if (useR8MapId) {
+        // AGP 8.12+: inject a fixed sentinel id (blank when nothing is uploaded) so the SDK signals
+        // r8-map-id mode, and derive the real id from R8's mapping file at upload time.
+        InjectMappingFileIdTask.registerForR8MapId(project, variant, mappingFileUploadEnabled)
+        if (mappingFileUploadEnabled) {
+          UploadMappingFileForR8MapIdTask.register(project, variant)
+        }
+      } else {
+        val injectMappingFileIdTask: TaskProvider<InjectMappingFileIdTask> =
+          InjectMappingFileIdTask.register(project, variant, crashlyticsExtension)
+
+        if (mappingFileUploadEnabled) {
+          UploadMappingFileTask.register(project, variant, injectMappingFileIdTask)
+        }
       }
 
       if (crashlyticsExtension.nativeSymbolUploadEnabled.getOrElse(false)) {

--- a/firebase-crashlytics-gradle/src/main/kotlin/com/google/firebase/crashlytics/buildtools/gradle/tasks/InjectMappingFileIdTask.kt
+++ b/firebase-crashlytics-gradle/src/main/kotlin/com/google/firebase/crashlytics/buildtools/gradle/tasks/InjectMappingFileIdTask.kt
@@ -30,18 +30,35 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
 
-/** Inject mapping file id task. */
+/**
+ * Injects a mapping file id into the app's Android resources, read by the Crashlytics SDK at
+ * runtime for deobfuscation. The id source is chosen by the AGP version when the task is
+ * registered:
+ * - **AGP 8.12+** ([registerForR8MapId]): a fixed value — the [CrashlyticsBuildtools.USE_R8_MAP_ID]
+ * that signals the SDK to use R8's `r8-map-id`, or [CrashlyticsBuildtools.BLANK_MAPPING_FILE_ID]
+ * when no mapping is uploaded. Being constant, the resource is byte-identical across rebuilds and
+ * does not invalidate the release build cache (#6770).
+ * - **AGP < 8.12** ([register]): a blank id when no mapping is uploaded, otherwise a fresh random
+ * id generated on every build.
+ */
 @CacheableTask
 abstract class InjectMappingFileIdTask : DefaultTask() {
-  @get:Internal abstract val useBlankMappingFileId: Property<Boolean>
-  @get:OutputFile abstract val mappingFileIdFile: RegularFileProperty
+  /** Fixed id to inject. When unset, a fresh random id is generated on every run. */
+  @get:[Input Optional]
+  abstract val mappingFileId: Property<String>
+
+  /** Optional id text file; written for consumers that read the id from disk (the upload task). */
+  @get:[OutputFile Optional]
+  abstract val mappingFileIdFile: RegularFileProperty
+
   @get:OutputDirectory abstract val resourceDir: DirectoryProperty
 
   init {
@@ -52,55 +69,71 @@ abstract class InjectMappingFileIdTask : DefaultTask() {
 
   @TaskAction
   fun injectMappingFileId() {
-    val mappingFileId =
-      if (useBlankMappingFileId.get()) {
-        CrashlyticsBuildtools.BLANK_MAPPING_FILE_ID
-      } else {
-        CrashlyticsBuildtools.generateMappingFileId()
-      }
-    mappingFileIdFile.get().asFile.writeText(mappingFileId)
-
+    val id = mappingFileId.orNull ?: CrashlyticsBuildtools.generateMappingFileId()
+    if (mappingFileIdFile.isPresent) {
+      mappingFileIdFile.get().asFile.writeText(id)
+    }
     CrashlyticsBuildtools.injectMappingFileIdIntoResource(
       resourceFile = File(resourceDir.get().asFile, "values/$MAPPING_FILE_ID_RESOURCE_FILENAME"),
-      mappingFileId,
+      id,
     )
   }
 
-  /**
-   * Check if a mapping file id file already exists, and that the mapping file id is blank - meaning
-   * no obfuscation is enabled. The Crashlytics SDK always needs a mapping file id.
-   */
-  private fun blankMappingFileIdExists(): Boolean {
-    val file: File = mappingFileIdFile.get().asFile
-    return file.exists() && file.readText() == CrashlyticsBuildtools.BLANK_MAPPING_FILE_ID
-  }
-
   internal companion object {
+    /**
+     * Registers the task for AGP < 8.12: a blank id when no mapping is uploaded, otherwise a fresh
+     * random id on every build.
+     */
     @Suppress("UnstableApiUsage") // isMinifyEnabled
     fun register(
       project: Project,
       variant: ApplicationVariant,
       crashlyticsExtension: CrashlyticsVariantExtension,
-    ): TaskProvider<InjectMappingFileIdTask> {
-      val injectMappingFileIdTaskProvider =
-        project.tasks.register<InjectMappingFileIdTask>(
-          "injectCrashlyticsMappingFileId${variant.name.capitalized()}"
-        ) {
-          this.useBlankMappingFileId.set(
-            !crashlyticsExtension.mappingFileUploadEnabled.getOrElse(variant.isMinifyEnabled)
-          )
-          this.mappingFileIdFile.set(buildFile(project, variant, "mappingFileId.txt"))
-
-          outputs.upToDateWhen { useBlankMappingFileId.get() && blankMappingFileIdExists() }
+    ): TaskProvider<InjectMappingFileIdTask> =
+      registerTask(project, variant) {
+        if (!crashlyticsExtension.mappingFileUploadEnabled.getOrElse(variant.isMinifyEnabled)) {
+          this.mappingFileId.set(CrashlyticsBuildtools.BLANK_MAPPING_FILE_ID)
         }
+        this.mappingFileIdFile.set(buildFile(project, variant, "mappingFileId.txt"))
+        // A fixed id (blank) stays up to date; an unset id regenerates on every build.
+        outputs.upToDateWhen { mappingFileId.isPresent }
+      }
+
+    /**
+     * Registers the task for AGP 8.12+: the constant r8-map-id sentinel, or a blank id when no
+     * mapping is uploaded.
+     */
+    fun registerForR8MapId(
+      project: Project,
+      variant: ApplicationVariant,
+      mappingFileUploadEnabled: Boolean,
+    ): TaskProvider<InjectMappingFileIdTask> =
+      registerTask(project, variant) {
+        this.mappingFileId.set(
+          if (mappingFileUploadEnabled) CrashlyticsBuildtools.USE_R8_MAP_ID
+          else CrashlyticsBuildtools.BLANK_MAPPING_FILE_ID
+        )
+      }
+
+    @Suppress("UnstableApiUsage")
+    private fun registerTask(
+      project: Project,
+      variant: ApplicationVariant,
+      configure: InjectMappingFileIdTask.() -> Unit,
+    ): TaskProvider<InjectMappingFileIdTask> {
+      val provider =
+        project.tasks.register<InjectMappingFileIdTask>(
+          "injectCrashlyticsMappingFileId${variant.name.capitalized()}",
+          configure,
+        )
 
       // It is not possible to disable Android resources in the AGP app plugin.
       variant.sources.res?.addGeneratedSourceDirectory(
-        injectMappingFileIdTaskProvider,
-        InjectMappingFileIdTask::resourceDir,
+        provider,
+        InjectMappingFileIdTask::resourceDir
       )
 
-      return injectMappingFileIdTaskProvider
+      return provider
     }
   }
 }

--- a/firebase-crashlytics-gradle/src/main/kotlin/com/google/firebase/crashlytics/buildtools/gradle/tasks/UploadMappingFileForR8MapIdTask.kt
+++ b/firebase-crashlytics-gradle/src/main/kotlin/com/google/firebase/crashlytics/buildtools/gradle/tasks/UploadMappingFileForR8MapIdTask.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.google.firebase.crashlytics.buildtools.gradle.tasks
+
+import com.android.build.api.artifact.SingleArtifact
+import com.android.build.api.variant.Variant
+import com.google.firebase.crashlytics.buildtools.AppBuildInfo
+import com.google.firebase.crashlytics.buildtools.Obfuscator
+import com.google.firebase.crashlytics.buildtools.exception.ZeroByteFileException
+import com.google.firebase.crashlytics.buildtools.gradle.AppIdFetcher
+import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsBuildtools
+import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPlugin
+import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPlugin.Companion.CRASHLYTICS_TASK_GROUP
+import com.google.firebase.crashlytics.buildtools.gradle.extensions.capitalized
+import java.io.File
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.kotlin.dsl.register
+import org.gradle.work.DisableCachingByDefault
+
+/**
+ * Uploads the obfuscation mapping file for AGP 8.12+ builds.
+ *
+ * Starting with AGP 8.12, R8 stamps a stable, content-derived id (`r8_map_id`/`pg_map_id`) into the
+ * merged mapping file as a comment. It stays identical across rebuilds while the obfuscated output
+ * is unchanged and changes only when R8's output changes, so it is a stable handle for the uploaded
+ * mapping and keeps the release build cache valid (#6770).
+ *
+ * This task reads that id straight out of the mapping file and uploads with it. The id reaches
+ * crash reports through the `r8-map-id` that R8 embeds in the obfuscated stack frames.
+ */
+@DisableCachingByDefault(because = "Uploading to network")
+abstract class UploadMappingFileForR8MapIdTask : DefaultTask() {
+  @get:[InputFile PathSensitive(PathSensitivity.NONE) SkipWhenEmpty]
+  abstract val mergedMappingFile: RegularFileProperty
+  @get:[InputFile PathSensitive(PathSensitivity.NONE) Optional]
+  abstract val appIdFile: RegularFileProperty
+  @get:Internal abstract val buildDir: DirectoryProperty
+
+  init {
+    group = CRASHLYTICS_TASK_GROUP
+    description = "Uploads mapping files to Crashlytics for crash deobfuscation."
+  }
+
+  @TaskAction
+  fun uploadMappingFile() {
+    val mappingFile = mergedMappingFile.get().asFile
+    val mappingFileId = extractR8MapId(mappingFile)
+    if (mappingFileId == null) {
+      logger.warn(
+        "Crashlytics could not find an r8 map id (`r8_map_id`/`pg_map_id`) in ${mappingFile.path}; " +
+          "skipping mapping file upload. This id is emitted by R8 in AGP 8.12 and above when " +
+          "obfuscation is enabled."
+      )
+      return
+    }
+    try {
+      val appId = appIdFile.get().asFile.readText()
+      // TODO (rothbutter) Vendor field is always assumed to be PROGUARD
+      CrashlyticsBuildtools.uploadMappingFile(
+        mappingFile,
+        mappingFileId = mappingFileId,
+        AppBuildInfo("", appId, buildDir.get().asFile),
+        Obfuscator(Obfuscator.Vendor.PROGUARD, "0.0"),
+      )
+    } catch (ex: ZeroByteFileException) {
+      logger.warn(
+        ex.message,
+        "(Use -Pcom.google.firebase.crashlytics.suppressWarnings=true to suppress this warning)",
+      )
+    }
+  }
+
+  internal companion object {
+    // R8 stamps the map id in the mapping file header, e.g. `# r8_map_id: <hex>` and/or
+    // `# pg_map_id: <hex>`. Prefer r8_map_id — it is the full map hash matching the r8-map-id R8
+    // embeds in obfuscated stack frames (what the backend extracts); pg_map_id is the fallback for
+    // older mapping files.
+    private val MAP_ID_REGEX = Regex("""^#\s*(r8_map_id|pg_map_id):\s*([0-9a-fA-F]+)\s*$""")
+
+    /**
+     * Returns the r8 map id from an R8 mapping file (prefers r8_map_id), or null if not present.
+     */
+    fun extractR8MapId(mappingFile: File): String? {
+      var r8MapId: String? = null
+      var pgMapId: String? = null
+      mappingFile.useLines { lines ->
+        for (line in lines) {
+          if (line.isBlank()) continue
+          if (!line.startsWith("#")) break // header comments precede the first class mapping
+          val match = MAP_ID_REGEX.find(line) ?: continue
+          when (match.groupValues[1]) {
+            "r8_map_id" -> r8MapId = match.groupValues[2]
+            "pg_map_id" -> pgMapId = match.groupValues[2]
+          }
+          if (r8MapId != null) break // preferred id found
+        }
+      }
+      return r8MapId ?: pgMapId
+    }
+
+    fun register(
+      project: Project,
+      variant: Variant
+    ): TaskProvider<UploadMappingFileForR8MapIdTask> {
+      val uploadMappingFileTaskProvider =
+        project.tasks.register<UploadMappingFileForR8MapIdTask>(
+          "uploadCrashlyticsMappingFile${variant.name.capitalized()}"
+        ) {
+          this.mergedMappingFile.set(variant.artifacts.get(SingleArtifact.OBFUSCATION_MAPPING_FILE))
+          this.appIdFile.set(AppIdFetcher.getGoogleServicesAppId(project, variant))
+          this.buildDir.set(CrashlyticsPlugin.buildDir(project, variant))
+
+          printDebugProperties()
+        }
+
+      // Do this outside of the configuration lambda because some lazy loading is happening.
+      project.afterEvaluate {
+        it.tasks
+          .findByPath("minify${variant.name.capitalized()}WithR8")
+          ?.finalizedBy(uploadMappingFileTaskProvider)
+      }
+
+      return uploadMappingFileTaskProvider
+    }
+  }
+
+  private fun printDebugProperties() {
+    logger.debug("UploadMappingFileForR8MapIdTask:")
+    logger.debug("  mergedMappingFile: ${mergedMappingFile.orNull?.asFile?.path}")
+    logger.debug("  appIdFile: ${appIdFile.orNull?.asFile?.path}")
+    logger.debug("  buildDir: ${buildDir.orNull?.asFile?.path}")
+  }
+}

--- a/firebase-crashlytics-gradle/src/test/kotlin/com/google/firebase/crashlytics/buildtools/gradle/tasks/UploadMappingFileForR8MapIdTaskTest.kt
+++ b/firebase-crashlytics-gradle/src/test/kotlin/com/google/firebase/crashlytics/buildtools/gradle/tasks/UploadMappingFileForR8MapIdTaskTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.crashlytics.buildtools.gradle.tasks
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class UploadMappingFileForR8MapIdTaskTest {
+
+  @TempDir lateinit var tempDir: File
+
+  private fun mappingFile(contents: String): File =
+    File(tempDir, "mapping.txt").apply { writeText(contents) }
+
+  @Test
+  fun `extractR8MapId returns the pg_map_id from a typical R8 mapping header`() {
+    val mapping =
+      mappingFile(
+        """
+        # compiler: R8
+        # compiler_version: 9.1.31
+        # min_api: 24
+        # common_typos_disable
+        # {"id":"com.android.tools.r8.mapping","version":"2.2"}
+        # pg_map_id: af97edca6a8456b027e588e6168d6310661fa953e25f5bce3730fb21041f8dfa
+        # pg_map_hash: SHA-256 af97edca6a8456b027e588e6168d6310661fa953e25f5bce3730fb21041f8dfa
+        com.example.Foo -> a.a:
+            void bar() -> a
+        """
+          .trimIndent()
+      )
+
+    assertThat(UploadMappingFileForR8MapIdTask.extractR8MapId(mapping))
+      .isEqualTo("af97edca6a8456b027e588e6168d6310661fa953e25f5bce3730fb21041f8dfa")
+  }
+
+  @Test
+  fun `extractR8MapId ignores the similarly named pg_map_hash comment`() {
+    // pg_map_hash also starts with a hex value but is prefixed by `SHA-256 `, so it must not match.
+    val mapping =
+      mappingFile(
+        """
+        # pg_map_hash: SHA-256 deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+        # pg_map_id: 0123456789abcdef0123456789abcdef
+        """
+          .trimIndent()
+      )
+
+    assertThat(UploadMappingFileForR8MapIdTask.extractR8MapId(mapping))
+      .isEqualTo("0123456789abcdef0123456789abcdef")
+  }
+
+  @Test
+  fun `extractR8MapId returns null when no pg_map_id is present`() {
+    val mapping =
+      mappingFile(
+        """
+        # compiler: R8
+        com.example.Foo -> a.a:
+            void bar() -> a
+        """
+          .trimIndent()
+      )
+
+    assertThat(UploadMappingFileForR8MapIdTask.extractR8MapId(mapping)).isNull()
+  }
+
+  @Test
+  fun `extractR8MapId returns null for an empty mapping file`() {
+    assertThat(UploadMappingFileForR8MapIdTask.extractR8MapId(mappingFile(""))).isNull()
+  }
+
+  @Test
+  fun `extractR8MapId returns null when the pg_map_id value is missing`() {
+    assertThat(UploadMappingFileForR8MapIdTask.extractR8MapId(mappingFile("# pg_map_id:"))).isNull()
+  }
+
+  @Test
+  fun `extractR8MapId returns the r8_map_id when present`() {
+    val mapping =
+      mappingFile(
+        """
+        # compiler: R8
+        # r8_map_id: 1111aaaa2222bbbb3333cccc4444dddd
+        com.example.Foo -> a.a:
+        """
+          .trimIndent()
+      )
+
+    assertThat(UploadMappingFileForR8MapIdTask.extractR8MapId(mapping))
+      .isEqualTo("1111aaaa2222bbbb3333cccc4444dddd")
+  }
+
+  @Test
+  fun `extractR8MapId prefers r8_map_id over pg_map_id regardless of order`() {
+    val r8First = mappingFile("# r8_map_id: aaaa1111\n# pg_map_id: bbbb2222")
+    val pgFirst = mappingFile("# pg_map_id: bbbb2222\n# r8_map_id: aaaa1111")
+
+    assertThat(UploadMappingFileForR8MapIdTask.extractR8MapId(r8First)).isEqualTo("aaaa1111")
+    assertThat(UploadMappingFileForR8MapIdTask.extractR8MapId(pgFirst)).isEqualTo("aaaa1111")
+  }
+}


### PR DESCRIPTION
#6770


`injectCrashlyticsMappingFileIdRelease` minted a new random id on every minified release build and wrote it into a generated resource, cascading through `mergeResources → R8 → packaging` and invalidating the build cache on every release.

Since AGP 8.12, R8 stamps a stable, content-derived map id (`pg_map_id`) into the mapping file and embeds the matching `r8-map-id` in obfuscated stack frames. On AGP 8.12+ we consume that id instead of minting our own — stable when the obfuscated output is unchanged, regenerated only when it changes. No churning id, no cache busting.

## Changes

- **New `UploadMappingFileForR8MapIdTask`** task: reads the map id from the merged mapping file and uploads with it. Falls back to `pg_map_id` (the only id R8 emits today) but prefers an `r8_map_id` header defensively if a future R8 ever writes one. Warns and skips when no id is present.
- **`InjectMappingFileIdTask`** serves both paths via two factory methods: `registerForR8MapId` injects the constant `USE_R8_MAP_ID` sentinel (all ones, blank when no mapping is uploaded); `register` keeps the legacy blank/random behavior. Being constant, the AGP 8.12+ resource is byte-identical across rebuilds and keeps the release build cache valid.
- **`CrashlyticsPlugin`** gates on AGP version: `>= 8.12` registers the sentinel inject + new upload tasks; `< 8.12` keeps the original inject + upload behavior unchanged.


## Verification

To confirm the standalone results reflect real AGP-driven builds, [a minimal Android app](https://github.com/jrodiz/pg_map_id_probe) (one kept entry class + one obfuscated helper, `isMinifyEnabled = true`, default optimize rules) was built with `:assembleRelease` across five AGP versions on JDK 17, each AGP paired with its required Gradle version, and the resulting `app/build/outputs/mapping/release/mapping.txt` header inspected:

| AGP | bundled R8 | compileSdk | `pg_map_id` length | `r8_map_id` present? |
|---|---|---|---|---|
| 8.1.4  | 8.1.68 | 34 | 7 (prefix) | no |
| 8.7.3  | 8.7.18 | 34 | 7 (prefix) | no |
| 8.11.2 | 8.11.26 | 35 | 7 (prefix) | no |
| 8.12.0 | 8.12.14 | 35 | 64 (full hash) | no |
| 8.13.0 | 8.13.6 | 35 | 64 (full hash) | no |
| 9.1.0  | 9.1.31 | 36 | 64 (full hash) | no |
| 9.2.1  | 9.2.14 | 36 | 64 (full hash) | no |