### PR TITLE
[Infra] Disable credential persistence in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ai-daily-tests.yml
+++ b/.github/workflows/ai-daily-tests.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.github/workflows/api-information.yml
+++ b/.github/workflows/api-information.yml
@@ -11,6 +11,7 @@ jobs:
         with:
           fetch-depth: 2
           submodules: true
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.github/workflows/api-information.yml
+++ b/.github/workflows/api-information.yml
@@ -2,6 +2,9 @@ name: API Information
 
 on: [ pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   api-information-check:
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/app-distribution-gradle-compatibility-tests.yml
+++ b/.github/workflows/app-distribution-gradle-compatibility-tests.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Upload Test Report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: integration-test-report
           path: firebase-appdistribution-gradle/build/reports/tests/

--- a/.github/workflows/app-distribution-gradle-compatibility-tests.yml
+++ b/.github/workflows/app-distribution-gradle-compatibility-tests.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:

--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - 'releases/**'
 
+permissions:
+  contents: read
+
 jobs:
   build-artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -13,6 +13,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,6 +7,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
     cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changelog-check:
     runs-on: ubuntu-22.04

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         fetch-depth: 100
         submodules: true
+        persist-credentials: false
     - uses: ruby/setup-ruby@12fd324f1d0b43274fdc8130f6980590a667c455 # v1.312.0
       with:
         ruby-version: '3.4'

--- a/.github/workflows/check-firebaseai-responses.yml
+++ b/.github/workflows/check-firebaseai-responses.yml
@@ -39,6 +39,6 @@ jobs:
             should be updated to clone the latest version of the responses: `${{env.latest_tag}}`
       - name: Delete comment when version gets updated
         if: ${{env.cloned_tag == env.latest_tag && steps.fc.outputs.comment-id}}
-        uses: detomarco/delete-comments@dd37d1026c669ebfb0ffa5d23890010759ff05d5 # v1.1.0
+        uses: detomarco/delete-comments@dd37d1026c669ebfb0ffa5d23890010759ff05d5 # 1.1.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/check-firebaseai-responses.yml
+++ b/.github/workflows/check-firebaseai-responses.yml
@@ -39,6 +39,6 @@ jobs:
             should be updated to clone the latest version of the responses: `${{env.latest_tag}}`
       - name: Delete comment when version gets updated
         if: ${{env.cloned_tag == env.latest_tag && steps.fc.outputs.comment-id}}
-        uses: detomarco/delete-comment@dd37d1026c669ebfb0ffa5d23890010759ff05d5 # v1.1.0
+        uses: detomarco/delete-comments@dd37d1026c669ebfb0ffa5d23890010759ff05d5 # v1.1.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/check-firebaseai-responses.yml
+++ b/.github/workflows/check-firebaseai-responses.yml
@@ -9,6 +9,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Clone mock responses
         run: ai-logic/firebase-ai/update_responses.sh
       - name: Find cloned and latest versions

--- a/.github/workflows/check-head-dependencies.yml
+++ b/.github/workflows/check-head-dependencies.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - 'releases/**'
 
+permissions:
+  contents: read
+
 jobs:
   check-head-dependencies:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-head-dependencies.yml
+++ b/.github/workflows/check-head-dependencies.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check_format:
     name: "Check Format"

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   determine_changed:
     name: "Determine changed modules"

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           fetch-depth: 2
           submodules: true
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -52,6 +53,7 @@ jobs:
         with:
           fetch-depth: 2
           submodules: true
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -139,6 +141,7 @@ jobs:
         with:
           fetch-depth: 2
           submodules: true
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.github/workflows/config-e2e.yml
+++ b/.github/workflows/config-e2e.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout firebase-config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.github/workflows/config-e2e.yml
+++ b/.github/workflows/config-e2e.yml
@@ -11,6 +11,9 @@ concurrency:
 env:
   REMOTE_CONFIG_E2E_GOOGLE_SERVICES: ${{ secrets.REMOTE_CONFIG_E2E_GOOGLE_SERVICES }}
 
+permissions:
+  contents: read
+
 jobs:
   test:
 

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   copyright-check:
     runs-on: ubuntu-22.04

--- a/.github/workflows/create-releases-buildtools.yml
+++ b/.github/workflows/create-releases-buildtools.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -52,6 +54,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -80,6 +84,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:

--- a/.github/workflows/create_releases.yml
+++ b/.github/workflows/create_releases.yml
@@ -24,8 +24,10 @@ jobs:
       - name: Create base branch
         run: |
           gh api repos/${{ github.repository }}/git/refs \
-            -f ref="refs/heads/releases/${{ inputs.name }}" \
+            -f ref="refs/heads/releases/${INPUTS_NAME}" \
             -f sha="${{ github.sha }}"
+        env:
+          INPUTS_NAME: ${{ inputs.name }}
 
   create-pull-request:
     runs-on: ubuntu-latest
@@ -37,6 +39,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:

--- a/.github/workflows/diff-javadoc.yml
+++ b/.github/workflows/diff-javadoc.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           fetch-depth: 2
           submodules: true
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -38,6 +39,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.base_ref }}
+          persist-credentials: false
 
       - name: Generate docs for main
         run: ./gradlew kotlindoc

--- a/.github/workflows/fireci.yml
+++ b/.github/workflows/fireci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   fireci:
     name: "fireci tests"

--- a/.github/workflows/fireci.yml
+++ b/.github/workflows/fireci.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'

--- a/.github/workflows/fireperf-e2e.yml
+++ b/.github/workflows/fireperf-e2e.yml
@@ -12,6 +12,10 @@ env:
   PERF_E2E_GOOGLE_SERVICES: ${{ secrets.PERF_E2E_GOOGLE_SERVICES }}
   FTL_RESULTS_BUCKET: fireescape
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/fireperf-e2e.yml
+++ b/.github/workflows/fireperf-e2e.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout firebase-android-sdk
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:

--- a/.github/workflows/firestore_ci_tests.yml
+++ b/.github/workflows/firestore_ci_tests.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   determine_changed:
     name: "Determine changed modules"

--- a/.github/workflows/firestore_ci_tests.yml
+++ b/.github/workflows/firestore_ci_tests.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           fetch-depth: 2
           submodules: true
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -51,6 +52,7 @@ jobs:
         with:
           fetch-depth: 2
           submodules: true
+          persist-credentials: false
 
       - name: Enable KVM
         run: |
@@ -117,6 +119,7 @@ jobs:
         with:
           fetch-depth: 2
           submodules: true
+          persist-credentials: false
 
       - name: Enable KVM
         run: |
@@ -210,6 +213,7 @@ jobs:
         with:
           fetch-depth: 2
           submodules: true
+          persist-credentials: false
 
       - name: Enable KVM
         run: |
@@ -276,6 +280,7 @@ jobs:
         with:
           fetch-depth: 2
           submodules: true
+          persist-credentials: false
 
       - name: Enable KVM
         run: |

--- a/.github/workflows/health-metrics.yml
+++ b/.github/workflows/health-metrics.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           fetch-depth: 2
           submodules: true
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -73,6 +74,7 @@ jobs:
         with:
           fetch-depth: 2
           submodules: true
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -114,6 +116,7 @@ jobs:
         with:
           fetch-depth: 2
           submodules: true
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:

--- a/.github/workflows/health-metrics.yml
+++ b/.github/workflows/health-metrics.yml
@@ -20,6 +20,9 @@ on:
 env:
   GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     name: Coverage

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Build with Jekyll

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -18,8 +18,6 @@ on:
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Allow one concurrent deployment
 concurrency:
@@ -29,9 +27,14 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Build with Jekyll
@@ -49,6 +52,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -32,8 +32,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Build with Jekyll

--- a/.github/workflows/make-bom.yml
+++ b/.github/workflows/make-bom.yml
@@ -13,6 +13,8 @@ jobs:
           python-version: '3.12'
           pip-version: '26.0.1'
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.github/workflows/make-bom.yml
+++ b/.github/workflows/make-bom.yml
@@ -3,6 +3,9 @@ name: Make BoM
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -19,6 +19,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: false
+        persist-credentials: false
 
     - name: Filter paths
       id: filter

--- a/.github/workflows/metalava-semver-check.yml
+++ b/.github/workflows/metalava-semver-check.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.base_ref }}
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -34,6 +35,7 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           clean: false
+          persist-credentials: false
 
       - name: Run Metalava SemVer check
         run: ./gradlew metalavaSemver

--- a/.github/workflows/perf-gradle-compatibility-tests.yml
+++ b/.github/workflows/perf-gradle-compatibility-tests.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:

--- a/.github/workflows/plugins-check.yml
+++ b/.github/workflows/plugins-check.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:

--- a/.github/workflows/post_release_cleanup.yml
+++ b/.github/workflows/post_release_cleanup.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           ref: ${{ inputs.target-branch }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:

--- a/.github/workflows/post_release_cleanup.yml
+++ b/.github/workflows/post_release_cleanup.yml
@@ -12,6 +12,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   create-pull-request:
     runs-on: ubuntu-latest

--- a/.github/workflows/private-mirror-sync.yml
+++ b/.github/workflows/private-mirror-sync.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     if: github.repository == 'FirebasePrivate/firebase-android-sdk'

--- a/.github/workflows/private-mirror-sync.yml
+++ b/.github/workflows/private-mirror-sync.yml
@@ -16,12 +16,14 @@ jobs:
           ref: main
           fetch-depth: 0
           submodules: true
+          persist-credentials: false
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           submodules: true
           token: ${{ secrets.GOOGLE_OSS_BOT_TOKEN }}
+          persist-credentials: false
       - name: Force push HEAD to private repo main branch
         run: |
           git config --local user.name google-oss-bot

--- a/.github/workflows/release-note-changes.yml
+++ b/.github/workflows/release-note-changes.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Create output file
         run: touch changelog_comment.md

--- a/.github/workflows/release-note-changes.yml
+++ b/.github/workflows/release-note-changes.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - 'main'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   release-notes-changed:
     runs-on: ubuntu-latest

--- a/.github/workflows/sessions-e2e.yml
+++ b/.github/workflows/sessions-e2e.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout firebase-sessions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.github/workflows/sessions-e2e.yml
+++ b/.github/workflows/sessions-e2e.yml
@@ -11,6 +11,9 @@ concurrency:
 env:
   SESSIONS_E2E_GOOGLE_SERVICES: ${{ secrets.SESSIONS_E2E_GOOGLE_SERVICES }}
 
+permissions:
+  contents: read
+
 jobs:
   test:
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -11,6 +11,7 @@ jobs:
         with:
           fetch-depth: 2
           submodules: true
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -2,6 +2,9 @@ name: Smoke Tests
 
 on: [ pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   smoke-tests:
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -12,6 +12,9 @@ on:
       # Only run this if a gradle.properties file is touched.
       - '**/gradle.properties'
 
+permissions:
+  contents: read
+
 jobs:
   check_if_version_changed:
     name: Check if released version changed
@@ -64,12 +67,15 @@ jobs:
           persist-credentials: false
 
       - name: Get firebase-workflow-trigger token
-        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: generate-token
         with:
-          app_id: ${{ secrets.CPP_WORKFLOW_TRIGGER_APP_ID }}
-          private_key: ${{ secrets.CPP_WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
-          repository: firebase/firebase-cpp-sdk
+          app-id: ${{ secrets.CPP_WORKFLOW_TRIGGER_APP_ID }}
+          private-key: ${{ secrets.CPP_WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
+          owner: firebase
+          repositories: firebase-cpp-sdk
+          permission-actions: write
+          permission-contents: write
 
       - name: Trigger firebase-cpp-sdk update
         run: |

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -29,6 +29,7 @@ jobs:
           ref: ${{ github.sha }}
           # Specify fetch-depth so we can query the log, the default is a shallow clone.
           fetch-depth: 0
+          persist-credentials: false
       - name: Check if version was updated in git history
         id: check_version
         run: |
@@ -60,6 +61,7 @@ jobs:
         with:
           repository: firebase/firebase-cpp-sdk
           ref: main
+          persist-credentials: false
 
       - name: Get firebase-workflow-trigger token
         uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c

--- a/.github/workflows/validate-dependencies.yml
+++ b/.github/workflows/validate-dependencies.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:

--- a/.github/workflows/validate-dependencies.yml
+++ b/.github/workflows/validate-dependencies.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - 'releases/**'
 
+permissions:
+  contents: read
+
 jobs:
   build-artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - 'releases/**'
 
+permissions:
+  contents: read
+
 jobs:
   version-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updated all CI/CD workflow files to set `persist-credentials: false` in the `actions/checkout` step. This security improvement prevents the checkout action from persisting the GITHUB_TOKEN in the local git configuration of the runner.

Change generated using the [zizmor](https://github.com/zizmorcore/zizmor) tool