### PR TITLE
dataconnect(chore): upgrade gradleplugin dependencies `com.google.cloud:google-cloud-storage` to 2.69.0 and `io.github.z4kn4fein:semver` to 3.1.0

### DIFF
--- a/firebase-dataconnect/gradleplugin/plugin/build.gradle.kts
+++ b/firebase-dataconnect/gradleplugin/plugin/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
   implementation(firebaseLibs.kotlinx.serialization.core)
   implementation(firebaseLibs.kotlinx.serialization.json)
   implementation("com.google.cloud:google-cloud-storage:2.69.0")
-  implementation("io.github.z4kn4fein:semver:3.0.0")
+  implementation("io.github.z4kn4fein:semver:3.1.0")
 }
 
 gradlePlugin {

--- a/firebase-dataconnect/gradleplugin/plugin/build.gradle.kts
+++ b/firebase-dataconnect/gradleplugin/plugin/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
   implementation(gradleKotlinDsl())
   implementation(firebaseLibs.kotlinx.serialization.core)
   implementation(firebaseLibs.kotlinx.serialization.json)
-  implementation("com.google.cloud:google-cloud-storage:2.56.0")
+  implementation("com.google.cloud:google-cloud-storage:2.69.0")
   implementation("io.github.z4kn4fein:semver:3.0.0")
 }
 


### PR DESCRIPTION
Upgrade the dataconnect gradle plugin dependencies `com.google.cloud:google-cloud-storage` to 2.69.0 and `io.github.z4kn4fein:semver` to 3.1.0.

The upgrade of the `com.google.cloud:google-cloud-storage` dependency is motivated by medium severity CVE fixes in transitive dependencies `io.opentelemetry:opentelemetry-api` and `com.fasterxml.jackson.core:jackson-core`.

The upgrade of `io.github.z4kn4fein:semver` is just being done for posterity, since I'm already in there upgrading dependencies.

Googlers see b/524332007 for context.