### PR TITLE
fix(perf): Make FirstDrawDoneListener cleanup OnGlobalLayoutListener after use

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/FirstDrawDoneListener.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/FirstDrawDoneListener.java
@@ -73,7 +73,14 @@ public class FirstDrawDoneListener implements ViewTreeObserver.OnDrawListener {
     // OnDrawListeners cannot be removed within onDraw, so we remove it with a
     // GlobalLayoutListener
     view.getViewTreeObserver()
-        .addOnGlobalLayoutListener(() -> view.getViewTreeObserver().removeOnDrawListener(this));
+        .addOnGlobalLayoutListener(
+            new ViewTreeObserver.OnGlobalLayoutListener() {
+              @Override
+              public void onGlobalLayout() {
+                view.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                view.getViewTreeObserver().removeOnDrawListener(FirstDrawDoneListener.this);
+              }
+            });
     mainThreadHandler.postAtFrontOfQueue(callback);
   }
 

--- a/firebase-perf/src/test/java/com/google/firebase/perf/util/FirstDrawDoneListenerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/util/FirstDrawDoneListenerTest.java
@@ -125,6 +125,27 @@ public class FirstDrawDoneListenerTest {
     assertThat(mOnDrawListeners.size()).isEqualTo(0);
   }
 
+  @Test
+  @Config(sdk = 26)
+  public void onDraw_removesOnGlobalLayoutListenerAfterCleanup()
+      throws NoSuchFieldException, IllegalAccessException {
+    ArrayList<OnDrawListener> mOnDrawListeners =
+        initViewTreeObserverWithListener(testView.getViewTreeObserver());
+    ArrayList<?> mOnGlobalLayoutListeners =
+        initViewTreeObserverGlobalLayoutListeners(testView.getViewTreeObserver());
+
+    FirstDrawDoneListener.registerForNextDraw(testView, () -> {});
+
+    // onDraw registers a cleanup OnGlobalLayoutListener
+    testView.getViewTreeObserver().dispatchOnDraw();
+    assertThat(mOnGlobalLayoutListeners.size()).isGreaterThan(0);
+
+    // onGlobalLayout fires the cleanup, which removes both listeners
+    testView.getViewTreeObserver().dispatchOnGlobalLayout();
+    assertThat(mOnGlobalLayoutListeners).isEmpty();
+    assertThat(mOnDrawListeners).isEmpty();
+  }
+
   /**
    * Returns ViewTreeObserver.mOnDrawListeners field through reflection. Since reflections are
    * employed, prefer to be used in tests with fixed API level using @Config(sdk = X).
@@ -145,6 +166,30 @@ public class FirstDrawDoneListenerTest {
     ArrayList<OnDrawListener> listeners = (ArrayList<OnDrawListener>) mOnDrawListeners.get(vto);
     assertThat(listeners).isNotNull();
     assertThat(listeners.size()).isEqualTo(0);
+    return listeners;
+  }
+
+  /**
+   * Returns the internal ArrayList backing ViewTreeObserver.mOnGlobalLayoutListeners through
+   * reflection. The field is a CopyOnWriteArray, so we read its mData field.
+   */
+  private static ArrayList<?> initViewTreeObserverGlobalLayoutListeners(ViewTreeObserver vto)
+      throws NoSuchFieldException, IllegalAccessException {
+    ViewTreeObserver.OnGlobalLayoutListener placeHolder = () -> {};
+    vto.addOnGlobalLayoutListener(placeHolder);
+    vto.removeOnGlobalLayoutListener(placeHolder);
+
+    Field mOnGlobalLayoutListeners =
+        ViewTreeObserver.class.getDeclaredField("mOnGlobalLayoutListeners");
+    mOnGlobalLayoutListeners.setAccessible(true);
+    Object copyOnWriteArray = mOnGlobalLayoutListeners.get(vto);
+    assertThat(copyOnWriteArray).isNotNull();
+
+    Field mData = copyOnWriteArray.getClass().getDeclaredField("mData");
+    mData.setAccessible(true);
+    ArrayList<?> listeners = (ArrayList<?>) mData.get(copyOnWriteArray);
+    assertThat(listeners).isNotNull();
+    assertThat(listeners).isEmpty();
     return listeners;
   }
 


### PR DESCRIPTION
## Description

The `OnGlobalLayoutListener` registered in `onDraw()` to defer removal of the `OnDrawListener` is never itself removed from the `ViewTreeObserver`. In single-Activity apps, this causes a per-registration leak — one listener per `registerForNextDraw` call — each pinning the view and callback on the VTO indefinitely.

The fix makes the `OnGlobalLayoutListener` remove itself after firing.

This was discovered in Sentry's Android SDK, which adapted this code. See: https://github.com/getsentry/sentry-java/issues/5495

## Testing

Added a regression test that verifies `mOnGlobalLayoutListeners` is empty after the cleanup fires.