### PR TITLE
[RTDB] Replace abbreviations in Javadoc comments

### DIFF
--- a/firebase-database/src/main/java/com/google/firebase/database/DataSnapshot.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/DataSnapshot.java
@@ -35,7 +35,7 @@ import java.util.Iterator;
  * <br>
  * They are efficiently-generated immutable copies of the data at a Firebase Database location. They
  * can't be modified and will never change. To modify data at a location, use a <br>
- * {@link DatabaseReference} reference (e.g. with {@link DatabaseReference#setValue(Object)}).
+ * {@link DatabaseReference} reference (for example, with {@link DatabaseReference#setValue(Object)}).
  */
 public class DataSnapshot {
 
@@ -53,7 +53,7 @@ public class DataSnapshot {
 
   /**
    * Get a DataSnapshot for the location at the specified relative path. The relative path can
-   * either be a simple child key (e.g. 'fred') or a deeper slash-separated path (e.g.
+   * either be a simple child key (for example, 'fred') or a deeper slash-separated path (for example,
    * 'fred/name/first'). If the child location has no data, an empty DataSnapshot is returned.
    *
    * @param path A relative path to the location of child data

--- a/firebase-database/src/main/java/com/google/firebase/database/DatabaseError.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/DatabaseError.java
@@ -216,7 +216,7 @@ public class DatabaseError {
     return message;
   }
 
-  /** @return Human-readable details on the error and additional information, e.g. links to docs; */
+  /** @return Human-readable details on the error and additional information, for example, links to docs; */
   @NonNull
   public String getDetails() {
     return details;

--- a/firebase-database/src/main/java/com/google/firebase/database/DatabaseReference.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/DatabaseReference.java
@@ -148,7 +148,7 @@ public class DatabaseReference extends Query {
    *
    * <br>
    * <br>
-   * Generic collections of objects that satisfy the above constraints are also permitted, i.e.
+   * Generic collections of objects that satisfy the above constraints are also permitted, that is,
    * <code>Map&lt;String, MyPOJO&gt;</code>, as well as null values.
    *
    * @param value The value to set at this location or null to delete the existing data
@@ -187,7 +187,7 @@ public class DatabaseReference extends Query {
    *
    * <br>
    * <br>
-   * Generic collections of objects that satisfy the above constraints are also permitted, i.e.
+   * Generic collections of objects that satisfy the above constraints are also permitted, that is,
    * <code>Map&lt;String, MyPOJO&gt;</code>, as well as null values.
    *
    * @param value The value to set at this location or null to delete the existing data
@@ -227,7 +227,7 @@ public class DatabaseReference extends Query {
    *
    * <br>
    * <br>
-   * Generic collections of objects that satisfy the above constraints are also permitted, i.e.
+   * Generic collections of objects that satisfy the above constraints are also permitted, that is,
    * <code>Map&lt;String, MyPOJO&gt;</code>, as well as null values.
    *
    * @param value The value to set at this location or null to delete the existing data
@@ -264,7 +264,7 @@ public class DatabaseReference extends Query {
    *
    * <br>
    * <br>
-   * Generic collections of objects that satisfy the above constraints are also permitted, i.e.
+   * Generic collections of objects that satisfy the above constraints are also permitted, that is,
    * <code>Map&lt;String, MyPOJO&gt;</code>, as well as null values.
    *
    * @param value The value to set at this location or null to delete the existing data

--- a/firebase-database/src/main/java/com/google/firebase/database/FirebaseDatabase.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/FirebaseDatabase.java
@@ -219,7 +219,7 @@ public class FirebaseDatabase {
 
   /**
    * The Firebase Database client automatically queues writes and sends them to the server at the
-   * earliest opportunity, depending on network connectivity. In some cases (e.g. offline usage)
+   * earliest opportunity, depending on network connectivity. In some cases (for example, offline usage)
    * there may be a large number of writes waiting to be sent. Calling this method will purge all
    * outstanding writes so they are abandoned.
    *

--- a/firebase-database/src/main/java/com/google/firebase/database/MutableData.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/MutableData.java
@@ -288,7 +288,7 @@ public class MutableData {
    *
    * <br>
    * <br>
-   * Generic collections of objects that satisfy the above constraints are also permitted, i.e.
+   * Generic collections of objects that satisfy the above constraints are also permitted, that is,
    * <code>Map&lt;String, MyPOJO&gt;</code>, as well as null values.
    *
    * <p>Note that this overrides the priority, which must be set separately.

--- a/firebase-database/src/main/java/com/google/firebase/database/android/SqlPersistenceStorageEngine.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/android/SqlPersistenceStorageEngine.java
@@ -79,7 +79,7 @@ import java.util.Set;
  * data exists, whether it's complete, and what serverCache data can be pruned.
  *
  * <p>- trackedKeys: Keys in tracked queries. For each query in trackedQueries that is filtered
- * (i.e. not a loadsAllData() query), we'll track which keys are in the query. This allows us to
+ * (that is, not a loadsAllData() query), we'll track which keys are in the query. This allows us to
  * re-load only the keys of interest when restoring the query, as well as prune data for keys that
  * aren't tracked by any query.
  *
@@ -98,7 +98,7 @@ import java.util.Set;
  * multi-part/split writes starting with 0, NULL if not split + type: 'o' for overwrite and 'm' for
  * merge - serverCache + path: path for this node as string + value: serialized node as JSON (utf-8)
  * bytes - trackedQueries + id: unique id across restarts + path: Path of query. + query: A
- * serialization of the query parameters. + lastUse: When this query was last used (e.g. there was
+ * serialization of the query parameters. + lastUse: When this query was last used (for example, there was
  * an active listener). + complete: Whether serverCache contains complete data for the query. +
  * active: Whether we have an active listener for the query. - trackedKeys + id: id of the
  * trackedQuery for which this is a tracked key. + key: The tracked key belonging to the

--- a/firebase-database/src/main/java/com/google/firebase/database/core/Repo.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/Repo.java
@@ -104,7 +104,7 @@ public class Repo implements PersistentConnection.Delegate {
   }
 
   /**
-   * Defers any initialization that is potentially expensive (e.g. disk access) and must be run on
+   * Defers any initialization that is potentially expensive (for example, disk access) and must be run on
    * the run loop
    */
   private void deferredInitialization() {

--- a/firebase-database/src/main/java/com/google/firebase/database/core/SyncPoint.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/SyncPoint.java
@@ -50,7 +50,7 @@ import java.util.Set;
  *
  * <p>It's responsible for: - Maintaining the set of 1 or more views necessary at this location (a
  * SyncPoint with 0 views should be removed). - Proxying user / server operations to the views as
- * appropriate (i.e. applyServerOverwrite, applyUserOverwrite, etc.)
+ * appropriate (that is, applyServerOverwrite, applyUserOverwrite, etc.)
  */
 public class SyncPoint {
 

--- a/firebase-database/src/main/java/com/google/firebase/database/core/TokenProvider.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/TokenProvider.java
@@ -37,7 +37,7 @@ public interface TokenProvider {
   /** */
   public interface TokenChangeListener {
     /**
-     * Called whenever an event happens that will affect the current auth token (e.g. user logging
+     * Called whenever an event happens that will affect the current auth token (for example, user logging
      * in or out). Use {@link #getToken(boolean, GetTokenCompletionListener)} method to get the
      * updated token.
      */

--- a/firebase-database/src/main/java/com/google/firebase/database/core/persistence/PruneForest.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/persistence/PruneForest.java
@@ -27,7 +27,7 @@ import java.util.Set;
  *
  * <p>Internally we store this as a single tree of booleans with the following characteristics: *
  * 'true' indicates a location that can be pruned, possibly with some excluded descendants. *
- * 'false' indicates a location that we should keep (i.e. exclude from pruning). * 'true' (prune)
+ * 'false' indicates a location that we should keep (that is, exclude from pruning). * 'true' (prune)
  * cannot be a descendant of 'false' (keep). This will trigger an exception. * 'true' cannot be a
  * descendant of 'true' (we'll just keep the more shallow 'true'). * 'false' cannot be a descendant
  * of 'false' (we'll just keep the more shallow 'false').

--- a/firebase-database/src/main/java/com/google/firebase/database/core/view/CacheNode.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/view/CacheNode.java
@@ -22,7 +22,7 @@ import com.google.firebase.database.snapshot.Node;
 /**
  * A cache node only stores complete children. Additionally it holds a flag whether the node can be
  * considered fully initialized in the sense that we know at one point in time this represented a
- * valid state of the world, e.g. initialized with data from the server, or a complete overwrite by
+ * valid state of the world, for example, initialized with data from the server, or a complete overwrite by
  * the client. The filtered flag also tracks whether a node potentially had children removed due to
  * a filter.
  */

--- a/firebase-database/src/main/java/com/google/firebase/database/core/view/filter/NodeFilter.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/view/filter/NodeFilter.java
@@ -62,7 +62,7 @@ public interface NodeFilter {
   /**
    * Since updates to filtered nodes might require nodes to be pulled in from "outside" the node,
    * this interface can help to get complete children that can be pulled in. A class implementing
-   * this interface takes potentially multiple sources (e.g. user writes, server data from other
+   * this interface takes potentially multiple sources (for example, user writes, server data from other
    * views etc.) to try it's best to get a complete child that might be useful in pulling into the
    * view.
    */

--- a/firebase-database/src/main/java/com/google/firebase/database/snapshot/IndexedNode.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/snapshot/IndexedNode.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 /**
  * Represents a node together with an index. The index and node are updated in unison. In the case
- * where the index does not affect the ordering (i.e. the ordering is identical to the key ordering)
+ * where the index does not affect the ordering (that is, the ordering is identical to the key ordering)
  * this class uses a fallback index to save memory. Everything operating on the index must special
  * case the fallback index.
  */


### PR DESCRIPTION
Updated various Javadoc comments across the codebase to replace informal abbreviations like "e.g." with "for example" and "i.e." with "that is" for improved clarity and readability.

NO_RELEASE_CHANGE