### PR TITLE
[Crashlytics] Improve documentation clarity

### DIFF
--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/IdManager.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/IdManager.java
@@ -228,7 +228,7 @@ public class IdManager implements InstallIdProvider {
 
   /**
    * @return {@link String} identifying the display version of the Android OS that the device is
-   *     running, e.g. "4.2.2". Any forward slashes in the system returned value will be removed.
+   *     running, for example "4.2.2". Any forward slashes in the system returned value will be removed.
    */
   public String getOsDisplayVersionString() {
     return removeForwardSlashesIn(Build.VERSION.RELEASE);
@@ -236,7 +236,7 @@ public class IdManager implements InstallIdProvider {
 
   /**
    * @return {@link String} identifying the build version of the Android OS that the device is
-   *     running, e.g. "573038". Any forward slashes in the system returned value will be removed.
+   *     running, for example "573038". Any forward slashes in the system returned value will be removed.
    */
   public String getOsBuildVersionString() {
     return removeForwardSlashesIn(Build.VERSION.INCREMENTAL);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/NativeSessionFile.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/NativeSessionFile.java
@@ -25,7 +25,7 @@ import java.io.InputStream;
  */
 interface NativeSessionFile {
 
-  /** Shortname of the file sent to the reports endpoint, e.g., "logs" */
+  /** Shortname of the file sent to the reports endpoint, for example, "logs" */
   @NonNull
   String getReportsEndpointFilename();
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/QueueFile.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/QueueFile.java
@@ -70,7 +70,7 @@ class QueueFile implements Closeable {
    * The underlying file. Uses a ring buffer to store entries. Designed so that a modification isn't
    * committed or visible until we write the header. The header is much smaller than a segment. So
    * long as the underlying file system supports atomic segment writes, changes to the queue are
-   * atomic. Storing the file length ensures we can recover from a failed expansion (i.e. if setting
+   * atomic. Storing the file length ensures we can recover from a failed expansion (that is, if setting
    * the file length succeeds but the process dies before the data can be copied).
    *
    * <p>

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
@@ -326,7 +326,7 @@ public class UserMetadata {
      * so, it sets the marker bit to false, so the serialized data is guaranteed to contain all
      * updates until the next time the marker is flipped to true.
      *
-     * <p>If there's nothing to serialize (i.e., the marker bit is false), this method does nothing.
+     * <p>If there's nothing to serialize (that is, the marker bit is false), this method does nothing.
      */
     private void serializeIfMarked() {
       Map<String, String> keyData = null;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/stacktrace/MiddleOutStrategy.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/stacktrace/MiddleOutStrategy.java
@@ -17,7 +17,7 @@ package com.google.firebase.crashlytics.internal.stacktrace;
 /**
  * Strategy for trimming a given stack trace by removing the middle portion.
  *
- * <p>The most important details in a stack are the beginning and end - i.e. the point at which it
+ * <p>The most important details in a stack are the beginning and end - that is, the point at which it
  * was generated and where it originated. This strategy takes advantage of this notion and always
  * generates a trimmed stack of a given size by removing the middle of the stack, returning a
  * trimmed stack with half of the trimmed size from the beginning of the input stack, and half from


### PR DESCRIPTION
Replaced "e.g." and "i.e." with "for example" and "that is" throughout the documentation comments to improve readability and style.

NO_RELEASE_CHANGE