### PR TITLE
[AppCheck] Log errors in RecaptchaAppCheckProvider

### DIFF
--- a/appcheck/firebase-appcheck-recaptcha/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-recaptcha/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
 - [changed] Added warning logs when failing to initialize the reCAPTCHA client or
-  nexchange attestation for a token (#8330)
+  exchange attestation for a token (#8330)
 - [feature] Initial release of the Firebase AppCheck reCaptcha SDK
   (`firebase-appcheck-recaptcha`)

--- a/appcheck/firebase-appcheck-recaptcha/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-recaptcha/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
 - [changed] Added warning logs when failing to initialize the reCAPTCHA client or
-  nexchange attestation for a token.
+  nexchange attestation for a token (#8330)
 - [feature] Initial release of the Firebase AppCheck reCaptcha SDK
   (`firebase-appcheck-recaptcha`)

--- a/appcheck/firebase-appcheck-recaptcha/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-recaptcha/CHANGELOG.md
@@ -7,3 +7,4 @@
 
 - [feature] Initial release of the Firebase AppCheck reCaptcha SDK
   (`firebase-appcheck-recaptcha`)
+

--- a/appcheck/firebase-appcheck-recaptcha/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-recaptcha/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [changed] Added warning logs when failing to initialize the reCAPTCHA client or
+  nexchange attestation for a token.
 - [feature] Initial release of the Firebase AppCheck reCaptcha SDK
   (`firebase-appcheck-recaptcha`)
-

--- a/appcheck/firebase-appcheck-recaptcha/gradle.properties
+++ b/appcheck/firebase-appcheck-recaptcha/gradle.properties
@@ -1,1 +1,2 @@
-version=19.0.0
+version=19.1.0
+latestReleasedVersion=19.0.0

--- a/appcheck/firebase-appcheck-recaptcha/src/main/java/com/google/firebase/appcheck/recaptcha/internal/RecaptchaAppCheckProvider.java
+++ b/appcheck/firebase-appcheck-recaptcha/src/main/java/com/google/firebase/appcheck/recaptcha/internal/RecaptchaAppCheckProvider.java
@@ -114,6 +114,11 @@ public class RecaptchaAppCheckProvider implements AppCheckProvider {
 
   private Task<AppCheckToken> getToken(boolean isLimitedUseToken) {
     return getRecaptchaAttestation()
+        .addOnFailureListener(
+            liteExecutor,
+            e -> {
+              Log.w(TAG, "Failed to obtain reCAPTCHA client", e);
+            })
         .onSuccessTask(
             liteExecutor,
             recaptchaToken -> {
@@ -126,6 +131,11 @@ public class RecaptchaAppCheckProvider implements AppCheckProvider {
                           request.toJsonString().getBytes(StandardCharsets.UTF_8),
                           NetworkClient.RECAPTCHA,
                           retryManager));
+            })
+        .addOnFailureListener(
+            liteExecutor,
+            e -> {
+              Log.w(TAG, "Failed to exchange attestation for token", e);
             })
         .onSuccessTask(
             liteExecutor,


### PR DESCRIPTION
Added failure listeners to the reCAPTCHA token acquisition flow to log errors when failing to obtain the reCAPTCHA client or exchange the attestation for a token.