### PR TITLE
dataconnect(chore): headless_android_emulator_run.zsh minor improvements

### DIFF
--- a/firebase-dataconnect/scripts/headless_android_emulator_run.zsh
+++ b/firebase-dataconnect/scripts/headless_android_emulator_run.zsh
@@ -112,6 +112,7 @@ typeset -r args=(
   -timezone "Etc/UTC"
   -skip-adb-auth
   -no-metrics
+  -grpc-use-token
   "${emulator_extra_args[@]}"
 )
 

--- a/firebase-dataconnect/scripts/headless_android_emulator_run.zsh
+++ b/firebase-dataconnect/scripts/headless_android_emulator_run.zsh
@@ -35,6 +35,37 @@ show_help() {
   say "to find the Android emulator binary."
 }
 
+host_cpu_arch() {
+  case "$(uname -m)" in
+    arm64|aarch64) say "arm64-v8a" ;;
+    x86_64|amd64)  say "x86_64" ;;
+    *)             say "unknown" ;;
+  esac
+}
+
+say_sample_create_avd_command() {
+  local -r sdk_package="system-images;android-36;google_apis;$(host_cpu_arch)"
+  local -r avdmanager_cmd="${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager"
+  local -r avdmanager_args=(
+    "${avdmanager_cmd}"
+    --verbose
+    create
+    avd
+    --device
+    small_phone
+    --name
+    SmallPhoneAPI36
+    --package
+    "${sdk_package}"
+  )
+  say_args "${avdmanager_args[@]}"
+
+  local -r sdkmanager_cmd="${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager"
+  local -r sdkmanager_args=("${sdkmanager_cmd}" "${sdk_package}")
+  say "If needed, install the ${sdk_package} package by running:"
+  say_args "${sdkmanager_args[@]}"
+}
+
 # Parse the command-line arguments.
 zparseopts -D -E h=opt_help
 if (( ${#opt_help} )); then
@@ -84,6 +115,8 @@ if (( ! ${+emulator_avd} )) ; then
   typeset -r avds
   if (( ${#avds[@]} == 0 )) ; then
     say_error "no AVDs are configured in the Android emulator." >&2
+    say "To create an AVD, run this command:" >&2
+    say_sample_create_avd_command >&2
     exit 1
   elif (( ${#avds[@]} > 1 )) ; then
     say_error "${#avds[@]} AVDs are configured in the Android emulator." >&2

--- a/firebase-dataconnect/scripts/headless_android_emulator_run.zsh
+++ b/firebase-dataconnect/scripts/headless_android_emulator_run.zsh
@@ -103,7 +103,7 @@ typeset -r args=(
   -no-audio
   -no-boot-anim
   -accel on
-  -gpu off
+  -gpu host # use "swiftshader_indirect" for robust software rendering in CI/CD runners
   -no-snapshot-load
   -no-snapshot-save
   -screen touch

--- a/firebase-dataconnect/scripts/headless_android_emulator_run.zsh
+++ b/firebase-dataconnect/scripts/headless_android_emulator_run.zsh
@@ -109,7 +109,7 @@ typeset -r args=(
   -screen touch
   -netfast
   -no-sim
-  -timezone UTC
+  -timezone "Etc/UTC"
   -skip-adb-auth
   -no-metrics
   "${emulator_extra_args[@]}"

--- a/firebase-dataconnect/scripts/headless_android_emulator_run.zsh
+++ b/firebase-dataconnect/scripts/headless_android_emulator_run.zsh
@@ -136,7 +136,6 @@ typeset -r args=(
   -no-audio
   -no-boot-anim
   -accel on
-  -gpu host # use "swiftshader_indirect" for robust software rendering in CI/CD runners
   -no-snapshot-load
   -no-snapshot-save
   -screen touch


### PR DESCRIPTION
Introduces several minor improvements and warning fixes to the `headless_android_emulator_run.zsh` script for Data Connect SDK development. These enhancements improve emulator performance, secure the gRPC port, resolve timezone warnings, and provide helpful setup commands when no AVDs are configured.

### Highlights

* **AVD Creation Helper**: Implemented host CPU architecture detection and added helper functions to print sample `avdmanager` and `sdkmanager` commands when no Android Virtual Devices (AVDs) are configured locally.
* **Warning Fixes**: Resolved gRPC security warnings by adding the `-grpc-use-token` flag and eliminated timezone zoneinfo warnings by switching the `-timezone` flag value from `UTC` to `"Etc/UTC"`.
* **Auto-GPU Detection**: Removed the hardcoded `-gpu off` flag, allowing the emulator to default to automatic GPU detection for better rendering performance.

<details>

<summary><b>Changelog</b></summary>

* **headless_android_emulator_run.zsh**
  * Added `host_cpu_arch` function to detect the host machine's CPU architecture (`arm64` or `x86_64`).
  * Added `say_sample_create_avd_command` function to generate and output example `avdmanager` and `sdkmanager` commands for setting up a compatible AVD.
  * Updated AVD verification logic to output these setup commands and exit when no AVDs are configured.
  * Removed the hardcoded `-gpu off` flag from the emulator launch options.
  * Changed the `-timezone UTC` flag to `-timezone "Etc/UTC"`.
  * Added the `-grpc-use-token` flag to secure gRPC access and silence warning messages.

</details>