### PR TITLE
dataconnect(fix): fix abruptly failure in realtime query subscriptions if the auth token changed

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -14,6 +14,9 @@
 - [fixed] Realtime query subscriptions now correctly throw an exception when
   the Firebase Auth user changes, instead of silently stopping emitting.
   ([#8283](https://github.com/firebase/firebase-android-sdk/pull/8283))
+- [fixed] Realtime query subscriptions could fail abruptly if the auth
+  token changed while connected.
+  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
 
 # 17.3.0
 

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -16,7 +16,7 @@
   ([#8283](https://github.com/firebase/firebase-android-sdk/pull/8283))
 - [fixed] Realtime query subscriptions could fail abruptly if the auth
   token changed while connected.
-  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
+  ([#8312](https://github.com/firebase/firebase-android-sdk/pull/8312))
 
 # 17.3.0
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -270,6 +270,7 @@ internal class DataConnectBidiConnectStream(
     }
 
     class Connected(
+      val connectionId: String,
       val outgoingRequests: SendChannel<StreamRequestProto>,
       private val hadPendingSubscription: Boolean,
       private val subscribeOrResumeSignal: ConflatedSignal,
@@ -292,6 +293,7 @@ internal class DataConnectBidiConnectStream(
 
       override fun toString(): String =
         "Connected(" +
+          "connectionId=$connectionId, " +
           "hadPendingSubscription=$hadPendingSubscription, " +
           "subscribeOrResumeSignal.hasPendingSignal=${subscribeOrResumeSignal.hasPendingSignal}, " +
           "subscribeOrResumeJob={isActive=${subscribeOrResumeJob.isActive}, " +
@@ -392,10 +394,14 @@ internal class DataConnectBidiConnectStream(
         val isPendingSubscription =
           when (currentState) {
             is SubscriptionState.Connected ->
-              error(
-                "internal error nqe9gre3ny: got event $event, " +
-                  "but state=$currentState (expected state=Disconnected)"
-              )
+              if (currentState.connectionId == event.connectionId) {
+                break // already connected; this can occur due to an auth token update
+              } else {
+                error(
+                  "internal error nqe9gre3ny: got event $event, " +
+                    "but state=$currentState (expected state=Disconnected)"
+                )
+              }
             is SubscriptionState.Disconnected -> false
             is SubscriptionState.DisconnectedWithPendingSubscription -> true
           }
@@ -414,6 +420,7 @@ internal class DataConnectBidiConnectStream(
 
         val newState =
           SubscriptionState.Connected(
+            event.connectionId,
             event.outgoingRequests,
             hadPendingSubscription = isPendingSubscription,
             subscribeOrResumeSignal = subscribeOrResumeSignal,

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -399,7 +399,8 @@ internal class DataConnectBidiConnectStream(
               } else {
                 error(
                   "internal error nqe9gre3ny: got event $event, " +
-                    "but state=$currentState (expected state=Disconnected)"
+                    "but state=$currentState (expected state=Disconnected or " +
+                    "state=Connected(connectionId=${event.connectionId}))"
                 )
               }
             is SubscriptionState.Disconnected -> false


### PR DESCRIPTION
This PR resolves an issue in `firebase-dataconnect` where realtime query subscriptions fail abruptly with an `IllegalStateException` when the Firebase Auth token is updated mid-stream. It fixes the state machine logic by identifying and ignoring connection events representing token refreshes on the already-connected stream.

### Highlights

* **Auth Token Refresh Crash Fix**: Fixed a bug where a mid-stream auth token update triggered an incorrect transition to the `Connected` state, resulting in a crash.
* **Connection ID Tracking**: Added tracking of `connectionId` to `SubscriptionState.Connected` to distinguish between new connections and token refreshes on the same connection.

<details>
<summary><b>Changelog</b></summary>

* **CHANGELOG.md**
  * Added a fixed entry noting that realtime query subscriptions no longer fail when the auth token changes while connected.
* **DataConnectBidiConnectStream.kt**
  * Added `connectionId` to `SubscriptionState.Connected`.
  * Updated `transitionToConnectedState()` to ignore `Connected` events that match the current active `connectionId`, preventing erroneous `IllegalStateException` errors.
</details>