### PR TITLE
dataconnect(test): person_ops.gql: fix illegal `@check` directive outside of a transaction

### DIFF
--- a/firebase-dataconnect/emulator/dataconnect/connector/person/person_ops.gql
+++ b/firebase-dataconnect/emulator/dataconnect/connector/person/person_ops.gql
@@ -96,7 +96,7 @@ query getPersonWithPartialFailure($id: String!) @auth(level: PUBLIC) {
 
 mutation createPersonWithPartialFailure($id1: String!, $id2: String!, $name: String!) @auth(level: PUBLIC) {
   person1: person_insert(data: { id: $id1, name: $name })
-  query @redact { _select(sql: "SELECT NoSuchColumn FROM ShouldFail") }
+  query @redact { _select(sql: "SELECT 1/0") }
   person2: person_insert(data: { id: $id2, name: $name })
 }
 

--- a/firebase-dataconnect/emulator/dataconnect/connector/person/person_ops.gql
+++ b/firebase-dataconnect/emulator/dataconnect/connector/person/person_ops.gql
@@ -94,10 +94,10 @@ query getPersonWithPartialFailure($id: String!) @auth(level: PUBLIC) {
   person2: person(id: $id) @check(expr: "false", message: "c8azjdwz2x") { name }
 }
 
-mutation createPersonWithPartialFailure($id: String!, $name: String!) @auth(level: PUBLIC) {
-  person1: person_insert(data: { id: $id, name: $name })
-  query @redact { person(id: $id) { id @check(expr: "false", message: "ecxpjy4qfy") } }
-  person2: person_insert(data: { id_expr: "uuidV4()", name: $name })
+mutation createPersonWithPartialFailure($id1: String!, $id2: String!, $name: String!) @auth(level: PUBLIC) {
+  person1: person_insert(data: { id: $id1, name: $name })
+  query @redact { _select(sql: "SELECT NoSuchColumn FROM ShouldFail") }
+  person2: person_insert(data: { id: $id2, name: $name })
 }
 
 mutation createPersonWithPartialFailureInTransaction($id: String!, $name: String!) @auth(level: PUBLIC) @transaction {

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/OperationExecutionErrorsIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/OperationExecutionErrorsIntegrationTest.kt
@@ -17,6 +17,7 @@
 package com.google.firebase.dataconnect
 
 import com.google.firebase.dataconnect.testutil.DataConnectIntegrationTestBase
+import com.google.firebase.dataconnect.testutil.property.arbitrary.distinctPair
 import com.google.firebase.dataconnect.testutil.schemas.PersonSchema
 import com.google.firebase.dataconnect.testutil.schemas.PersonSchema.CreatePersonMutation
 import com.google.firebase.dataconnect.testutil.schemas.PersonSchema.GetPersonQuery
@@ -157,12 +158,12 @@ class OperationExecutionErrorsIntegrationTest : DataConnectIntegrationTestBase()
 
   @Test
   fun executeMutationFailsWithNonNullDataNonEmptyErrorsDecodingSucceeds() = runTest {
-    val id = Arb.alphanumericString().next()
+    val (id1, id2) = Arb.alphanumericString().distinctPair().next()
     val name = Arb.alphanumericString().next()
     val mutationRef =
       dataConnect.mutation(
         operationName = "createPersonWithPartialFailure",
-        variables = CreatePersonWithPartialFailureVariables(id = id, name = name),
+        variables = CreatePersonWithPartialFailureVariables(id1 = id1, id2 = id2, name = name),
         dataDeserializer = serializer<CreatePersonWithPartialFailureData>(),
         variablesSerializer = serializer(),
         optionsBuilder = {},
@@ -172,10 +173,10 @@ class OperationExecutionErrorsIntegrationTest : DataConnectIntegrationTestBase()
 
     exception.shouldSatisfy(
       expectedMessageSubstringCaseInsensitive = "operation encountered errors",
-      expectedMessageSubstringCaseSensitive = "ecxpjy4qfy",
+      expectedMessageSubstringCaseSensitive = "invalid sql statement",
       expectedCause = null,
-      expectedRawData = mapOf("person1" to mapOf("id" to id), "person2" to null),
-      expectedData = CreatePersonWithPartialFailureData(id),
+      expectedRawData = mapOf("person1" to mapOf("id" to id1), "person2" to mapOf("id" to id2)),
+      expectedData = CreatePersonWithPartialFailureData(id1, id2),
       errorsValidator = { it.shouldHaveAtLeastSize(1) },
     )
   }
@@ -208,12 +209,12 @@ class OperationExecutionErrorsIntegrationTest : DataConnectIntegrationTestBase()
 
   @Test
   fun executeMutationFailsWithNonNullDataNonEmptyErrorsDecodingFails() = runTest {
-    val id = Arb.alphanumericString().next()
+    val (id1, id2) = Arb.alphanumericString().distinctPair().next()
     val name = Arb.alphanumericString().next()
     val mutationRef =
       dataConnect.mutation(
         operationName = "createPersonWithPartialFailure",
-        variables = CreatePersonWithPartialFailureVariables(id = id, name = name),
+        variables = CreatePersonWithPartialFailureVariables(id1 = id1, id2 = id2, name = name),
         dataDeserializer = serializer<IncompatibleData>(),
         variablesSerializer = serializer(),
         optionsBuilder = {},
@@ -223,10 +224,35 @@ class OperationExecutionErrorsIntegrationTest : DataConnectIntegrationTestBase()
 
     exception.shouldSatisfy(
       expectedMessageSubstringCaseInsensitive = "operation encountered errors",
-      expectedMessageSubstringCaseSensitive = "ecxpjy4qfy",
+      expectedMessageSubstringCaseSensitive = "invalid sql statement",
       expectedCause = null,
-      expectedRawData = mapOf("person1" to mapOf("id" to id), "person2" to null),
+      expectedRawData = mapOf("person1" to mapOf("id" to id1), "person2" to mapOf("id" to id2)),
       expectedData = null,
+      errorsValidator = { it.shouldHaveAtLeastSize(1) },
+    )
+  }
+
+  @Test
+  fun executeMutationFailsWithNonNullDataNonEmptyErrorsDecodingSucceedsInTransaction() = runTest {
+    val id = Arb.alphanumericString().next()
+    val name = Arb.alphanumericString().next()
+    val mutationRef =
+      dataConnect.mutation(
+        operationName = "createPersonWithPartialFailureInTransaction",
+        variables = CreatePersonWithPartialFailureVariablesInTransaction(id = id, name = name),
+        dataDeserializer = serializer<CreatePersonWithPartialFailureDataNullable>(),
+        variablesSerializer = serializer(),
+        optionsBuilder = {},
+      )
+
+    val exception = shouldThrow<DataConnectOperationException> { mutationRef.execute() }
+
+    exception.shouldSatisfy(
+      expectedMessageSubstringCaseInsensitive = "operation encountered errors",
+      expectedMessageSubstringCaseSensitive = null,
+      expectedCause = null,
+      expectedRawData = mapOf("person1" to null, "person2" to null),
+      expectedData = CreatePersonWithPartialFailureDataNullable(null, null),
       errorsValidator = { it.shouldHaveAtLeastSize(1) },
     )
   }
@@ -238,7 +264,7 @@ class OperationExecutionErrorsIntegrationTest : DataConnectIntegrationTestBase()
     val mutationRef =
       dataConnect.mutation(
         operationName = "createPersonWithPartialFailureInTransaction",
-        variables = CreatePersonWithPartialFailureVariables(id = id, name = name),
+        variables = CreatePersonWithPartialFailureVariablesInTransaction(id = id, name = name),
         dataDeserializer = serializer<IncompatibleData>(),
         variablesSerializer = serializer(),
         optionsBuilder = {},
@@ -273,15 +299,28 @@ class OperationExecutionErrorsIntegrationTest : DataConnectIntegrationTestBase()
   }
 
   @Serializable
-  private data class CreatePersonWithPartialFailureVariables(val id: String, val name: String)
+  private data class CreatePersonWithPartialFailureVariables(
+    val id1: String,
+    val id2: String,
+    val name: String,
+  )
 
   @Serializable
-  private data class CreatePersonWithPartialFailureData(
-    val person1: Person,
-    val person2: Nothing?
-  ) {
-    constructor(person1Id: String) : this(Person(person1Id), null)
+  private data class CreatePersonWithPartialFailureVariablesInTransaction(
+    val id: String,
+    val name: String,
+  )
 
-    @Serializable private data class Person(val id: String)
+  @Serializable
+  private data class CreatePersonWithPartialFailureData(val person1: Person, val person2: Person) {
+    constructor(person1Id: String, person2Id: String) : this(Person(person1Id), Person(person2Id))
+
+    @Serializable data class Person(val id: String)
   }
+
+  @Serializable
+  private data class CreatePersonWithPartialFailureDataNullable(
+    val person1: CreatePersonWithPartialFailureData.Person?,
+    val person2: CreatePersonWithPartialFailureData.Person?,
+  )
 }

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/OperationExecutionErrorsIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/OperationExecutionErrorsIntegrationTest.kt
@@ -173,7 +173,7 @@ class OperationExecutionErrorsIntegrationTest : DataConnectIntegrationTestBase()
 
     exception.shouldSatisfy(
       expectedMessageSubstringCaseInsensitive = "operation encountered errors",
-      expectedMessageSubstringCaseSensitive = "invalid sql statement",
+      expectedMessageSubstringCaseSensitive = null,
       expectedCause = null,
       expectedRawData = mapOf("person1" to mapOf("id" to id1), "person2" to mapOf("id" to id2)),
       expectedData = CreatePersonWithPartialFailureData(id1, id2),
@@ -224,7 +224,7 @@ class OperationExecutionErrorsIntegrationTest : DataConnectIntegrationTestBase()
 
     exception.shouldSatisfy(
       expectedMessageSubstringCaseInsensitive = "operation encountered errors",
-      expectedMessageSubstringCaseSensitive = "invalid sql statement",
+      expectedMessageSubstringCaseSensitive = null,
       expectedCause = null,
       expectedRawData = mapOf("person1" to mapOf("id" to id1), "person2" to mapOf("id" to id2)),
       expectedData = null,


### PR DESCRIPTION
This PR fixes the data connect integration tests when run against prod.

For the longest time, the file `person_ops.gql` has this mutation defined:

```gql
mutation createPersonWithPartialFailure($id: String!, $name: String!) @auth(level: PUBLIC) {
  person1: person_insert(data: { id: $id, name: $name })
  query @redact { person(id: $id) { id @check(expr: "false", message: "ecxpjy4qfy") } }
  person2: person_insert(data: { id_expr: "uuidV4()", name: $name })
}
```

Note the `@check` directive in the "query" line. This is accepted by the data connect emulator but fails with the following error from `firebase deploy --only dataconnect`:

```
Error: There are errors in your schema and connector files:
person_ops.gql:99: On person2: @check is disallowed on side-effect fields unless the operation has @transaction
```

This restriction on `@check` directives was added a long time ago but is only enforced in prod.

This PR changes the definition to use invalid SQL to trigger a partial failure, like this:

```gql
mutation createPersonWithPartialFailure($id1: String!, $id2: String!, $name: String!) @auth(level: PUBLIC) {
  person1: person_insert(data: { id: $id1, name: $name })
  query @redact { _select(sql: "SELECT NoSuchColumn FROM ShouldFail") }
  person2: person_insert(data: { id: $id2, name: $name })
}
```