### PR TITLE
dataconnect(test): QuerySubscriptionImplUnitTest.kt add tests for UNAUTHENTICATED error

### DIFF
--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -1345,12 +1345,13 @@ class QuerySubscriptionImplUnitTest {
         status.code shouldBe Status.Code.UNAUTHENTICATED
         status.description shouldBe "Request is missing required authentication credential"
 
-        getTokenCalls
-          ?.invoke()
-          ?.shouldContainExactly(
-            GetTokenCall(forceRefresh = false),
-            GetTokenCall(forceRefresh = true)
-          )
+        if (getTokenCalls != null) {
+          getTokenCalls()
+            .shouldContainExactly(
+              GetTokenCall(forceRefresh = false),
+              GetTokenCall(forceRefresh = true)
+            )
+        }
 
         serverCollector.cancelAndIgnoreRemainingEvents()
         clientCollector.cancelAndIgnoreRemainingEvents()

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -32,6 +32,7 @@ import com.google.firebase.dataconnect.core.DataConnectBidiConnectStream.Compani
 import com.google.firebase.dataconnect.testutil.CleanupsRule
 import com.google.firebase.dataconnect.testutil.DataConnectLogLevelRule
 import com.google.firebase.dataconnect.testutil.FirebaseAppUnitTestingRule
+import com.google.firebase.dataconnect.testutil.GetTokenCall
 import com.google.firebase.dataconnect.testutil.ImmediateDeferred
 import com.google.firebase.dataconnect.testutil.InProcessDataConnectGrpcStreamingServer
 import com.google.firebase.dataconnect.testutil.InProcessDataConnectGrpcStreamingServer.Event.ConnectRpcStarted
@@ -41,6 +42,7 @@ import com.google.firebase.dataconnect.testutil.LoggedInMultiTokenAndUidAuthProv
 import com.google.firebase.dataconnect.testutil.NotLoggedInInternalAuthProvider
 import com.google.firebase.dataconnect.testutil.OperationNameVariablesPair
 import com.google.firebase.dataconnect.testutil.RandomSeedTestRule
+import com.google.firebase.dataconnect.testutil.TestInteropAppCheckTokenProvider
 import com.google.firebase.dataconnect.testutil.UnavailableDeferred
 import com.google.firebase.dataconnect.testutil.appCheckTokenGrpcMetadataKey
 import com.google.firebase.dataconnect.testutil.authTokenGrpcMetadataKey
@@ -82,6 +84,7 @@ import io.kotest.assertions.withClue
 import io.kotest.common.DelicateKotest
 import io.kotest.common.ExperimentalKotest
 import io.kotest.matchers.collections.shouldBeIn
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.shouldBe
@@ -1009,6 +1012,351 @@ class QuerySubscriptionImplUnitTest {
         expectedHeaderValue1 = null,
         expectedHeaderValue2 = null,
       )
+    }
+  }
+
+  @Test
+  fun `appCheck token refresh upon initial connection failure with StatusException UNAUTHENTICATED`() =
+    runTest {
+      testAppCheckTokenRefreshOnInitialConnectionUnauthenticated { status ->
+        StatusException(status)
+      }
+    }
+
+  @Test
+  fun `appCheck token refresh upon initial connection failure with StatusRuntimeException UNAUTHENTICATED`() =
+    runTest {
+      testAppCheckTokenRefreshOnInitialConnectionUnauthenticated { status ->
+        StatusRuntimeException(status)
+      }
+    }
+
+  @Test
+  fun `appCheck token refresh upon initial connection failure with StatusException UNAUTHENTICATED when token does NOT change`() =
+    runTest {
+      testAppCheckTokenNoRefreshOnUnchangedTokenInitialConnectionUnauthenticated { status ->
+        StatusException(status)
+      }
+    }
+
+  @Test
+  fun `appCheck token refresh upon initial connection failure with StatusRuntimeException UNAUTHENTICATED when token does NOT change`() =
+    runTest {
+      testAppCheckTokenNoRefreshOnUnchangedTokenInitialConnectionUnauthenticated { status ->
+        StatusRuntimeException(status)
+      }
+    }
+
+  @Test
+  fun `appCheck token refresh upon initial connection failure with StatusException UNAUTHENTICATED when no App Check provider`() =
+    runTest {
+      testAppCheckTokenNoRefreshOnNoAppCheckProviderInitialConnectionUnauthenticated { status ->
+        StatusException(status)
+      }
+    }
+
+  @Test
+  fun `appCheck token refresh upon initial connection failure with StatusRuntimeException UNAUTHENTICATED when no App Check provider`() =
+    runTest {
+      testAppCheckTokenNoRefreshOnNoAppCheckProviderInitialConnectionUnauthenticated { status ->
+        StatusRuntimeException(status)
+      }
+    }
+
+  @Test
+  fun `authToken refresh upon initial connection failure with StatusException UNAUTHENTICATED`() =
+    runTest {
+      testAuthTokenRefreshOnInitialConnectionUnauthenticated { status -> StatusException(status) }
+    }
+
+  @Test
+  fun `authToken refresh upon initial connection failure with StatusRuntimeException UNAUTHENTICATED`() =
+    runTest {
+      testAuthTokenRefreshOnInitialConnectionUnauthenticated { status ->
+        StatusRuntimeException(status)
+      }
+    }
+
+  @Test
+  fun `authToken refresh upon initial connection failure with StatusException UNAUTHENTICATED when token does NOT change`() =
+    runTest {
+      testAuthTokenNoRefreshOnUnchangedTokenInitialConnectionUnauthenticated { status ->
+        StatusException(status)
+      }
+    }
+
+  @Test
+  fun `authToken refresh upon initial connection failure with StatusRuntimeException UNAUTHENTICATED when token does NOT change`() =
+    runTest {
+      testAuthTokenNoRefreshOnUnchangedTokenInitialConnectionUnauthenticated { status ->
+        StatusRuntimeException(status)
+      }
+    }
+
+  @Test
+  fun `authToken refresh upon initial connection failure with StatusException UNAUTHENTICATED when no user logged in`() =
+    runTest {
+      testAuthTokenNoRefreshOnNoUserSignedInInitialConnectionUnauthenticated { status ->
+        StatusException(status)
+      }
+    }
+
+  @Test
+  fun `authToken refresh upon initial connection failure with StatusRuntimeException UNAUTHENTICATED when no user logged in`() =
+    runTest {
+      testAuthTokenNoRefreshOnNoUserSignedInInitialConnectionUnauthenticated { status ->
+        StatusRuntimeException(status)
+      }
+    }
+
+  @Test
+  fun `authToken refresh upon initial connection failure with StatusException UNAUTHENTICATED when no auth provider`() =
+    runTest {
+      testAuthTokenNoRefreshOnNoAuthProviderInitialConnectionUnauthenticated { status ->
+        StatusException(status)
+      }
+    }
+
+  @Test
+  fun `authToken refresh upon initial connection failure with StatusRuntimeException UNAUTHENTICATED when no auth provider`() =
+    runTest {
+      testAuthTokenNoRefreshOnNoAuthProviderInitialConnectionUnauthenticated { status ->
+        StatusRuntimeException(status)
+      }
+    }
+
+  private suspend fun TestScope.testAppCheckTokenRefreshOnInitialConnectionUnauthenticated(
+    createException: (Status) -> Throwable
+  ) {
+    val deferredAuthProvider = Arb.dataConnect.deferredAuthProvider().sample()
+    val appCheckProvider = Arb.dataConnect.appCheckMultiTokenProvider(count = 2).sample()
+    testTokenRefreshOnInitialConnectionUnauthenticated(
+      createException = createException,
+      deferredAuthProvider = deferredAuthProvider,
+      deferredAppCheckProvider = ImmediateDeferred(appCheckProvider),
+      awaitReady = { awaitAppCheckReady() },
+      headerKey = appCheckTokenGrpcMetadataKey,
+      tokens = appCheckProvider.tokens,
+      getTokenCalls = appCheckProvider::getTokenCalls,
+    )
+  }
+
+  private suspend fun TestScope
+    .testAppCheckTokenNoRefreshOnUnchangedTokenInitialConnectionUnauthenticated(
+    createException: (Status) -> Throwable
+  ) {
+    val deferredAuthProvider = Arb.dataConnect.deferredAuthProvider().sample()
+    val token = Arb.dataConnect.appCheckToken().sample()
+    val appCheckProvider = TestInteropAppCheckTokenProvider(token)
+    testTokenNoRefreshOnInitialConnectionUnauthenticated(
+      createException = createException,
+      deferredAuthProvider = deferredAuthProvider,
+      deferredAppCheckProvider = ImmediateDeferred(appCheckProvider),
+      awaitReady = { awaitAppCheckReady() },
+      headerKey = appCheckTokenGrpcMetadataKey,
+      token = token,
+      getTokenCalls = appCheckProvider::getTokenCalls,
+    )
+  }
+
+  private suspend fun TestScope
+    .testAppCheckTokenNoRefreshOnNoAppCheckProviderInitialConnectionUnauthenticated(
+    createException: (Status) -> Throwable
+  ) {
+    val deferredAuthProvider = Arb.dataConnect.deferredAuthProvider().sample()
+    testTokenNoRefreshOnInitialConnectionUnauthenticated(
+      createException = createException,
+      deferredAuthProvider = deferredAuthProvider,
+      deferredAppCheckProvider = UnavailableDeferred(),
+      awaitReady = {},
+      headerKey = appCheckTokenGrpcMetadataKey,
+      token = null,
+      getTokenCalls = null,
+    )
+  }
+
+  private suspend fun TestScope.testAuthTokenRefreshOnInitialConnectionUnauthenticated(
+    createException: (Status) -> Throwable
+  ) {
+    val authProvider = Arb.dataConnect.loggedInMultiTokenAuthProvider(count = 2).sample()
+    val deferredAppCheckProvider = Arb.dataConnect.deferredAppCheckProvider().sample()
+    testTokenRefreshOnInitialConnectionUnauthenticated(
+      createException = createException,
+      deferredAuthProvider = ImmediateDeferred(authProvider),
+      deferredAppCheckProvider = deferredAppCheckProvider,
+      awaitReady = { awaitAuthReady() },
+      headerKey = authTokenGrpcMetadataKey,
+      tokens = authProvider.tokens,
+      getTokenCalls = authProvider::getTokenCalls,
+    )
+  }
+
+  private suspend fun TestScope
+    .testAuthTokenNoRefreshOnUnchangedTokenInitialConnectionUnauthenticated(
+    createException: (Status) -> Throwable
+  ) {
+    val token = Arb.dataConnect.authToken().sample()
+    val authUid = Arb.dataConnect.authUid().sample()
+    val authProvider = LoggedInInternalAuthProvider(token = token, uid = authUid.string)
+    val deferredAppCheckProvider = Arb.dataConnect.deferredAppCheckProvider().sample()
+    testTokenNoRefreshOnInitialConnectionUnauthenticated(
+      createException = createException,
+      deferredAuthProvider = ImmediateDeferred(authProvider),
+      deferredAppCheckProvider = deferredAppCheckProvider,
+      awaitReady = { awaitAuthReady() },
+      headerKey = authTokenGrpcMetadataKey,
+      token = token,
+      getTokenCalls = authProvider::getTokenCalls,
+    )
+  }
+
+  private suspend fun TestScope
+    .testAuthTokenNoRefreshOnNoUserSignedInInitialConnectionUnauthenticated(
+    createException: (Status) -> Throwable
+  ) {
+    val deferredAppCheckProvider = Arb.dataConnect.deferredAppCheckProvider().sample()
+    testTokenNoRefreshOnInitialConnectionUnauthenticated(
+      createException = createException,
+      deferredAuthProvider = ImmediateDeferred(NotLoggedInInternalAuthProvider),
+      deferredAppCheckProvider = deferredAppCheckProvider,
+      awaitReady = { awaitAuthReady() },
+      headerKey = authTokenGrpcMetadataKey,
+      token = null,
+      getTokenCalls = null,
+    )
+  }
+
+  private suspend fun TestScope
+    .testAuthTokenNoRefreshOnNoAuthProviderInitialConnectionUnauthenticated(
+    createException: (Status) -> Throwable
+  ) {
+    val deferredAppCheckProvider = Arb.dataConnect.deferredAppCheckProvider().sample()
+    testTokenNoRefreshOnInitialConnectionUnauthenticated(
+      createException = createException,
+      deferredAuthProvider = UnavailableDeferred(),
+      deferredAppCheckProvider = deferredAppCheckProvider,
+      awaitReady = {},
+      headerKey = authTokenGrpcMetadataKey,
+      token = null,
+      getTokenCalls = null,
+    )
+  }
+
+  private suspend fun TestScope.testTokenRefreshOnInitialConnectionUnauthenticated(
+    createException: (Status) -> Throwable,
+    deferredAuthProvider: com.google.firebase.inject.Deferred<InternalAuthProvider>,
+    deferredAppCheckProvider: com.google.firebase.inject.Deferred<InteropAppCheckTokenProvider>,
+    awaitReady: suspend FirebaseDataConnectImpl.() -> Unit,
+    headerKey: Metadata.Key<String>,
+    tokens: List<String>,
+    getTokenCalls: () -> List<GetTokenCall>
+  ) {
+    val server = runningInProcessDataConnectServer()
+    val (token1, token2) = tokens
+
+    val dataConnect =
+      dataConnect(
+        serverLocalBindPort = server.port,
+        deferredAuthProvider = deferredAuthProvider,
+        deferredAppCheckProvider = deferredAppCheckProvider,
+      )
+
+    try {
+      dataConnect.awaitReady()
+
+      val subscription = querySubscription(dataConnect)
+      turbineScope {
+        val serverCollector = server.events.testIn(backgroundScope, name = "serverCollector")
+        val clientCollector = subscription.flow.testIn(backgroundScope, name = "clientCollector")
+
+        val call1 = serverCollector.awaitCall()
+        call1.headers.get(headerKey) shouldBe token1
+
+        val responseObserver = serverCollector.awaitResponseSender()
+        serverCollector.awaitUntilSubscribeStreamRequest()
+
+        val exception =
+          createException(
+            Status.UNAUTHENTICATED.withDescription(
+              "Request is missing required authentication credential"
+            )
+          )
+        responseObserver.onError(exception)
+
+        val call2 = serverCollector.awaitCall()
+        call2.headers.get(headerKey) shouldBe token2
+
+        getTokenCalls()
+          .shouldContainExactly(
+            GetTokenCall(forceRefresh = false),
+            GetTokenCall(forceRefresh = true)
+          )
+
+        serverCollector.cancelAndIgnoreRemainingEvents()
+        clientCollector.cancelAndIgnoreRemainingEvents()
+      }
+    } finally {
+      dataConnect.suspendingClose()
+    }
+  }
+
+  private suspend fun TestScope.testTokenNoRefreshOnInitialConnectionUnauthenticated(
+    createException: (Status) -> Throwable,
+    deferredAuthProvider: com.google.firebase.inject.Deferred<InternalAuthProvider>,
+    deferredAppCheckProvider: com.google.firebase.inject.Deferred<InteropAppCheckTokenProvider>,
+    awaitReady: suspend FirebaseDataConnectImpl.() -> Unit,
+    headerKey: Metadata.Key<String>,
+    token: String?,
+    getTokenCalls: (() -> List<GetTokenCall>)?
+  ) {
+    val server = runningInProcessDataConnectServer()
+
+    val dataConnect =
+      dataConnect(
+        serverLocalBindPort = server.port,
+        deferredAuthProvider = deferredAuthProvider,
+        deferredAppCheckProvider = deferredAppCheckProvider,
+      )
+
+    try {
+      dataConnect.awaitReady()
+
+      val subscription = querySubscription(dataConnect)
+      turbineScope {
+        val serverCollector = server.events.testIn(backgroundScope, name = "serverCollector")
+        val clientCollector = subscription.flow.testIn(backgroundScope, name = "clientCollector")
+
+        val call1 = serverCollector.awaitCall()
+        call1.headers.get(headerKey) shouldBe token
+
+        val responseObserver = serverCollector.awaitResponseSender()
+        serverCollector.awaitUntilSubscribeStreamRequest()
+
+        val exception =
+          createException(
+            Status.UNAUTHENTICATED.withDescription(
+              "Request is missing required authentication credential"
+            )
+          )
+        responseObserver.onError(exception)
+
+        val clientError = clientCollector.awaitError()
+        val status = Status.fromThrowable(clientError)
+        status.code shouldBe Status.Code.UNAUTHENTICATED
+        status.description shouldBe "Request is missing required authentication credential"
+
+        getTokenCalls
+          ?.invoke()
+          ?.shouldContainExactly(
+            GetTokenCall(forceRefresh = false),
+            GetTokenCall(forceRefresh = true)
+          )
+
+        serverCollector.cancelAndIgnoreRemainingEvents()
+        clientCollector.cancelAndIgnoreRemainingEvents()
+      }
+    } finally {
+      dataConnect.suspendingClose()
     }
   }
 

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/AccessTokenTestUtils.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/AccessTokenTestUtils.kt
@@ -233,13 +233,12 @@ class TestInteropAppCheckTokenProvider(val token: String) : BaseInteropAppCheckT
   val getTokenCalls: List<GetTokenCall>
     get() = lock.withLock { _getTokenCalls.toList() }
 
-  override fun getToken(forceRefresh: Boolean) =
-    lock.withLock {
-      _getTokenCalls.add(GetTokenCall(forceRefresh))
-      Tasks.forResult<com.google.firebase.appcheck.AppCheckTokenResult>(
-        TestAppCheckTokenResultImpl(token)
-      )
-    }
+  override fun getToken(
+    forceRefresh: Boolean
+  ): Task<com.google.firebase.appcheck.AppCheckTokenResult> {
+    lock.withLock { _getTokenCalls.add(GetTokenCall(forceRefresh)) }
+    return Tasks.forResult(TestAppCheckTokenResultImpl(token))
+  }
 
   override fun getLimitedUseToken() = TODO("not implemented")
 

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/AccessTokenTestUtils.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/AccessTokenTestUtils.kt
@@ -116,9 +116,15 @@ object NotLoggedInInternalAuthProvider : BaseInternalAuthProvider() {
 class LoggedInInternalAuthProvider(val token: String, uid: String) : BaseInternalAuthProvider() {
 
   private val _uid = uid
+  private val lock = ReentrantLock()
+  private val _getTokenCalls = mutableListOf<GetTokenCall>()
+  val getTokenCalls: List<GetTokenCall>
+    get() = lock.withLock { _getTokenCalls.toList() }
 
-  override fun getAccessTokenImpl(forceRefresh: Boolean) =
-    authTokenResultFor(token = token, uid = uid)
+  override fun getAccessTokenImpl(forceRefresh: Boolean): com.google.firebase.auth.GetTokenResult {
+    lock.withLock { _getTokenCalls.add(GetTokenCall(forceRefresh)) }
+    return authTokenResultFor(token = token, uid = uid)
+  }
 
   override fun getUid() = _uid
 
@@ -131,17 +137,20 @@ class LoggedInMultiTokenInternalAuthProvider(tokens: List<String>, uid: String) 
   val tokens = tokens.toList()
   private val lock = ReentrantLock()
   private val iterator = this.tokens.iterator()
-
   private val _uid = uid
+  private val _getTokenCalls = mutableListOf<GetTokenCall>()
+  val getTokenCalls: List<GetTokenCall>
+    get() = lock.withLock { _getTokenCalls.toList() }
 
-  override fun getAccessTokenImpl(forceRefresh: Boolean) =
-    authTokenResultFor(token = nextToken(), uid = uid)
-
-  private fun nextToken(): String =
-    lock.withLock {
-      check(iterator.hasNext()) { "internal error p37nr2p9dk: no more Auth tokens to produce" }
-      iterator.next()
-    }
+  override fun getAccessTokenImpl(forceRefresh: Boolean): com.google.firebase.auth.GetTokenResult {
+    val token =
+      lock.withLock {
+        _getTokenCalls.add(GetTokenCall(forceRefresh))
+        check(iterator.hasNext()) { "internal error p37nr2p9dk: no more Auth tokens to produce" }
+        iterator.next()
+      }
+    return authTokenResultFor(token = token, uid = _uid)
+  }
 
   override fun getUid() = _uid
 
@@ -219,15 +228,25 @@ abstract class BaseInteropAppCheckTokenProvider : InteropAppCheckTokenProvider {
 
 class TestInteropAppCheckTokenProvider(val token: String) : BaseInteropAppCheckTokenProvider() {
 
+  private val lock = ReentrantLock()
+  private val _getTokenCalls = mutableListOf<GetTokenCall>()
+  val getTokenCalls: List<GetTokenCall>
+    get() = lock.withLock { _getTokenCalls.toList() }
+
   override fun getToken(forceRefresh: Boolean) =
-    Tasks.forResult<com.google.firebase.appcheck.AppCheckTokenResult>(
-      TestAppCheckTokenResultImpl(token)
-    )
+    lock.withLock {
+      _getTokenCalls.add(GetTokenCall(forceRefresh))
+      Tasks.forResult<com.google.firebase.appcheck.AppCheckTokenResult>(
+        TestAppCheckTokenResultImpl(token)
+      )
+    }
 
   override fun getLimitedUseToken() = TODO("not implemented")
 
   override fun toString() = "TestInteropAppCheckTokenProvider(token=$token)"
 }
+
+data class GetTokenCall(val forceRefresh: Boolean)
 
 class TestMultiTokenInteropAppCheckTokenProvider(tokens: List<String>) :
   BaseInteropAppCheckTokenProvider() {
@@ -235,17 +254,23 @@ class TestMultiTokenInteropAppCheckTokenProvider(tokens: List<String>) :
   val tokens = tokens.toList()
   private val lock = ReentrantLock()
   private val iterator = this.tokens.iterator()
+  private val _getTokenCalls = mutableListOf<GetTokenCall>()
+  val getTokenCalls: List<GetTokenCall>
+    get() = lock.withLock { _getTokenCalls.toList() }
 
-  override fun getToken(forceRefresh: Boolean) =
-    Tasks.forResult<com.google.firebase.appcheck.AppCheckTokenResult>(
-      TestAppCheckTokenResultImpl(nextToken())
-    )
-
-  private fun nextToken(): String =
-    lock.withLock {
-      check(iterator.hasNext()) { "internal error jkgvfsmktg: no more App Check tokens to produce" }
-      iterator.next()
-    }
+  override fun getToken(
+    forceRefresh: Boolean
+  ): Task<com.google.firebase.appcheck.AppCheckTokenResult> {
+    val token =
+      lock.withLock {
+        _getTokenCalls.add(GetTokenCall(forceRefresh))
+        check(iterator.hasNext()) {
+          "internal error jkgvfsmktg: no more App Check tokens to produce"
+        }
+        iterator.next()
+      }
+    return Tasks.forResult(TestAppCheckTokenResultImpl(token))
+  }
 
   override fun getLimitedUseToken() = TODO("not implemented")
 


### PR DESCRIPTION
Adds comprehensive unit tests to data connect's `QuerySubscriptionImplUnitTest` verifying the token refresh and stream reconnection retry behaviors for both `DataConnectAppCheck` and `DataConnectAuth` upon receiving an `UNAUTHENTICATED` error.

### Highlights

* **Comprehensive Token Refresh & Retry Tests**: Added tests covering cases where the token changes after an initial `UNAUTHENTICATED` error (triggering a successful immediate retry), where the token remains unchanged (terminating the stream with the error immediately), and where the corresponding provider is entirely absent or not logged in.
* **Streamlined Test Helpers**: Refactored the shared test boilerplate into two highly-reusable parameterized helper methods (`testTokenRefreshOnInitialConnectionUnauthenticated` and `testTokenNoRefreshOnInitialConnectionUnauthenticated`) that cleanly isolate the common gRPC connection flow and assertions.
* **Thread-Safe Call Recording in Mocks**: Updated `TestInteropAppCheckTokenProvider`, `TestMultiTokenInteropAppCheckTokenProvider`, `LoggedInInternalAuthProvider`, and `LoggedInMultiTokenInternalAuthProvider` to record the history of `forceRefresh` parameters during token requests in a thread-safe `getTokenCalls` list.
* **Mock Provider Architectural Alignment**: Refactored `LoggedInInternalAuthProvider` to override the protected `getAccessTokenImpl()` method instead of the public `getAccessToken()`, aligning it with the multi-token provider and correctly utilizing the base provider's template-method pattern while minimizing lock holding times.

### Changelog

<details>
<summary>Detailed File Changes</summary>

* **QuerySubscriptionImplUnitTest.kt**: Added 12 new test cases covering all permutations of token-changing, token-unchanging, and absent-provider scenarios for App Check and Auth. Refactored common stream connection, error injection, and assertion flows into reusable parameterized helpers.
* **AccessTokenTestUtils.kt**: Extended `TestInteropAppCheckTokenProvider`, `TestMultiTokenInteropAppCheckTokenProvider`, `LoggedInInternalAuthProvider`, and `LoggedInMultiTokenInternalAuthProvider` to record `forceRefresh` calls. Aligned `LoggedInInternalAuthProvider` with the base class's template-method design and minimized lock contention.

</details>