### PR TITLE
[Encoders] Improve documentation readability

### DIFF
--- a/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/TypeToken.java
+++ b/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/TypeToken.java
@@ -28,11 +28,11 @@ import java.lang.reflect.WildcardType;
  *
  * <ol>
  *   <li>Primitive types
- *   <li>Array Types: primitive arrays(i.e. {@code int[]}) and object arrays(i.e. {@code Foo[]})
- *   <li>Plain class types. i.e. {@code Foo}
- *   <li>Generic types. i.e. {@code Foo<String, Double>}
- *   <li>Wildcard types: only support {@code Foo<? extend Bar>} by downgrading it to {@code
- *       Foo<Bar>}, and throw exception when stumbled upon {@code Foo<? super Bar>}.
+ *   <li>Array Types: primitive arrays (like {@code int[]}) and object arrays (like {@code Foo[]})
+ *   <li>Plain class types, for example, {@code Foo}
+ *   <li>Generic types, for example, {@code Foo<String, Double>}
+ *   <li>Wildcard types: only support {@code Foo<? extend Bar>} by downgrading it to
+         {@code Foo<Bar>}, and throw exception when stumbled upon {@code Foo<? super Bar>}.
  * </ol>
  */
 public abstract class TypeToken<T> {
@@ -175,7 +175,7 @@ public abstract class TypeToken<T> {
 
   /**
    * {@link ArrayToken} is used to represent Array types in a type-safe manner. such as: primitive
-   * arrays(i.e. {@code int[]}) and object arrays(i.e. {@code Foo[]})
+   * arrays (that is, {@code int[]}) and object arrays (that is, {@code Foo[]})
    */
   public static class ArrayToken<T> extends TypeToken<T> {
     private final TypeToken<?> componentType;

--- a/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/TypeToken.java
+++ b/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/TypeToken.java
@@ -32,7 +32,7 @@ import java.lang.reflect.WildcardType;
  *   <li>Plain class types, for example, {@code Foo}
  *   <li>Generic types, for example, {@code Foo<String, Double>}
  *   <li>Wildcard types: only support {@code Foo<? extend Bar>} by downgrading it to
-         {@code Foo<Bar>}, and throw exception when stumbled upon {@code Foo<? super Bar>}.
+ * {@code Foo<Bar>}, and throw exception when stumbled upon {@code Foo<? super Bar>}.
  * </ol>
  */
 public abstract class TypeToken<T> {

--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/getters/AnnotationProperty.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/getters/AnnotationProperty.java
@@ -20,7 +20,7 @@ import javax.lang.model.element.AnnotationValue;
 /** Represents an annotation property/method with its value as explicitly set in source. */
 @AutoValue
 public abstract class AnnotationProperty {
-  /** Name of the property, e.g. \"value\". */
+  /** Name of the property, for example \"value\". */
   public abstract String name();
 
   /** Value of the property. */

--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/getters/Getter.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/getters/Getter.java
@@ -45,7 +45,7 @@ public abstract class Getter {
   /**
    * Getter's underlying Java type.
    *
-   * <p>The type is fully resolved with respect to generics, i.e. {@code Optional<MyType<String>>},
+   * <p>The type is fully resolved with respect to generics, for example, {@code Optional<MyType<String>>},
    * not {@code Optional<T>}.
    */
   public TypeMirror getUnderlyingType() {

--- a/encoders/protoc-gen-firebase-encoders/src/main/kotlin/com/google/firebase/encoders/proto/codegen/Types.kt
+++ b/encoders/protoc-gen-firebase-encoders/src/main/kotlin/com/google/firebase/encoders/proto/codegen/Types.kt
@@ -55,18 +55,19 @@ sealed class Primitive(override val javaName: String, val defaultValue: String) 
  * Can be one of [Message] or [ProtoEnum].
  */
 sealed class UserDefined : ProtobufType() {
-  /** A fully qualified protobuf message name, i.e. `com.example.Outer.Inner`. */
+  /** A fully qualified protobuf message name, for example, `com.example.Outer.Inner`. */
   abstract val protobufFullName: String
 
   /**
-   * Specifies the scope that this type is defined in, i.e. a [Owner.Package] or a parent [Message].
+   * Specifies the scope that this type is defined in, that is, a [Owner.Package] or a parent
+   * [Message].
    */
   abstract val owner: Owner
 
   /** Unqualified name of this type */
   abstract val name: String
 
-  /** A fully qualified java name of this type, i.e. `com.example.Outer$Inner`. */
+  /** A fully qualified java name of this type, for example, `com.example.Outer$Inner`. */
   override val javaName: String
     get() = "${owner.javaName}${owner.scopeSeparator}$name"
 


### PR DESCRIPTION
Updated Javadoc comments across multiple modules to replace non-standard abbreviations like "i.e." with clearer alternatives such as "for example" or "that is" for better readability.

NO_RELEASE_CHANGE