### PR TITLE
dataconnect(fix): fix potential infinite loop when Auth and/or App Check tokens refreshed

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -17,6 +17,9 @@
 - [fixed] Realtime query subscriptions could fail abruptly if the auth
   token changed while connected.
   ([#8312](https://github.com/firebase/firebase-android-sdk/pull/8312))
+- [fixed] An infinite loop could occur when Auth and/or App Check tokens were
+  refreshed.
+  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
 
 # 17.3.0
 

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -19,7 +19,7 @@
   ([#8312](https://github.com/firebase/firebase-android-sdk/pull/8312))
 - [fixed] An infinite loop could occur when Auth and/or App Check tokens were
   refreshed.
-  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
+  ([#8319](https://github.com/firebase/firebase-android-sdk/pull/8319))
 
 # 17.3.0
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectCredentialsTokenManager.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectCredentialsTokenManager.kt
@@ -410,7 +410,6 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
   private sealed class GetTokenRetry(message: String) : Exception(message)
   private class ForceRefresh(message: String) : GetTokenRetry(message)
   private class NewProvider(message: String) : GetTokenRetry(message)
-  private class NewToken(message: String) : GetTokenRetry(message)
 
   @DeferredApi
   private fun onProviderAvailable(newProvider: T) {
@@ -459,27 +458,35 @@ internal sealed class DataConnectCredentialsTokenManager<T : Any, R : GetTokenRe
     val invocationId = idStringGenerator.next("otc")
     logger.debug { "$invocationId onTokenChanged(newToken=${newToken?.toScrubbedAccessToken()})" }
 
-    while (true) {
-      val currentState = state.value
-
-      val activeState =
-        when (currentState) {
-          State.New -> return
-          is State.Initialized -> break
-          is State.Idle -> break
-          is State.Active -> currentState
-          State.Closed -> return
-        }
-
-      val newState = State.Idle(activeState.provider, forceTokenRefresh = false)
-      if (state.compareAndSet(currentState, newState)) {
-        val message = "$invocationId a new token is available (j567n2577q)"
-        activeState.job.cancel(message, NewToken(message))
-        break
+    when (val currentState = state.value) {
+      State.New -> return
+      is State.Initialized,
+      is State.Idle -> {
+        coroutineScope.launch(CoroutineName("$invocationId.ds5wtt2m5g")) { getToken(invocationId) }
       }
-    }
+      is State.Active -> {
+        coroutineScope.launch(CoroutineName("$invocationId.p97bsry4p8")) {
+          val result = currentState.job.runCatching { await() }
+          currentCoroutineContext().ensureActive()
 
-    coroutineScope.launch(CoroutineName(invocationId)) { getToken(invocationId) }
+          val callGetToken =
+            result.fold(
+              onFailure = { true },
+              onSuccess = { result2 ->
+                result2.ref.fold(
+                  onFailure = { true },
+                  onSuccess = { it.token != newToken },
+                )
+              },
+            )
+
+          if (callGetToken) {
+            getToken(invocationId)
+          }
+        }
+      }
+      State.Closed -> return
+    }
   }
 
   /**

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
@@ -18,9 +18,7 @@
 package com.google.firebase.dataconnect.core
 
 import app.cash.turbine.test
-import com.google.android.gms.tasks.TaskCompletionSource
 import com.google.android.gms.tasks.Tasks
-import com.google.firebase.auth.GetTokenResult
 import com.google.firebase.auth.internal.IdTokenListener
 import com.google.firebase.auth.internal.InternalAuthProvider
 import com.google.firebase.dataconnect.DataConnectException
@@ -31,7 +29,6 @@ import com.google.firebase.dataconnect.testutil.DataConnectLogLevelRule
 import com.google.firebase.dataconnect.testutil.DelayedDeferred
 import com.google.firebase.dataconnect.testutil.ImmediateDeferred
 import com.google.firebase.dataconnect.testutil.SuspendingCountDownLatch
-import com.google.firebase.dataconnect.testutil.SuspendingFlag
 import com.google.firebase.dataconnect.testutil.UnavailableDeferred
 import com.google.firebase.dataconnect.testutil.awaitUntilItem
 import com.google.firebase.dataconnect.testutil.newBackgroundScopeThatAdvancesLikeForeground
@@ -61,6 +58,7 @@ import io.kotest.matchers.collections.shouldBeSorted
 import io.kotest.matchers.collections.shouldBeUnique
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -795,37 +793,6 @@ class DataConnectAuthUnitTest {
   }
 
   @Test
-  fun `onTokenChanged() should cancel in-flight getToken() requests and retry`() = runTest {
-    val dataConnectAuth = newDataConnectAuth()
-    val idTokenListener = dataConnectAuth.initializeAndGetIdTokenListener()
-
-    val taskCompletionSource1 = TaskCompletionSource<GetTokenResult>()
-    val finalToken = GetAuthTokenResult("test-token", AuthUid("test-user"))
-    val getAccessTokenCalled = SuspendingFlag()
-    run {
-      val tokenTask = taskForToken(finalToken.token, finalToken.authUid)
-      coEvery { mockInternalAuthProvider.getAccessToken(any()) } coAnswers
-        {
-          val isFirstCall = !getAccessTokenCalled.getAndSet()
-          if (isFirstCall) {
-            taskCompletionSource1.task
-          } else {
-            tokenTask
-          }
-        }
-    }
-
-    val getTokenJob = async { dataConnectAuth.getToken(requestId) }
-    getAccessTokenCalled.await()
-
-    idTokenListener.onIdTokenChanged(mockk(relaxed = true))
-    advanceUntilIdle()
-    taskCompletionSource1.setException(Exception("unhang hung test tv8v7pyf6v"))
-    getTokenJob.await().ref shouldBe finalToken
-    dataConnectAuth.token.value.ref shouldBe finalToken
-  }
-
-  @Test
   fun `onTokenChanged() should call getToken() if new token is different`() = runTest {
     val distinctAuthTokenPairArb =
       Arb.dataConnect.authToken().orNull(nullProbability = 0.2).distinctPair()
@@ -861,6 +828,28 @@ class DataConnectAuthUnitTest {
       advanceUntilIdle()
       dataConnectAuth.token.value.ref?.token shouldBe authToken
       verify(exactly = 1) { mockInternalAuthProvider.getAccessToken(any()) }
+      clearMocks(mockInternalAuthProvider)
+    }
+  }
+
+  @Test
+  fun `onTokenChanged() called synchronously from getToken()`() = runTest {
+    checkAll(propTestConfig, Arb.dataConnect.authTokenResult()) { (authToken, authUid) ->
+      val dataConnectAuth = newDataConnectAuth()
+      val idTokenListener = dataConnectAuth.initializeAndGetIdTokenListener()
+      val getAccessTokenCallCount = AtomicInteger(0)
+      coEvery { mockInternalAuthProvider.getAccessToken(any()) } answers
+        {
+          val callCount = getAccessTokenCallCount.incrementAndGet()
+          if (callCount < 5) {
+            idTokenListener.onIdTokenChanged(InternalTokenResult(authToken))
+          }
+          taskForToken(authToken, authUid)
+        }
+
+      dataConnectAuth.getToken(requestId)
+
+      getAccessTokenCallCount.get() shouldBeLessThan 2
       clearMocks(mockInternalAuthProvider)
     }
   }


### PR DESCRIPTION
This PR resolves a potential infinite loop of cancellations and retries in Data Connect that could occur in `DataConnectCredentialsTokenManager` if an auth or App Check token change notification was triggered synchronously during an active token fetch. Instead of immediately cancelling the active job when a token change is detected, the manager now awaits its completion and inspects the result to determine if the expected token has already been retrieved.

### Highlights

* **Awaits active jobs instead of cancelling:** Refactored `onTokenChanged()` to await the in-flight `getToken()` job rather than cancelling it immediately. This prevents a cascade of cancellation-retry loops when token notifications are synchronous.
* **Reuse of successful fetches:** If the completed job returns the newly notified token, no further calls are made, reducing the total calls to the provider's `getAccessToken()` to exactly 1.
* **Updated unit tests:** Replaced the cancellation-behavior test with a synchronous-refresh test to verify that calling `onTokenChanged` during a fetch doesn't result in redundant provider calls.

<details>
<summary><b>Changelog</b></summary>

* **CHANGELOG.md**
  * Added a entry for the infinite loop fix when Auth/App Check tokens are refreshed.
* **DataConnectCredentialsTokenManager.kt**
  * Removed the `NewToken` retry exception class.
  * Refactored `onTokenChanged()` to launch a coroutine that awaits the active job and evaluates the retrieved token against the new token, skipping the retry if they match.
* **DataConnectAuthUnitTest.kt**
  * Removed `onTokenChanged() should cancel in-flight getToken() requests and retry`.
  * Added `onTokenChanged() called synchronously from getToken()` to verify synchronous notifications don't trigger redundant calls.
  * Cleaned up unused imports.

</details>