### PR TITLE
[Perf] Warm up device-cache SharedPreferences off main thread

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/DeviceCacheManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/DeviceCacheManager.java
@@ -76,7 +76,7 @@ public class DeviceCacheManager {
             if (sharedPref == null && appContext != null) {
               SharedPreferences prefs =
                   appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
-              prefs.getAll();
+              prefs.contains("");
               this.sharedPref = prefs;
             }
           });

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/DeviceCacheManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/DeviceCacheManager.java
@@ -74,7 +74,10 @@ public class DeviceCacheManager {
       serialExecutor.execute(
           () -> {
             if (sharedPref == null && appContext != null) {
-              this.sharedPref = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+              SharedPreferences prefs =
+                  appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+              prefs.getAll();
+              this.sharedPref = prefs;
             }
           });
     }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/DeviceCacheManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/DeviceCacheManagerTest.java
@@ -58,11 +58,11 @@ public final class DeviceCacheManagerTest extends FirebasePerformanceTestBase {
 
     deviceCacheManager.setContext(warmUpContext);
 
-    verify(spyPrefs, never()).getAll();
+    verify(spyPrefs, never()).contains("");
 
     fakeScheduledExecutorService.runAll();
 
-    verify(spyPrefs).getAll();
+    verify(spyPrefs).contains("");
   }
 
   @Test

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/DeviceCacheManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/DeviceCacheManagerTest.java
@@ -15,8 +15,12 @@
 package com.google.firebase.perf.config;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.content.SharedPreferences;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.perf.FirebasePerformanceTestBase;
@@ -38,6 +42,27 @@ public final class DeviceCacheManagerTest extends FirebasePerformanceTestBase {
   public void setUp() {
     fakeScheduledExecutorService = new FakeScheduledExecutorService();
     deviceCacheManager = new DeviceCacheManager(fakeScheduledExecutorService);
+  }
+
+  @Test
+  public void setContext_warmsUpSharedPreferencesOnExecutor() {
+    SharedPreferences spyPrefs =
+        spy(appContext.getSharedPreferences(Constants.PREFS_NAME, Context.MODE_PRIVATE));
+    Context warmUpContext =
+        new ContextWrapper(appContext) {
+          @Override
+          public SharedPreferences getSharedPreferences(String name, int mode) {
+            return spyPrefs;
+          }
+        };
+
+    deviceCacheManager.setContext(warmUpContext);
+
+    verify(spyPrefs, never()).getAll();
+
+    fakeScheduledExecutorService.runAll();
+
+    verify(spyPrefs).getAll();
   }
 
   @Test


### PR DESCRIPTION
Fixes #8332


## Root Cause
`DeviceCacheManager.setContext()` already moves `Context.getSharedPreferences()` onto a background executor, but that call only returns the handle — Android loads the backing XML **lazily**, and the first getter blocks the calling thread in `SharedPreferencesImpl.awaitLoadedLocked()` until the disk read finishes. Since `setContext()` never read from the instance, that one-time load was deferred to the first real read: `Trace.start()` → `isPerformanceMonitoringEnabled()` → `getBoolean()` → `contains()` on the **main thread**, which absorbed the disk load and could ANR.

## Fix
After obtaining the `SharedPreferences` on the serial executor, force the load on that background thread with `prefs.contains("")` *before* publishing it to the `volatile sharedPref` field. A main-thread read then either sees `null` (returns `Optional.absent()` and falls back to manifest/default without blocking) or a fully-loaded instance (returns instantly). The one-time disk read can no longer land on the main thread.

## Tests
- New `DeviceCacheManagerTest#setContext_warmsUpSharedPreferencesOnExecutor`: asserts
  `contains("")` is not called before the executor runs and is called after `runAll()`.
