### PR TITLE
Add reference to go/firestore-android-sdk-keepalive in inline comments

### DIFF
--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -752,7 +752,7 @@ internal class DataConnectGrpcRPCs(
 
         // Ensure gRPC recovers from a dead connection. This is not typically necessary, as
         // the OS will usually notify gRPC when a connection dies. But not always. This acts as a
-        // failsafe.
+        // failsafe. Googlers see go/firestore-android-sdk-keepalive for details.
         it.keepAliveTime(30, TimeUnit.SECONDS)
 
         it.executor(executor)

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/GrpcCallProvider.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/GrpcCallProvider.java
@@ -106,6 +106,7 @@ public class GrpcCallProvider {
 
     // Ensure gRPC recovers from a dead connection. (Not typically necessary, as the OS will
     // usually notify gRPC when a connection dies. But not always. This acts as a failsafe.)
+    // Googlers see go/firestore-android-sdk-keepalive for details.
     channelBuilder.keepAliveTime(30, TimeUnit.SECONDS);
 
     // Wrap the ManagedChannelBuilder in an AndroidChannelBuilder. This allows the channel to


### PR DESCRIPTION
I (well, actually, gemini) found this useful discussion about grpc keepalives on Android that explain why Firestore (and Data Connect by virtue of copying Firestore's logic) specifies `channelBuilder.keepAliveTime(30, TimeUnit.SECONDS);`. This had always puzzled me so I'm adding a link into the comments so future Googlers can easily get some more details from go/firestore-android-sdk-keepalive.