### PR TITLE
dataconnect(chore): rename internal class AuthUidChangedException to FirebaseUserChangedException

### DIFF
--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -92,7 +92,7 @@ internal class DataConnectBidiConnectStream(
   private val logger: Logger,
 ) {
 
-  val isPermanentlyFailedDueToAuthUidChange: Boolean
+  val isPermanentlyFailedDueToFirebaseUserChange: Boolean
     get() = firebaseUserChangedFlow.replayCache.isNotEmpty()
 
   /**

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -93,7 +93,7 @@ internal class DataConnectBidiConnectStream(
 ) {
 
   val isPermanentlyFailedDueToAuthUidChange: Boolean
-    get() = authUidChangedFlow.replayCache.isNotEmpty()
+    get() = firebaseUserChangedFlow.replayCache.isNotEmpty()
 
   /**
    * A flow that emits `null` when [coroutineScope] is canceled, which happens when
@@ -102,15 +102,15 @@ internal class DataConnectBidiConnectStream(
   private val scopeCompletedFlow = coroutineScope.completedFlow().map { null }
 
   /**
-   * A flow that emits a [AuthUidChangedException] when the connection is permanently failed due to
-   * the Firebase Auth user changing.
+   * A flow that emits a [FirebaseUserChangedException] when the connection is permanently failed
+   * due to the Firebase Auth user changing.
    */
-  private val _authUidChangedFlow =
-    MutableSharedFlow<AuthUidChangedException>(
+  private val _firebaseUserChangedFlow =
+    MutableSharedFlow<FirebaseUserChangedException>(
       replay = 1,
       onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
-  private val authUidChangedFlow = _authUidChangedFlow.asSharedFlow()
+  private val firebaseUserChangedFlow = _firebaseUserChangedFlow.asSharedFlow()
 
   private val connectionFlow: Flow<SubscriptionEvent> = run {
     val connectionStateFlow =
@@ -135,8 +135,8 @@ internal class DataConnectBidiConnectStream(
         }
         .map(SubscriptionEvent::Message)
         .catch { exception ->
-          if (exception is AuthUidChangedException) {
-            _authUidChangedFlow.emit(exception)
+          if (exception is FirebaseUserChangedException) {
+            _firebaseUserChangedFlow.emit(exception)
           }
           throw exception
         }
@@ -147,7 +147,7 @@ internal class DataConnectBidiConnectStream(
           throw throwable ?: Exception("to be handled by retryWhen")
         }
         .retryWhen { cause, attempt ->
-          if (cause is AuthUidChangedException || attempt > 2) {
+          if (cause is FirebaseUserChangedException || attempt > 2) {
             false
           } else {
             delay(1.seconds)
@@ -234,7 +234,7 @@ internal class DataConnectBidiConnectStream(
     return merge(
         subscriptionFlow,
         scopeCompletedFlow,
-        authUidChangedFlow.transform { throw it },
+        firebaseUserChangedFlow.transform { throw it },
       )
       .transformWhile {
         if (it !== null && coroutineScope.isActive) {
@@ -643,7 +643,7 @@ private class ConnectionStateUpdater(private val idStringGenerator: IdStringGene
     val currentAuthUid = currentState.authToken.ref?.authUid
     val newAuthUid = sequencedAuthToken.ref?.authUid
     if (currentAuthUid != newAuthUid) {
-      throw AuthUidChangedException("cgvra2bwg3", currentAuthUid, newAuthUid)
+      throw FirebaseUserChangedException("cgvra2bwg3", currentAuthUid, newAuthUid)
     }
 
     // Ignore outdated auth token changes.
@@ -660,7 +660,7 @@ private class ConnectionStateUpdater(private val idStringGenerator: IdStringGene
 
     // Do not send an empty token, as that is wasteful too (and should never happen in practice
     // because if newToken==null and oldToken!=newToken then it must hold that
-    // currentAuthUid!=newAuthUid, and should have resulted in AuthUidChangedException above).
+    // currentAuthUid!=newAuthUid, and should have resulted in FirebaseUserChangedException above).
     if (newToken == null) {
       return null
     }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -398,7 +398,7 @@ internal class DataConnectGrpcRPCs(
         val authToken = initialAuthToken.getAndSet(null) ?: dataConnectAuth.getToken(streamId)
         val authUid = authToken.ref?.authUid
         if (authUid != connectionAuthUid) {
-          throw AuthUidChangedException("ytd7yf2geh", connectionAuthUid, authUid)
+          throw FirebaseUserChangedException("ytd7yf2geh", connectionAuthUid, authUid)
         }
         val appCheckToken = dataConnectAppCheck.getToken(streamId)
         val metadata = grpcMetadata.get(authToken.ref, appCheckToken.ref, callerSdkType)
@@ -814,11 +814,12 @@ internal fun List<DataConnectProperties>.getEntityIdForPathFunction(): GetEntity
   return ::getEntityIdForPathFunction
 }
 
-internal class AuthUidChangedException(
+internal class FirebaseUserChangedException(
   errorCode: String,
   currentAuthUid: AuthUid?,
   newAuthUid: AuthUid?,
 ) :
   DataConnectException(
-    "Firebase Auth UID changed from $currentAuthUid to $newAuthUid [$errorCode]"
+    "Firebase user changed from uid=${currentAuthUid?.string} " +
+      "to uid=${newAuthUid?.string} [$errorCode]"
   )

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/querymgr/RealtimeQueryManager.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/querymgr/RealtimeQueryManager.kt
@@ -184,7 +184,7 @@ internal class RealtimeQueryManager(
           }
         }
         is State.Connected -> {
-          if (!currentState.stream.isPermanentlyFailedDueToAuthUidChange) {
+          if (!currentState.stream.isPermanentlyFailedDueToFirebaseUserChange) {
             return currentState
           }
           state.compareAndSet(currentState, State.Disconnected)

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -594,7 +594,7 @@ class QuerySubscriptionImplUnitTest {
   }
 
   @Test
-  fun `flow fails with AuthUidChangedException if auth uid changes mid-stream`() = runTest {
+  fun `flow fails with FirebaseUserChangedException if auth uid changes mid-stream`() = runTest {
     val server = runningInProcessDataConnectServer()
 
     checkAll(
@@ -629,13 +629,13 @@ class QuerySubscriptionImplUnitTest {
           checkNotNull(authProvider.idTokenListener)
             .onIdTokenChanged(InternalTokenResult(authToken2))
 
-          // The flow should throw AuthUidChangedException and terminate
+          // The flow should throw FirebaseUserChangedException and terminate
           val exception = clientCollector.awaitError()
-          exception.shouldBeInstanceOf<AuthUidChangedException>()
-          exception.message shouldContainWithNonAbuttingTextIgnoringCase "Firebase Auth UID changed"
+          exception.shouldBeInstanceOf<FirebaseUserChangedException>()
+          exception.message shouldContainWithNonAbuttingTextIgnoringCase "Firebase user changed"
           exception.message shouldContainWithNonAbuttingText "cgvra2bwg3"
-          exception.message shouldContainWithNonAbuttingText authUid1.toString()
-          exception.message shouldContainWithNonAbuttingText authUid2.toString()
+          exception.message shouldContainWithNonAbuttingText "uid=${authUid1?.string}"
+          exception.message shouldContainWithNonAbuttingText "uid=${authUid2?.string}"
 
           serverCollector.cancelAndIgnoreRemainingEvents()
           clientCollector.cancelAndIgnoreRemainingEvents()
@@ -647,7 +647,7 @@ class QuerySubscriptionImplUnitTest {
   }
 
   @Test
-  fun `flow fails with AuthUidChangedException if auth uid changes during reconnection`() =
+  fun `flow fails with FirebaseUserChangedException if auth uid changes during reconnection`() =
     runTest {
       val server = runningInProcessDataConnectServer()
 
@@ -684,16 +684,15 @@ class QuerySubscriptionImplUnitTest {
             // Close the connection from the server to force a reconnection attempt
             responseSender.onCompleted()
 
-            // The flow should throw AuthUidChangedException and terminate
+            // The flow should throw FirebaseUserChangedException and terminate
             val exception = clientCollector.awaitError()
 
-            // The flow should throw AuthUidChangedException and terminate
-            exception.shouldBeInstanceOf<AuthUidChangedException>()
-            exception.message shouldContainWithNonAbuttingTextIgnoringCase
-              "Firebase Auth UID changed"
+            // The flow should throw FirebaseUserChangedException and terminate
+            exception.shouldBeInstanceOf<FirebaseUserChangedException>()
+            exception.message shouldContainWithNonAbuttingTextIgnoringCase "Firebase user changed"
             exception.message shouldContainWithNonAbuttingText "ytd7yf2geh"
-            exception.message shouldContainWithNonAbuttingText authUid1.toString()
-            exception.message shouldContainWithNonAbuttingText authUid2.toString()
+            exception.message shouldContainWithNonAbuttingText "uid=${authUid1?.string}"
+            exception.message shouldContainWithNonAbuttingText "uid=${authUid2?.string}"
 
             serverCollector.cancelAndIgnoreRemainingEvents()
             clientCollector.cancelAndIgnoreRemainingEvents()
@@ -705,12 +704,12 @@ class QuerySubscriptionImplUnitTest {
     }
 
   @Test
-  fun `flow fails with AuthUidChangedException if auth uid changes concurrently with reconnection`() =
+  fun `flow fails with FirebaseUserChangedException if auth uid changes concurrently with reconnection`() =
     runTest {
       val server = runningInProcessDataConnectServer()
 
-      // Make sure that AuthUidChangedException is thrown even if the sequence number of the pending
-      // reconnect token is stale; otherwise, auth uid changes could slip through.
+      // Make sure that FirebaseUserChangedException is thrown even if the sequence number of the
+      // pending reconnect token is stale; otherwise, auth uid changes could slip through.
       val postReconnectSequenceNumberArb = Arb.of(nextSequenceNumber(), Long.MAX_VALUE)
 
       checkAll(
@@ -761,19 +760,18 @@ class QuerySubscriptionImplUnitTest {
                 // Close the connection from the server to force a reconnection attempt
                 responseSender.onCompleted()
 
-                // The flow should throw AuthUidChangedException and terminate
+                // The flow should throw FirebaseUserChangedException and terminate
                 clientCollector.awaitError()
               } finally {
                 unsetReconnectPendingAuthTokenForTesting(postReconnectPendingAuthToken)
               }
 
-            // The flow should throw AuthUidChangedException and terminate
-            exception.shouldBeInstanceOf<AuthUidChangedException>()
-            exception.message shouldContainWithNonAbuttingTextIgnoringCase
-              "Firebase Auth UID changed"
+            // The flow should throw FirebaseUserChangedException and terminate
+            exception.shouldBeInstanceOf<FirebaseUserChangedException>()
+            exception.message shouldContainWithNonAbuttingTextIgnoringCase "Firebase user changed"
             exception.message shouldContainWithNonAbuttingText "cgvra2bwg3"
-            exception.message shouldContainWithNonAbuttingText authUid1.toString()
-            exception.message shouldContainWithNonAbuttingText authUid2.toString()
+            exception.message shouldContainWithNonAbuttingText "uid=${authUid1?.string}"
+            exception.message shouldContainWithNonAbuttingText "uid=${authUid2?.string}"
 
             serverCollector.cancelAndIgnoreRemainingEvents()
             clientCollector.cancelAndIgnoreRemainingEvents()


### PR DESCRIPTION
This PR renames Data Connect's internal class `AuthUidChangedException` to `FirebaseUserChangedException` and updates its associated properties, flows, and tests to improve consistency and clarity in client logging.

### Highlights

* **Renamed Exception**: Changed the internal exception `AuthUidChangedException` to `FirebaseUserChangedException`.
* **Improved Error Messaging**: Updated the exception message to reference the Firebase user's change in UID using a clearer format (e.g., `uid=...`) instead of dumping raw/custom objects.
* **Flow & Property Refactoring**: Updated references, property names, and flows in `DataConnectBidiConnectStream` (e.g., `isPermanentlyFailedDueToAuthUidChange` to `isPermanentlyFailedDueToFirebaseUserChange`) for consistency.
* **Test Updates**: Updated test methods and assertion patterns in `QuerySubscriptionImplUnitTest` to match the renamed exception and new error message format.

<details>
<summary><b>Changelog</b></summary>

* **DataConnectBidiConnectStream.kt**
  * Renamed auth-related flows and properties (e.g., `isPermanentlyFailedDueToAuthUidChange` to `isPermanentlyFailedDueToFirebaseUserChange`) to match the new exception name.
* **DataConnectGrpcRPCs.kt**
  * Renamed `AuthUidChangedException` to `FirebaseUserChangedException` and updated the error message format.
* **RealtimeQueryManager.kt**
  * Updated references to the renamed stream property `isPermanentlyFailedDueToFirebaseUserChange`.
* **QuerySubscriptionImplUnitTest.kt**
  * Renamed test cases and adjusted exception class/message assertions to reflect `FirebaseUserChangedException`.
</details>