### PR TITLE
[Infra] Upgrade Android Gradle Plugin to 8.13.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # it needs to match the protobuf version which grpc has transitive dependency on, which
 # needs to match the version of grpc that grpc-kotlin has a transitive dependency on.
 android-lint = "31.3.2"
-androidGradlePlugin = "8.6.1"
+androidGradlePlugin = "8.13.2"
 androidx-core = "1.13.1"
 androidx-test-core = "1.5.0"
 androidx-test-junit = "1.1.5"

--- a/health-metrics/apk-size/apk-size.gradle
+++ b/health-metrics/apk-size/apk-size.gradle
@@ -20,7 +20,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath 'com.android.tools.build:gradle:8.13.2'
     }
 }
 

--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -23,7 +23,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.android.tools.build:gradle:8.6.1"
+    classpath "com.android.tools.build:gradle:8.13.2"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.21"
     classpath "com.google.gms:google-services:4.4.3"
     classpath "com.google.firebase:firebase-crashlytics-gradle:3.0.4"


### PR DESCRIPTION
Updated the Android Gradle Plugin version to 8.13.2 across the root configuration, apk-size health metrics, and smoke tests build files to ensure consistency and access to the latest build improvements.