### PR TITLE
TestUtils.kt: fix long-standing bug where the behavior of `ignoreCase` was inverted 🤦

### DIFF
--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/TestUtils.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/TestUtils.kt
@@ -53,9 +53,9 @@ fun containWithNonAbuttingText(s: String, ignoreCase: Boolean = false): Matcher<
     val fullPattern = "(^|\\W)${Pattern.quote(s)}($|\\W)"
     val expr =
       if (ignoreCase) {
-        Pattern.compile(fullPattern)
-      } else {
         Pattern.compile(fullPattern, Pattern.CASE_INSENSITIVE)
+      } else {
+        Pattern.compile(fullPattern)
       }
 
     MatcherResult(
@@ -83,7 +83,7 @@ infix fun String?.shouldContainWithNonAbuttingText(s: String): String? {
 
 /** Same as [shouldContainWithNonAbuttingText] but ignoring case. */
 infix fun String?.shouldContainWithNonAbuttingTextIgnoringCase(s: String): String? {
-  this should containWithNonAbuttingText(s, ignoreCase = false)
+  this should containWithNonAbuttingText(s, ignoreCase = true)
   return this
 }
 


### PR DESCRIPTION
This PR fixes a long-standing bug in data connect's test utility function `containWithNonAbuttingText` where the `ignoreCase` parameter had inverted behavior.

### Highlights

* **Fix `ignoreCase` Inversion**: Corrected the logic in `containWithNonAbuttingText` so that passing `ignoreCase = true` performs case-insensitive matching, and `false` (the default) performs case-sensitive matching.
* **Correct Usages**: Updated `shouldContainWithNonAbuttingTextIgnoringCase` to pass `ignoreCase = true` instead of `false`.

<details>

<summary><b>Changelog</b></summary>

* **TestUtils.kt**
  * Corrected the inversion of `ignoreCase` in `containWithNonAbuttingText` to use `Pattern.CASE_INSENSITIVE` when `ignoreCase` is true.
  * Updated `shouldContainWithNonAbuttingTextIgnoringCase` to pass `ignoreCase = true` to `containWithNonAbuttingText`.

</details>