### PR TITLE
dataconnect(chore): upgrade pytest to 9.1.1 (was 9.0.3)

### DIFF
--- a/firebase-dataconnect/ci/requirements.txt
+++ b/firebase-dataconnect/ci/requirements.txt
@@ -5,7 +5,7 @@ nodeenv==1.9.1
 packaging==24.2
 pluggy==1.5.0
 pyright==1.1.399
-pytest==9.0.3
+pytest==9.1.1
 ruff==0.11.5
 sortedcontainers==2.4.0
 typing_extensions==4.13.2


### PR DESCRIPTION
This upgrade is motivated by CVE-2025-71176:

> pytest through 9.0.2 on UNIX relies on directories with the /tmp/pytest-of-{user} name pattern, which allows local users to cause a denial of service or possibly gain privileges.

Googlers see b/524332007