### PR TITLE
dataconnect(change): add core/generated SDK info to request headers of realtime query subscriptions

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -12,6 +12,10 @@
 - [fixed] Expired Auth and/or App Check tokens were not automatically refreshed
   when rejected by the server upon connection.
   ([#8346](https://github.com/firebase/firebase-android-sdk/pull/8346))
+- [changed] Realtime query subscriptions now include SDK type metadata
+  (core vs. generated SDK) in request headers, matching the behavior of
+  standard query executions.
+  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
 
 # 17.3.1
 

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -15,7 +15,7 @@
 - [changed] Realtime query subscriptions now include SDK type metadata
   (core vs. generated SDK) in request headers, matching the behavior of
   standard query executions.
-  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
+  ([#8356](https://github.com/firebase/firebase-android-sdk/pull/8356))
 
 # 17.3.1
 

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/DataConnectGrpcRPCsConnectIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/DataConnectGrpcRPCsConnectIntegrationTest.kt
@@ -81,6 +81,7 @@ class DataConnectGrpcRPCsConnectIntegrationTest : DataConnectIntegrationTestBase
         requestId = requestIdArb.sample(),
         operationName = GetStringByKeyQuery.OPERATION_NAME,
         variables = key.encodeToGetStringByKeyQueryVariables(),
+        callerSdkType = callerSdkTypeArb.sample(),
       )
 
     executeResponseFlow.test {
@@ -101,6 +102,7 @@ class DataConnectGrpcRPCsConnectIntegrationTest : DataConnectIntegrationTestBase
         requestId = requestIdArb.sample(),
         operationName = GetStringByKeyQuery.OPERATION_NAME,
         variables = key.encodeToGetStringByKeyQueryVariables(),
+        callerSdkType = callerSdkTypeArb.sample(),
       )
 
     executeResponseFlow.test {

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/DataConnectGrpcRPCsConnectIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/DataConnectGrpcRPCsConnectIntegrationTest.kt
@@ -17,6 +17,7 @@ package com.google.firebase.dataconnect
 
 import app.cash.turbine.test
 import com.google.firebase.dataconnect.FirebaseDataConnect.CallerSdkType
+import com.google.firebase.dataconnect.core.CallerSdkTypeElement
 import com.google.firebase.dataconnect.core.DataConnectBidiConnectStream
 import com.google.firebase.dataconnect.core.DataConnectBidiConnectStream.ExecuteResponse
 import com.google.firebase.dataconnect.core.DataConnectGrpcRPCs
@@ -50,6 +51,7 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import kotlin.random.Random
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.serializer
 import org.junit.Before
@@ -76,15 +78,16 @@ class DataConnectGrpcRPCsConnectIntegrationTest : DataConnectIntegrationTestBase
     val key = keyArb.sample()
 
     val stream = dataConnectGrpcRPCs.connect()
+    val callerSdkType = callerSdkTypeArb.sample()
     val executeResponseFlow: Flow<ExecuteResponse> =
       stream.subscribe(
         requestId = requestIdArb.sample(),
         operationName = GetStringByKeyQuery.OPERATION_NAME,
         variables = key.encodeToGetStringByKeyQueryVariables(),
-        callerSdkType = callerSdkTypeArb.sample(),
+        callerSdkType,
       )
 
-    executeResponseFlow.test {
+    executeResponseFlow.flowOn(CallerSdkTypeElement(callerSdkType)).test {
       awaitItem().shouldBeGetStringByKeyQueryResponse(expectedName = null)
     }
   }
@@ -97,15 +100,16 @@ class DataConnectGrpcRPCsConnectIntegrationTest : DataConnectIntegrationTestBase
     val key = connector.insertString(name = name1)
 
     val stream = dataConnectGrpcRPCs.connect()
+    val callerSdkType = callerSdkTypeArb.sample()
     val executeResponseFlow: Flow<ExecuteResponse> =
       stream.subscribe(
         requestId = requestIdArb.sample(),
         operationName = GetStringByKeyQuery.OPERATION_NAME,
         variables = key.encodeToGetStringByKeyQueryVariables(),
-        callerSdkType = callerSdkTypeArb.sample(),
+        callerSdkType,
       )
 
-    executeResponseFlow.test {
+    executeResponseFlow.flowOn(CallerSdkTypeElement(callerSdkType)).test {
       awaitItem().shouldBeGetStringByKeyQueryResponse(expectedName = name1)
       connector.updateString(key, name = name2)
       awaitItem().shouldBeGetStringByKeyQueryResponse(expectedName = name2)

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/CallerSdkTypeElement.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/CallerSdkTypeElement.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.dataconnect.core
+
+import com.google.firebase.dataconnect.FirebaseDataConnect.CallerSdkType
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+internal class CallerSdkTypeElement(val callerSdkType: CallerSdkType) :
+  AbstractCoroutineContextElement(Key) {
+  companion object Key : CoroutineContext.Key<CallerSdkTypeElement>
+}

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -17,8 +17,10 @@
 package com.google.firebase.dataconnect.core
 
 import androidx.annotation.VisibleForTesting
+import com.google.firebase.dataconnect.FirebaseDataConnect.CallerSdkType
 import com.google.firebase.dataconnect.core.DataConnectAuth.AuthUid
 import com.google.firebase.dataconnect.core.DataConnectAuth.GetAuthTokenResult
+import com.google.firebase.dataconnect.core.DataConnectGrpcMetadata.Companion.FIREBASE_AUTH_TOKEN_HEADER
 import com.google.firebase.dataconnect.core.LoggerGlobals.debug
 import com.google.firebase.dataconnect.util.CoroutineUtils.completedFlow
 import com.google.firebase.dataconnect.util.CoroutineUtils.mergeColdAndHotFlow
@@ -184,12 +186,14 @@ internal class DataConnectBidiConnectStream(
    * @param requestId A unique identifier for this request, used to correlate incoming responses.
    * @param operationName The name of the operation to execute.
    * @param variables The variables for the operation.
+   * @param callerSdkType The type of caller that is making the request.
    * @return A [Flow] of [ExecuteResponse] objects for the subscription.
    */
   fun subscribe(
     requestId: String,
     operationName: String,
     variables: Struct,
+    callerSdkType: CallerSdkType,
   ): Flow<ExecuteResponse> {
     val state = AtomicReference<SubscriptionState>(SubscriptionState.Disconnected)
 
@@ -742,7 +746,7 @@ private class ConnectionStateUpdater(private val idStringGenerator: IdStringGene
   private fun authTokenUpdateStreamRequest(authToken: String): StreamRequestProto =
     StreamRequestProto.newBuilder()
       .setRequestId(idStringGenerator.next("auth"))
-      .putHeaders("x-firebase-auth-token", authToken)
+      .putHeaders(FIREBASE_AUTH_TOKEN_HEADER, authToken)
       .build()
 }
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -99,6 +99,7 @@ internal class DataConnectBidiConnectStream(
   authToken: Flow<SequencedReference<GetAuthTokenResult?>>,
   shouldRetry: suspend (Throwable) -> RetryStrategy,
   idStringGenerator: IdStringGenerator,
+  private val grpcMetadata: DataConnectGrpcMetadata,
   private val coroutineScope: CoroutineScope,
   private val logger: Logger,
 ) {
@@ -202,7 +203,7 @@ internal class DataConnectBidiConnectStream(
       while (true) {
         when (val currentState = state.get()) {
           is SubscriptionState.Connected -> {
-            currentState.enqueueSubscribeOrResume()
+            currentState.enqueueSubscribeOrResume(callerSdkType)
             break
           }
           SubscriptionState.DisconnectedWithPendingSubscription -> break
@@ -229,7 +230,7 @@ internal class DataConnectBidiConnectStream(
             SubscriptionState.Disconnected
           }
         }
-        .transformToMessage(requestId, operationName, variables, state)
+        .transformToMessage(requestId, operationName, variables, callerSdkType, state)
         .map<_, MessageOrSubscribe> { MessageOrSubscribe.Message(it) }
         .buffer(capacity = Channel.CONFLATED) // use CONFLATED to drop stale data
         .shareIn(
@@ -290,12 +291,12 @@ internal class DataConnectBidiConnectStream(
       val connectionId: String,
       val outgoingRequests: SendChannel<StreamRequestProto>,
       private val hadPendingSubscription: Boolean,
-      private val subscribeOrResumeSignal: ConflatedSignal<Unit>,
+      private val subscribeOrResumeSignal: ConflatedSignal<CallerSdkType>,
       private val subscribeOrResumeJob: Job,
     ) : SubscriptionState {
 
-      fun enqueueSubscribeOrResume() {
-        subscribeOrResumeSignal.signal()
+      fun enqueueSubscribeOrResume(callerSdkType: CallerSdkType) {
+        subscribeOrResumeSignal.signal(callerSdkType)
         subscribeOrResumeJob.start()
       }
 
@@ -339,6 +340,7 @@ internal class DataConnectBidiConnectStream(
     requestId: String,
     operationName: String,
     variables: Struct,
+    callerSdkType: CallerSdkType,
     state: AtomicReference<SubscriptionState>,
   ): Flow<SubscriptionEvent.Message> {
     val subscribeRequest =
@@ -373,6 +375,7 @@ internal class DataConnectBidiConnectStream(
       subscribeRequest = subscribeRequest,
       resumeRequest = resumeRequest,
       cancelRequest = cancelRequest,
+      callerSdkType = callerSdkType,
     )
   }
 
@@ -381,20 +384,32 @@ internal class DataConnectBidiConnectStream(
     subscribeRequest: StreamRequestProto,
     resumeRequest: StreamRequestProto,
     cancelRequest: StreamRequestProto,
+    callerSdkType: CallerSdkType,
   ): Flow<SubscriptionEvent.Message> {
 
     suspend fun SendChannel<StreamRequestProto>.subscribeOrResumeLoop(
       authUid: AuthUid?,
-      subscribeOrResumeSignal: ConflatedSignal<Unit>,
+      subscribeOrResumeSignal: ConflatedSignal<CallerSdkType>,
     ) {
       var subscribed = false
       try {
-        subscribeOrResumeSignal.signals.collect {
+        subscribeOrResumeSignal.signals.collect { callerSdkType ->
+          val value = grpcMetadata.googApiClientHeaderValue(callerSdkType)
           if (!subscribed) {
-            trySendOrThrow(authUid, subscribeRequest)
+            val request =
+              subscribeRequest
+                .toBuilder()
+                .putHeaders(DataConnectGrpcMetadata.GOOG_API_CLIENT_HEADER, value)
+                .build()
+            trySendOrThrow(authUid, request)
             subscribed = true
           } else {
-            trySendOrThrow(authUid, resumeRequest)
+            val request =
+              resumeRequest
+                .toBuilder()
+                .putHeaders(DataConnectGrpcMetadata.GOOG_API_CLIENT_HEADER, value)
+                .build()
+            trySendOrThrow(authUid, request)
           }
         }
       } finally {
@@ -424,9 +439,9 @@ internal class DataConnectBidiConnectStream(
             is SubscriptionState.DisconnectedWithPendingSubscription -> true
           }
 
-        val subscribeOrResumeSignal = ConflatedSignal<Unit>()
+        val subscribeOrResumeSignal = ConflatedSignal<CallerSdkType>()
         if (isPendingSubscription) {
-          subscribeOrResumeSignal.signal()
+          subscribeOrResumeSignal.signal(callerSdkType)
         }
         val subscribeOrResumeJob =
           coroutineScope.launch(start = CoroutineStart.LAZY) {

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -29,6 +29,7 @@ import com.google.firebase.dataconnect.util.IdStringGenerator
 import com.google.firebase.dataconnect.util.ProtoUtil.toCompactString
 import com.google.firebase.dataconnect.util.SequencedReference
 import com.google.firebase.dataconnect.util.coroutines.ConflatedSignal
+import com.google.firebase.dataconnect.util.coroutines.signal
 import com.google.firebase.dataconnect.util.update
 import com.google.protobuf.Empty as EmptyProto
 import com.google.protobuf.Struct
@@ -289,7 +290,7 @@ internal class DataConnectBidiConnectStream(
       val connectionId: String,
       val outgoingRequests: SendChannel<StreamRequestProto>,
       private val hadPendingSubscription: Boolean,
-      private val subscribeOrResumeSignal: ConflatedSignal,
+      private val subscribeOrResumeSignal: ConflatedSignal<Unit>,
       private val subscribeOrResumeJob: Job,
     ) : SubscriptionState {
 
@@ -384,7 +385,7 @@ internal class DataConnectBidiConnectStream(
 
     suspend fun SendChannel<StreamRequestProto>.subscribeOrResumeLoop(
       authUid: AuthUid?,
-      subscribeOrResumeSignal: ConflatedSignal,
+      subscribeOrResumeSignal: ConflatedSignal<Unit>,
     ) {
       var subscribed = false
       try {
@@ -423,7 +424,7 @@ internal class DataConnectBidiConnectStream(
             is SubscriptionState.DisconnectedWithPendingSubscription -> true
           }
 
-        val subscribeOrResumeSignal = ConflatedSignal()
+        val subscribeOrResumeSignal = ConflatedSignal<Unit>()
         if (isPendingSubscription) {
           subscribeOrResumeSignal.signal()
         }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -29,7 +29,6 @@ import com.google.firebase.dataconnect.util.IdStringGenerator
 import com.google.firebase.dataconnect.util.ProtoUtil.toCompactString
 import com.google.firebase.dataconnect.util.SequencedReference
 import com.google.firebase.dataconnect.util.coroutines.ConflatedSignal
-import com.google.firebase.dataconnect.util.coroutines.signal
 import com.google.firebase.dataconnect.util.update
 import com.google.protobuf.Empty as EmptyProto
 import com.google.protobuf.Struct
@@ -189,7 +188,9 @@ internal class DataConnectBidiConnectStream(
    * @param operationName The name of the operation to execute.
    * @param variables The variables for the operation.
    * @param callerSdkType The type of caller that is making the request.
-   * @return A [Flow] of [ExecuteResponse] objects for the subscription.
+   * @return A [Flow] of [ExecuteResponse] objects for the subscription. The coroutine context that
+   * collects the flow **MUST** have a [CallerSdkTypeElement] element. This allows each individual
+   * flow collector to specify its own [CallerSdkType].
    */
   fun subscribe(
     requestId: String,
@@ -199,7 +200,7 @@ internal class DataConnectBidiConnectStream(
   ): Flow<ExecuteResponse> {
     val state = AtomicReference<SubscriptionState>(SubscriptionState.Disconnected)
 
-    fun sendSubscribeOrResume() {
+    fun sendSubscribeOrResume(callerSdkType: CallerSdkType) {
       while (true) {
         when (val currentState = state.get()) {
           is SubscriptionState.Connected -> {
@@ -241,7 +242,13 @@ internal class DataConnectBidiConnectStream(
         .onSubscription { emit(MessageOrSubscribe.Subscribed) }
         .transform { messageOrSubscribe ->
           when (messageOrSubscribe) {
-            MessageOrSubscribe.Subscribed -> sendSubscribeOrResume()
+            MessageOrSubscribe.Subscribed -> {
+              val callerSdkTypeElement = currentCoroutineContext()[CallerSdkTypeElement]
+              checkNotNull(callerSdkTypeElement) {
+                "internal error c6se9nvv5w: currentCoroutineContext()[CallerSdkTypeElement]==null"
+              }
+              sendSubscribeOrResume(callerSdkTypeElement.callerSdkType)
+            }
             is MessageOrSubscribe.Message -> emit(messageOrSubscribe)
           }
         }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadata.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadata.kt
@@ -55,7 +55,7 @@ internal class DataConnectGrpcMetadata(
 
   private val googRequestParamsHeaderValue = "location=${connectorLocation}&frontend=data"
 
-  private fun googApiClientHeaderValue(callerSdkType: FirebaseDataConnect.CallerSdkType): String {
+  fun googApiClientHeaderValue(callerSdkType: FirebaseDataConnect.CallerSdkType): String {
     val components = buildList {
       add("gl-kotlin/$kotlinVersion")
       add("gl-android/$androidVersion")
@@ -166,8 +166,10 @@ internal class DataConnectGrpcMetadata(
       }
     }
 
+    const val FIREBASE_AUTH_TOKEN_HEADER = "x-firebase-auth-token"
+
     private val firebaseAuthTokenHeader: Metadata.Key<String> =
-      Metadata.Key.of("x-firebase-auth-token", Metadata.ASCII_STRING_MARSHALLER)
+      Metadata.Key.of(FIREBASE_AUTH_TOKEN_HEADER, Metadata.ASCII_STRING_MARSHALLER)
 
     private val firebaseAppCheckTokenHeader: Metadata.Key<String> =
       Metadata.Key.of("x-firebase-appcheck", Metadata.ASCII_STRING_MARSHALLER)
@@ -175,8 +177,10 @@ internal class DataConnectGrpcMetadata(
     private val googRequestParamsHeader: Metadata.Key<String> =
       Metadata.Key.of("x-goog-request-params", Metadata.ASCII_STRING_MARSHALLER)
 
+    const val GOOG_API_CLIENT_HEADER = "x-goog-api-client"
+
     private val googApiClientHeader: Metadata.Key<String> =
-      Metadata.Key.of("x-goog-api-client", Metadata.ASCII_STRING_MARSHALLER)
+      Metadata.Key.of(GOOG_API_CLIENT_HEADER, Metadata.ASCII_STRING_MARSHALLER)
 
     @Suppress("SpellCheckingInspection")
     private val gmpAppIdHeader: Metadata.Key<String> =

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -526,6 +526,7 @@ internal class DataConnectGrpcRPCs(
       tokenManager.authToken,
       shouldRetry = shouldRetry,
       idStringGenerator,
+      grpcMetadata,
       connectCoroutineScope,
       Logger("DataConnectBidiConnectStream[sid=$streamId]").also {
         it.debug { "created by ${logger.nameWithId}" }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -97,7 +97,7 @@ internal class DataConnectGrpcRPCs(
   @get:VisibleForTesting val connectorResourceName: String,
   private val nonBlockingCoroutineDispatcher: CoroutineDispatcher,
   private val blockingCoroutineDispatcher: CoroutineDispatcher,
-  private val grpcMetadata: DataConnectGrpcMetadata,
+  @get:VisibleForTesting val grpcMetadata: DataConnectGrpcMetadata,
   private val cache: DataConnectCache?,
   parentLogger: Logger,
 ) {

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImpl.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImpl.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 
 internal class QuerySubscriptionImpl<Data, Variables>(
   override val query: QueryRefImpl<Data, Variables>,
@@ -51,7 +52,10 @@ internal class QuerySubscriptionImpl<Data, Variables>(
     }
 
     try {
-      realtimeQueryManager.subscribe(query).collect { resultSender.onRealtimeUpdate(it) }
+      val realtimeFlow = realtimeQueryManager.subscribe(query)
+      withContext(CallerSdkTypeElement(query.callerSdkType)) {
+        realtimeFlow.collect { resultSender.onRealtimeUpdate(it) }
+      }
     } finally {
       nonRealtimeJob.cancel()
     }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/querymgr/RealtimeQueryManager.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/querymgr/RealtimeQueryManager.kt
@@ -131,7 +131,12 @@ internal class RealtimeQueryManager(
     val coroutineName = "${logger.nameWithId}-subscribe(rid=$requestId)[ecpvdvmzvj]"
     val job =
       coroutineScope.async(CoroutineName(coroutineName)) {
-        connection.subscribe(requestId = requestId, operationName = operationName, variables)
+        connection.subscribe(
+          requestId = requestId,
+          operationName = operationName,
+          variables,
+          callerSdkType,
+        )
       }
 
     return job.await()
@@ -142,6 +147,7 @@ internal class RealtimeQueryManager(
     requestId: String,
     operationName: String,
     variables: Struct,
+    callerSdkType: CallerSdkType,
   ): Flow<SqliteSequencedReference<DataConnectGrpcClient.OperationResult>> {
     // calculateQueryId() is a CPU intensive operation that should NOT be performed on the main
     // thread. This is the first reason why this method assumes it's running in this.coroutineScope.
@@ -153,7 +159,7 @@ internal class RealtimeQueryManager(
     mutex.withLock {
       return flowByQueryId.getOrPut(queryId) {
         stream
-          .subscribe(requestId, operationName, variables)
+          .subscribe(requestId, operationName, variables, callerSdkType)
           .updateCache(cache, queryId)
           .mapToOperationResponse()
       }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/GrpcBidiFlow.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/GrpcBidiFlow.kt
@@ -20,6 +20,7 @@ import com.google.firebase.dataconnect.core.Logger
 import com.google.firebase.dataconnect.core.LoggerGlobals.debug
 import com.google.firebase.dataconnect.util.CoroutineUtils.asSendChannel
 import com.google.firebase.dataconnect.util.coroutines.ConflatedSignal
+import com.google.firebase.dataconnect.util.coroutines.signal
 import io.grpc.CallOptions
 import io.grpc.Channel as GrpcChannel
 import io.grpc.ClientCall
@@ -217,7 +218,7 @@ internal object GrpcBidiFlow {
 
       val clientCall: ClientCall<RequestT, ResponseT> = grpcChannel.newCall(method, callOptions)
 
-      val clientCallReadySignal = ConflatedSignal()
+      val clientCallReadySignal = ConflatedSignal<Unit>()
       suspend fun suspendUntilClientCallReady() {
         // Spurious "ready" signals are possible, so check clientCall.isReady to verify.
         // See the documentation for ClientCall.Listener.onReady() for details.

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignal.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignal.kt
@@ -95,6 +95,14 @@ internal class ConflatedSignal<T : Any> {
     get() = signalState.get() != null
 
   /**
+   * The value of the pending signal, or `null` if there is no pending signal.
+   *
+   * Reading this property does not consume the signal.
+   */
+  val pendingSignal: T?
+    get() = signalState.get()
+
+  /**
    * Emits a signal carrying the given [value].
    *
    * If a waiter is currently suspended (either in [await] or collecting from [signals]), it is

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignal.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignal.kt
@@ -149,12 +149,11 @@ internal class ConflatedSignal<T : Any> {
   suspend fun await(): T {
     while (true) {
       val current = signalState.get()
-      if (current != null) {
-        if (signalState.compareAndSet(current, null)) {
-          return current
-        }
+      if (current == null) {
+        channel.receive()
+      } else if (signalState.compareAndSet(current, null)) {
+        return current
       }
-      channel.receive()
     }
   }
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignal.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignal.kt
@@ -16,7 +16,7 @@
 
 package com.google.firebase.dataconnect.util.coroutines
 
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
@@ -57,13 +57,13 @@ import kotlinx.coroutines.flow.flow
  * All methods and properties of [ConflatedSignal] are thread-safe and may be safely called and/or
  * accessed concurrently from multiple threads and/or coroutines.
  */
-internal class ConflatedSignal {
+internal class ConflatedSignal<T : Any> {
 
-  private val signalState = AtomicBoolean(false)
+  private val signalState = AtomicReference<T?>(null)
   private val channel = Channel<Unit>(CONFLATED)
 
   /**
-   * A cold [Flow] that emits [Unit] every time a signal is received.
+   * A cold [Flow] that emits [T] every time a signal is received.
    *
    * ### Important Concurrency & Competing-Consumer Semantics
    *
@@ -76,10 +76,9 @@ internal class ConflatedSignal {
    * them (either resuming a direct [await] caller or emitting to a single flow collector). It will
    * *not* broadcast the signal to all collectors.
    */
-  val signals: Flow<Unit> = flow {
+  val signals: Flow<T> = flow {
     while (true) {
-      await()
-      emit(Unit)
+      emit(await())
     }
   }
 
@@ -88,22 +87,22 @@ internal class ConflatedSignal {
    * call to [await] or a collector of [signals].
    */
   val hasPendingSignal: Boolean
-    get() = signalState.get()
+    get() = signalState.get() != null
 
   /**
    * Emits a signal to resume a suspended waiter, if one is present, or buffers the signal for the
    * next waiter if none are currently awaiting.
    *
    * Because this signal is conflated, multiple sequential calls to [signal] without intervening
-   * calls to [await] (or collectors of [signal]) will be merged into a single signal. Only one
+   * calls to [await] (or collectors of [signals]) will be merged into a single signal. Only one
    * [await] call (or [signals] collector) will be resumed immediately, regardless of how many times
    * [signal] was called.
    *
    * This method is non-blocking, thread-safe, and safe to call from any context (including outside
    * of coroutines).
    */
-  fun signal() {
-    signalState.set(true)
+  fun signal(value: T) {
+    signalState.set(value)
     channel.trySend(Unit)
   }
 
@@ -126,14 +125,24 @@ internal class ConflatedSignal {
    * [await] is suspended, it will not resume successfully, even if it consumed a signal, but throws
    * a [CancellationException].
    */
-  suspend fun await() {
+  suspend fun await(): T {
     while (true) {
-      if (signalState.compareAndSet(true, false)) {
-        break
+      val current = signalState.get()
+      if (current != null) {
+        if (signalState.compareAndSet(current, null)) {
+          return current
+        }
       }
       channel.receive()
     }
   }
 
   override fun toString() = "ConflatedSignal(hasPendingSignal=$hasPendingSignal)"
+}
+
+/**
+ * Extension function to allow signaling a [ConflatedSignal] of [Unit] without passing an argument.
+ */
+internal fun ConflatedSignal<Unit>.signal() {
+  signal(Unit)
 }

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignal.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignal.kt
@@ -24,25 +24,28 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 /**
- * A coroutine-based signaling mechanism that allows a waiter to suspend until notified by a sender,
- * conflating multiple signals into one signal.
+ * A coroutine-based signaling mechanism that allows a waiter to suspend until a sender provides a
+ * signal value of type [T], conflating multiple signal values by retaining only the latest one.
  *
- * This class is designed to coordinate execution flow between asynchronous operations (such as a
- * producer and a consumer). A consumer can wait for a signal either by calling the suspending
- * method [await] or by collecting from the [signals] flow. In both cases, the consumer will resume
- * immediately once a producer calls [signal].
+ * This class is designed to coordinate execution flow and transfer data between asynchronous
+ * operations (such as a producer and a consumer). A consumer can wait for a signal value either by
+ * calling the suspending method [await] or by collecting from the [signals] flow. In both cases,
+ * the consumer will resume immediately and receive the value once a producer calls [signal].
+ *
+ * @param T the non-nullable type of the signal value (payload) carried by this signal.
  *
  * ### Key Behavioral Characteristics
  *
  * * **Single Signal Delivery / Competing Consumers:** If multiple coroutines are waiting for a
  * signal, whether they are suspended in [await] or collecting from the [signals] flow, then exactly
- * _one_ of them will be resumed/notified upon [signal] being called, chosen indeterminately. This
- * is *not* a broadcast event or a `signalAll` style primitive. Waiters and flow collectors
- * **compete** for signals.
- * * **Signal Conflation:** The signal is conflated and persistent until consumed. If [signal] is
- * called multiple times before any coroutine awaits, only a single signal is retained. The first
- * subsequent waiter (either via [await] or [signals] collection) will consume the signal and resume
- * immediately, while any further waiters will suspend.
+ * _one_ of them will be resumed with the value upon [signal] being called, chosen indeterminately.
+ * This is *not* a broadcast event or a `signalAll` style primitive. Waiters and flow collectors
+ * **compete** for signals and their associated values.
+ * * **Signal Conflation:** The signal value is conflated and persistent until consumed. If [signal]
+ * is called multiple times before any coroutine awaits, only the **most recent** signal value is
+ * retained, and all previous values are overwritten and lost. The first subsequent waiter (either
+ * via [await] or [signals] collection) will consume this latest value and resume immediately, while
+ * any further waiters will suspend.
  *
  * ### Prompt cancellation guarantee
  *
@@ -63,18 +66,20 @@ internal class ConflatedSignal<T : Any> {
   private val channel = Channel<Unit>(CONFLATED)
 
   /**
-   * A cold [Flow] that emits [T] every time a signal is received.
+   * A cold [Flow] that emits the signal value of type [T] every time a signal is successfully
+   * consumed by this flow collector.
    *
    * ### Important Concurrency & Competing-Consumer Semantics
    *
-   * This is a **competing-consumer** flow. Because [ConflatedSignal] only resumes one waiter per
-   * signal, collectors of this flow **compete** for signals with each other and with direct callers
-   * of [await].
+   * This is a **competing-consumer** flow. Because [ConflatedSignal] only delivers the signal value
+   * to one waiter per signal, collectors of this flow **compete** for signals with each other and
+   * with direct callers of [await].
    *
    * Specifically, if multiple collectors are actively collecting this flow concurrently, or if some
-   * coroutines are suspended in [await], a single call to [signal] will notify exactly **one** of
-   * them (either resuming a direct [await] caller or emitting to a single flow collector). It will
-   * *not* broadcast the signal to all collectors.
+   * coroutines are suspended in [await], a single call to [signal] will deliver the value to
+   * exactly **one** of them (either returning the value to a direct [await] caller or emitting the
+   * value to a single flow collector, chosen indeterminately). It will *not* broadcast the signal
+   * value to all collectors.
    */
   val signals: Flow<T> = flow {
     while (true) {
@@ -90,16 +95,21 @@ internal class ConflatedSignal<T : Any> {
     get() = signalState.get() != null
 
   /**
-   * Emits a signal to resume a suspended waiter, if one is present, or buffers the signal for the
-   * next waiter if none are currently awaiting.
+   * Emits a signal carrying the given [value].
+   *
+   * If a waiter is currently suspended (either in [await] or collecting from [signals]), it is
+   * resumed and receives this [value]. If no waiters are currently awaiting, the [value] is
+   * buffered as a pending signal for the next waiter.
    *
    * Because this signal is conflated, multiple sequential calls to [signal] without intervening
-   * calls to [await] (or collectors of [signals]) will be merged into a single signal. Only one
-   * [await] call (or [signals] collector) will be resumed immediately, regardless of how many times
-   * [signal] was called.
+   * consumption (via [await] or [signals]) will overwrite the pending value, retaining only the
+   * **most recent** [value]. Only one waiter will be resumed with this latest value, and all
+   * previously signaled values since the last consumption are lost.
    *
    * This method is non-blocking, thread-safe, and safe to call from any context (including outside
    * of coroutines).
+   *
+   * @param value the signal value of type [T] to emit.
    */
   fun signal(value: T) {
     signalState.set(value)
@@ -107,23 +117,26 @@ internal class ConflatedSignal<T : Any> {
   }
 
   /**
-   * Suspends the calling coroutine until a signal is received via [signal].
+   * Suspends the calling coroutine until a signal value of type [T] is received.
    *
-   * If a signal has already been emitted and not yet consumed, this method returns immediately,
-   * consuming that signal.
+   * If a signal value has already been emitted and not yet consumed, this method returns
+   * immediately, returning and consuming that value.
+   *
+   * @return the signal value of type [T] that was emitted.
    *
    * ### Important Concurrency & Competing-Consumer Semantics
    *
-   * Direct callers of [await] **compete** for signals with each other and with active collectors of
-   * the [signals] flow. Specifically, if multiple coroutines are waiting (either suspended in
-   * [await] or collecting from [signals]), a single call to [signal] will resume/notify exactly
-   * **one** of them, chosen indeterminately. It will *not* broadcast the signal to all.
+   * Direct callers of [await] **compete** for signals and their values with each other and with
+   * active collectors of the [signals] flow. Specifically, if multiple coroutines are waiting
+   * (either suspended in [await] or collecting from [signals]), a single call to [signal] will
+   * deliver the value and resume exactly **one** of them, chosen indeterminately. It will *not*
+   * broadcast the value to all.
    *
    * ### Prompt cancellation guarantee
    *
-   * This function provides **prompt cancellation guarantee**. That is, if the job is canceled while
-   * [await] is suspended, it will not resume successfully, even if it consumed a signal, but throws
-   * a [CancellationException].
+   * This function provides a **prompt cancellation guarantee**. That is, if the job is canceled
+   * while [await] is suspended, it will not resume successfully (even if it technically received a
+   * signal value), but will throw a [CancellationException].
    */
   suspend fun await(): T {
     while (true) {
@@ -141,7 +154,8 @@ internal class ConflatedSignal<T : Any> {
 }
 
 /**
- * Extension function to allow signaling a [ConflatedSignal] of [Unit] without passing an argument.
+ * Extension function to allow signaling a [ConflatedSignal] of type [Unit] without passing an
+ * argument, mimicking the original parameterless `signal()` behavior.
  */
 internal fun ConflatedSignal<Unit>.signal() {
   signal(Unit)

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
@@ -724,12 +724,19 @@ class DataConnectGrpcRPCsUnitTest {
       val cleanupsRegistration = cleanups.register(server)
       server.open()
       val dataConnectGrpcRPCs = newDataConnectGrpcRPCs(server, cache)
+      val callerSdkType = Arb.enum<CallerSdkType>().bind()
 
       server.events.test {
         val stream = dataConnectGrpcRPCs.connect(randomSource())
         expectNoEvents()
 
-        val subscriptionFlow = stream.subscribe("req1", "opName", StructProto.getDefaultInstance())
+        val subscriptionFlow =
+          stream.subscribe(
+            "req1",
+            "opName",
+            StructProto.getDefaultInstance(),
+            callerSdkType,
+          )
         expectNoEvents()
 
         backgroundScope.launch { subscriptionFlow.collect() }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
@@ -739,7 +739,7 @@ class DataConnectGrpcRPCsUnitTest {
           )
         expectNoEvents()
 
-        backgroundScope.launch { subscriptionFlow.collect() }
+        backgroundScope.launch(CallerSdkTypeElement(callerSdkType)) { subscriptionFlow.collect() }
         val streamRequest: StreamRequest = awaitUntilInitStreamRequest().streamRequest
 
         withClue("streamRequest=${streamRequest.print().value}") {

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -967,7 +967,7 @@ class QuerySubscriptionImplUnitTest {
 
           val resumeRequest = serverCollector.awaitUntilResumeStreamRequest().streamRequest
           val apiClientHeader = resumeRequest.headersMap["x-goog-api-client"]
-          apiClientHeader shouldBe dataConnect.googApiClientHeaderValue(callerSdkType1)
+          apiClientHeader shouldBe dataConnect.googApiClientHeaderValue(callerSdkType2)
 
           clientCollector2.cancelAndIgnoreRemainingEvents()
           clientCollector1.cancelAndIgnoreRemainingEvents()

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -60,6 +60,7 @@ import com.google.firebase.dataconnect.testutil.awaitUntilSubscribeStreamRequest
 import com.google.firebase.dataconnect.testutil.property.arbitrary.authUid
 import com.google.firebase.dataconnect.testutil.property.arbitrary.dataConnect
 import com.google.firebase.dataconnect.testutil.property.arbitrary.distinctPair
+import com.google.firebase.dataconnect.testutil.property.arbitrary.pair
 import com.google.firebase.dataconnect.testutil.registerDataConnectKotestPrinters
 import com.google.firebase.dataconnect.testutil.shouldBe
 import com.google.firebase.dataconnect.testutil.shouldContainWithNonAbuttingText
@@ -907,6 +908,70 @@ class QuerySubscriptionImplUnitTest {
 
           serverCollector.cancelAndIgnoreRemainingEvents()
           clientCollector.cancelAndIgnoreRemainingEvents()
+        }
+      } finally {
+        dataConnect.suspendingClose()
+      }
+    }
+  }
+
+  @Test
+  fun `x-goog-api-client header is sent with resume request`() = runTest {
+    val server = runningInProcessDataConnectServer()
+    checkAll(
+      propTestConfig,
+      Arb.enum<CallerSdkType>().pair(),
+      Arb.dataConnect.deferredAuthProvider(),
+      Arb.dataConnect.deferredAppCheckProvider(),
+    ) { (callerSdkType1, callerSdkType2), deferredAuthProvider, deferredAppCheckProvider ->
+      val dataConnect =
+        dataConnect(
+          serverLocalBindPort = server.port,
+          deferredAuthProvider = deferredAuthProvider,
+          deferredAppCheckProvider = deferredAppCheckProvider,
+        )
+
+      try {
+        val operationName = "opName_${alphabeticStringArb().sample()}"
+        val variables = testVariablesArb().sample()
+
+        val ref1 =
+          queryRef(
+            dataConnect = dataConnect,
+            operationName = operationName,
+            variables = variables,
+            callerSdkType = callerSdkType1,
+          )
+        val ref2 =
+          queryRef(
+            dataConnect = dataConnect,
+            operationName = operationName,
+            variables = variables,
+            callerSdkType = callerSdkType2,
+          )
+
+        val subscription1 = ref1.subscribe()
+        val subscription2 = ref2.subscribe()
+
+        turbineScope {
+          val serverCollector = server.events.testIn(backgroundScope, name = "serverCollector")
+          val clientCollector1 =
+            subscription1.flow.testIn(backgroundScope, name = "clientCollector1")
+
+          // Wait for the first subscriber's subscribe request
+          serverCollector.awaitUntilSubscribeStreamRequest()
+
+          // Start the second subscriber's flow, which triggers a resume request
+          val clientCollector2 =
+            subscription2.flow.testIn(backgroundScope, name = "clientCollector2")
+
+          val resumeRequest = serverCollector.awaitUntilResumeStreamRequest().streamRequest
+          val apiClientHeader = resumeRequest.headersMap["x-goog-api-client"]
+          apiClientHeader shouldBe dataConnect.googApiClientHeaderValue(callerSdkType1)
+
+          clientCollector2.cancelAndIgnoreRemainingEvents()
+          clientCollector1.cancelAndIgnoreRemainingEvents()
+          serverCollector.cancelAndIgnoreRemainingEvents()
         }
       } finally {
         dataConnect.suspendingClose()

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -878,6 +878,42 @@ class QuerySubscriptionImplUnitTest {
     }
   }
 
+  @Test
+  fun `x-goog-api-client header is sent with subscribe request`() = runTest {
+    val server = runningInProcessDataConnectServer()
+    checkAll(
+      propTestConfig,
+      Arb.enum<CallerSdkType>(),
+      Arb.dataConnect.deferredAuthProvider(),
+      Arb.dataConnect.deferredAppCheckProvider(),
+    ) { callerSdkType, deferredAuthProvider, deferredAppCheckProvider ->
+      val dataConnect =
+        dataConnect(
+          serverLocalBindPort = server.port,
+          deferredAuthProvider = deferredAuthProvider,
+          deferredAppCheckProvider = deferredAppCheckProvider,
+        )
+
+      try {
+        val subscription =
+          queryRef(dataConnect = dataConnect, callerSdkType = callerSdkType).subscribe()
+        turbineScope {
+          val serverCollector = server.events.testIn(backgroundScope, name = "serverCollector")
+          val clientCollector = subscription.flow.testIn(backgroundScope, name = "clientCollector")
+          val subscribeRequest = serverCollector.awaitUntilSubscribeStreamRequest().streamRequest
+
+          val apiClientHeader = subscribeRequest.headersMap["x-goog-api-client"]
+          apiClientHeader shouldBe dataConnect.googApiClientHeaderValue(callerSdkType)
+
+          serverCollector.cancelAndIgnoreRemainingEvents()
+          clientCollector.cancelAndIgnoreRemainingEvents()
+        }
+      } finally {
+        dataConnect.suspendingClose()
+      }
+    }
+  }
+
   private suspend fun TestScope.testDataConnectInitialHeader(
     server: InProcessDataConnectGrpcStreamingServer,
     deferredAuthProvider: com.google.firebase.inject.Deferred<InternalAuthProvider>,
@@ -1702,6 +1738,7 @@ class QuerySubscriptionImplUnitTest {
     dataConnect: FirebaseDataConnectImpl? = null,
     operationName: String? = null,
     variables: TestVariables? = null,
+    callerSdkType: CallerSdkType? = null,
   ): QueryRefImpl<TestData, TestVariables> =
     QueryRefImpl(
       dataConnect = dataConnect ?: dataConnect(),
@@ -1709,7 +1746,7 @@ class QuerySubscriptionImplUnitTest {
       variables = variables ?: testVariablesArb().sample(),
       dataDeserializer = serializer<TestData>(),
       variablesSerializer = serializer(),
-      callerSdkType = Arb.enum<CallerSdkType>().sample(),
+      callerSdkType = callerSdkType ?: Arb.enum<CallerSdkType>().sample(),
       dataSerializersModule = Arb.dataConnect.serializersModule().sample(),
       variablesSerializersModule = Arb.dataConnect.serializersModule().sample(),
     )
@@ -1802,3 +1839,6 @@ private fun StreamObserver<StreamResponse>.onNext(requestId: String, data: TestD
 
 private val retryableFailureGrpcStatusCodes: List<Status.Code> =
   Status.Code.entries.filterNot { it == Status.Code.OK || it == Status.Code.UNAUTHENTICATED }
+
+private fun FirebaseDataConnectImpl.googApiClientHeaderValue(callerSdkType: CallerSdkType): String =
+  grpcRPCs.grpcMetadata.googApiClientHeaderValue(callerSdkType)

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignalUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignalUnitTest.kt
@@ -157,6 +157,37 @@ class ConflatedSignalUnitTest {
   }
 
   @Test
+  fun `pendingSignal is initially null`() {
+    val signal = ConflatedSignal<String>()
+    signal.pendingSignal shouldBe null
+  }
+
+  @Test
+  fun `pendingSignal is the signaled value after signal is called`() {
+    val signal = ConflatedSignal<String>()
+    signal.signal("hello")
+    signal.pendingSignal shouldBe "hello"
+  }
+
+  @Test
+  fun `pendingSignal transitions to null after await completes`() = runTest {
+    val signal = ConflatedSignal<String>()
+    signal.signal("hello")
+    signal.pendingSignal shouldBe "hello"
+
+    signal.await() shouldBe "hello"
+    signal.pendingSignal shouldBe null
+  }
+
+  @Test
+  fun `pendingSignal remains the latest value after multiple signals`() {
+    val signal = ConflatedSignal<String>()
+    signal.signal("first")
+    signal.signal("second")
+    signal.pendingSignal shouldBe "second"
+  }
+
+  @Test
   fun `signals flow emits immediately if there is a pending signal`() = runTest {
     val signal = ConflatedSignal<Unit>()
     signal.signal()

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignalUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignalUnitTest.kt
@@ -42,7 +42,7 @@ class ConflatedSignalUnitTest {
 
   @Test
   fun `await returns immediately without suspending if there is a pending signal`() = runTest {
-    val signal = ConflatedSignal()
+    val signal = ConflatedSignal<Unit>()
     signal.signal()
 
     val job = backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { signal.await() }
@@ -52,7 +52,7 @@ class ConflatedSignalUnitTest {
 
   @Test
   fun `await suspends if there is NO pending signal`() = runTest {
-    val signal = ConflatedSignal()
+    val signal = ConflatedSignal<Unit>()
 
     val job = backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { signal.await() }
 
@@ -61,7 +61,7 @@ class ConflatedSignalUnitTest {
 
   @Test
   fun `multiple signals are conflated into one`() = runTest {
-    val signal = ConflatedSignal()
+    val signal = ConflatedSignal<Unit>()
     repeat(10) { signal.signal() }
 
     val job1 = backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { signal.await() }
@@ -72,7 +72,7 @@ class ConflatedSignalUnitTest {
 
   @Test
   fun `each call to signal resumes one call to await, leaving the others suspended`() = runTest {
-    val signal = ConflatedSignal()
+    val signal = ConflatedSignal<Unit>()
     val jobs =
       List(10) { backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { signal.await() } }
     check(jobs.all { !it.isCompleted })
@@ -87,7 +87,7 @@ class ConflatedSignalUnitTest {
 
   @Test
   fun `suspended await() calls are promptly canceled`() = runTest {
-    val signal = ConflatedSignal()
+    val signal = ConflatedSignal<Unit>()
     val job = backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { signal.await() }
     job.cancel()
     yield()
@@ -96,7 +96,7 @@ class ConflatedSignalUnitTest {
 
   @Test
   fun `canceling suspended await() calls do not disturb other awaiters`() = runTest {
-    val signal = ConflatedSignal()
+    val signal = ConflatedSignal<Unit>()
     val jobs =
       List(10) { backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { signal.await() } }
 
@@ -117,20 +117,20 @@ class ConflatedSignalUnitTest {
 
   @Test
   fun `hasPendingSignal is initially false`() {
-    val signal = ConflatedSignal()
+    val signal = ConflatedSignal<Unit>()
     signal.hasPendingSignal shouldBe false
   }
 
   @Test
   fun `hasPendingSignal is true after signal is called`() {
-    val signal = ConflatedSignal()
+    val signal = ConflatedSignal<Unit>()
     signal.signal()
     signal.hasPendingSignal shouldBe true
   }
 
   @Test
   fun `hasPendingSignal transitions to false after await completes`() = runTest {
-    val signal = ConflatedSignal()
+    val signal = ConflatedSignal<Unit>()
     signal.signal()
     signal.hasPendingSignal shouldBe true
 
@@ -140,14 +140,14 @@ class ConflatedSignalUnitTest {
 
   @Test
   fun `hasPendingSignal remains true after multiple signals`() {
-    val signal = ConflatedSignal()
+    val signal = ConflatedSignal<Unit>()
     repeat(5) { signal.signal() }
     signal.hasPendingSignal shouldBe true
   }
 
   @Test
   fun `hasPendingSignal remains false when multiple awaiters`() = runTest {
-    val signal = ConflatedSignal()
+    val signal = ConflatedSignal<Unit>()
     repeat(5) { backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { signal.await() } }
 
     repeat(100) {
@@ -158,7 +158,7 @@ class ConflatedSignalUnitTest {
 
   @Test
   fun `signals flow emits immediately if there is a pending signal`() = runTest {
-    val signal = ConflatedSignal()
+    val signal = ConflatedSignal<Unit>()
     signal.signal()
 
     signal.signals.test {
@@ -169,7 +169,7 @@ class ConflatedSignalUnitTest {
 
   @Test
   fun `signals flow collection suspends if there is NO pending signal`() = runTest {
-    val signal = ConflatedSignal()
+    val signal = ConflatedSignal<Unit>()
 
     val job =
       backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { signal.signals.collect {} }
@@ -179,7 +179,7 @@ class ConflatedSignalUnitTest {
 
   @Test
   fun `signals flow emits when signal is called`() = runTest {
-    val signal = ConflatedSignal()
+    val signal = ConflatedSignal<Unit>()
 
     signal.signals.test {
       signal.signal()
@@ -190,7 +190,7 @@ class ConflatedSignalUnitTest {
 
   @Test
   fun `multiple signals are conflated in the signals flow`() = runTest {
-    val signal = ConflatedSignal()
+    val signal = ConflatedSignal<Unit>()
     repeat(10) { signal.signal() }
 
     signal.signals.test {
@@ -201,7 +201,7 @@ class ConflatedSignalUnitTest {
 
   @Test
   fun `multiple collectors of signals flow compete for signals`() = runTest {
-    val signal = ConflatedSignal()
+    val signal = ConflatedSignal<Unit>()
 
     turbineScope {
       val collector1 = signal.signals.testIn(backgroundScope, name = "collector1")
@@ -221,7 +221,7 @@ class ConflatedSignalUnitTest {
 
   @Test
   fun `signals flow collectors compete with direct awaiters`() = runTest {
-    val signal = ConflatedSignal()
+    val signal = ConflatedSignal<Unit>()
 
     turbineScope {
       val collector = signal.signals.testIn(backgroundScope, name = "collector")
@@ -241,7 +241,7 @@ class ConflatedSignalUnitTest {
 
   @Test
   fun `toString contains hasPendingSignal=false initially`() {
-    val signal = ConflatedSignal()
+    val signal = ConflatedSignal<Unit>()
     check(!signal.hasPendingSignal)
 
     assertSoftly {
@@ -252,13 +252,46 @@ class ConflatedSignalUnitTest {
 
   @Test
   fun `toString contains hasPendingSignal=true after signal`() {
-    val signal = ConflatedSignal()
+    val signal = ConflatedSignal<Unit>()
     signal.signal()
     check(signal.hasPendingSignal)
 
     assertSoftly {
       signal.toString() shouldContainWithNonAbuttingText "ConflatedSignal"
       signal.toString() shouldContainWithNonAbuttingTextIgnoringCase "hasPendingSignal=true"
+    }
+  }
+
+  @Test
+  fun `await returns the signaled value`() = runTest {
+    val signal = ConflatedSignal<String>()
+    signal.signal("hello")
+
+    val result = signal.await()
+    result shouldBe "hello"
+  }
+
+  @Test
+  fun `signals are conflated to the latest value`() = runTest {
+    val signal = ConflatedSignal<String>()
+    signal.signal("A")
+    signal.signal("B")
+
+    val result = signal.await()
+    result shouldBe "B"
+  }
+
+  @Test
+  fun `signals flow emissions carry correct values`() = runTest {
+    val signal = ConflatedSignal<String>()
+
+    signal.signals.test {
+      signal.signal("hello")
+      awaitItem() shouldBe "hello"
+
+      signal.signal("world")
+      awaitItem() shouldBe "world"
+      cancelAndIgnoreRemainingEvents()
     }
   }
 }


### PR DESCRIPTION
This PR adds core and generated SDK information to the data connect request headers of realtime query subscriptions. This matches the behavior of standard query executions by sending the `x-goog-api-client` header with `callerSdkType` metadata when initiating subscribe or resume requests.

### Highlights

* **Realtime Query Metadata**: Wires up the propagation of SDK type info so that both subscribe and resume requests on the bidirectional connect stream send the `x-goog-api-client` header.
* **Generic Conflated Signal**: Refactors `ConflatedSignal` into a generic class `ConflatedSignal<T : Any>` that buffers and delivers non-nullable payloads (such as the caller SDK type) to competing waiters.
* **Coroutine Context SDK Propagation**: Introduces `CallerSdkTypeElement` to carry caller SDK type metadata in the coroutine context, allowing individual flow collectors to specify their caller SDK type.

<details>

<summary><b>Changelog</b></summary>

* **CHANGELOG.md**
  * Added a changelog entry documenting that realtime query subscriptions now include SDK type metadata.
* **CallerSdkTypeElement.kt**
  * Created `CallerSdkTypeElement` to carry `CallerSdkType` in the coroutine context.
* **DataConnectBidiConnectStream.kt**
  * Updated the `subscribe` method and internal connection states to propagate `CallerSdkType`.
  * Included `x-goog-api-client` header in subscribe and resume stream requests using `grpcMetadata`.
  * Required the collecting coroutine context to contain `CallerSdkTypeElement`.
* **DataConnectGrpcMetadata.kt**
  * Exposed `googApiClientHeaderValue()` publicly.
  * Added public constants `FIREBASE_AUTH_TOKEN_HEADER` and `GOOG_API_CLIENT_HEADER`.
* **DataConnectGrpcRPCs.kt**
  * Exposed `grpcMetadata` for testing.
  * Passed `grpcMetadata` to `DataConnectBidiConnectStream`.
* **QuerySubscriptionImpl.kt**
  * Collected the realtime subscription flow within a coroutine context containing `CallerSdkTypeElement`.
* **RealtimeQueryManager.kt**
  * Passed the `callerSdkType` parameter to the subscription stream connection.
* **GrpcBidiFlow.kt**
  * Specified the generic type `Unit` when instantiating `ConflatedSignal`.
* **ConflatedSignal.kt**
  * Converted `ConflatedSignal` to a generic class `ConflatedSignal<T : Any>` that buffers and delivers the latest signal value to a single waiter.
  * Added `signal(value: T)` and `await(): T` to handle generic payloads, with values conflating to the most recent signal value.
  * Added a `signal()` extension method for `ConflatedSignal<Unit>` to support parameterless signaling.
* **DataConnectGrpcRPCsConnectIntegrationTest.kt**
  * Updated integration tests to pass and assert `CallerSdkType` using `CallerSdkTypeElement`.
* **DataConnectGrpcRPCsUnitTest.kt**
  * Updated unit tests to specify and assert `CallerSdkType` on stream subscriptions.
* **QuerySubscriptionImplUnitTest.kt**
  * Added unit tests verifying the `x-goog-api-client` header is sent with both subscribe and resume requests.
* **ConflatedSignalUnitTest.kt**
  * Added tests covering the new generic payload support, latest value conflation, and `pendingSignal` property in `ConflatedSignal`.

</details>