### PR TITLE
dataconnect(change): add exponential backoff in realtime query subscriptions upon disconnecting from the server

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -16,6 +16,9 @@
   (core vs. generated SDK) in request headers, matching the behavior of
   standard query executions.
   ([#8356](https://github.com/firebase/firebase-android-sdk/pull/8356))
+- [changed] Realtime query subscriptions now retry connecting using an
+  exponential backoff strategy.
+  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
 
 # 17.3.1
 

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -18,7 +18,7 @@
   ([#8356](https://github.com/firebase/firebase-android-sdk/pull/8356))
 - [changed] Realtime query subscriptions now retry connecting using an
   exponential backoff strategy.
-  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
+  ([#8381](https://github.com/firebase/firebase-android-sdk/pull/8381))
 
 # 17.3.1
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.firebase.dataconnect.core
 
 import androidx.annotation.VisibleForTesting
@@ -29,6 +28,7 @@ import com.google.firebase.dataconnect.util.IdStringGenerator
 import com.google.firebase.dataconnect.util.ProtoUtil.toCompactString
 import com.google.firebase.dataconnect.util.SequencedReference
 import com.google.firebase.dataconnect.util.coroutines.ConflatedSignal
+import com.google.firebase.dataconnect.util.coroutines.signal
 import com.google.firebase.dataconnect.util.update
 import com.google.protobuf.Empty as EmptyProto
 import com.google.protobuf.Struct
@@ -39,7 +39,7 @@ import google.firebase.dataconnect.proto.ResumeRequest as ResumeRequestProto
 import google.firebase.dataconnect.proto.StreamRequest as StreamRequestProto
 import google.firebase.dataconnect.proto.StreamResponse as StreamResponseProto
 import java.util.concurrent.atomic.AtomicReference
-import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
@@ -49,7 +49,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.onFailure
 import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -62,6 +61,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
@@ -69,6 +69,7 @@ import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.flow.transformWhile
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Manages a bidirectional gRPC stream for Data Connect operations.
@@ -103,6 +104,9 @@ internal class DataConnectBidiConnectStream(
   private val logger: Logger,
 ) {
 
+  private val retryBackoff = RetryBackoffCalculator()
+  private val resetAndRetryEvent = ConflatedSignal<Unit>()
+
   val isPermanentlyFailed: Boolean
     get() = _permanentFailureFlow.replayCache.isNotEmpty()
 
@@ -129,6 +133,7 @@ internal class DataConnectBidiConnectStream(
 
     val sharedFlow =
       mergeGrpcAndAuth(flow, authToken)
+        .onStart { resetAndRetryEvent.clear() }
         .mapNotNull { event ->
           with(connectionStateUpdater) { connectionStateFlow.update(event) }
           when (event) {
@@ -137,7 +142,11 @@ internal class DataConnectBidiConnectStream(
             is GrpcAuthMergedFlowEvent.Grpc ->
               when (event.event) {
                 is GrpcBidiFlow.Event.ConnectionInfo -> null
-                is GrpcBidiFlow.Event.Message -> event.event
+                is GrpcBidiFlow.Event.Message -> {
+                  retryBackoff.reset()
+                  resetAndRetryEvent.clear()
+                  event.event
+                }
               }
           }
         }
@@ -148,7 +157,8 @@ internal class DataConnectBidiConnectStream(
           }
           throw throwable ?: Exception("to be handled by retryWhen")
         }
-        .retryWhen { cause, attempt ->
+        .retryWhen { cause, _ ->
+          resetAndRetryEvent.clear()
           val retryStrategy =
             try {
               shouldRetry(cause)
@@ -159,15 +169,21 @@ internal class DataConnectBidiConnectStream(
             }
 
           when (retryStrategy) {
-            RetryStrategy.RETRY_IMMEDIATELY -> true
+            RetryStrategy.RETRY_IMMEDIATELY -> {
+              retryBackoff.reset()
+              true
+            }
             RetryStrategy.RETRY_AFTER_BACKOFF -> {
-              if (attempt > 2) {
-                false
-              } else {
-                delay(1.seconds)
-                logger.debug { "retrying connection" }
-                true
+              val backoffMs = retryBackoff.next()
+              logger.debug {
+                "waiting ${backoffMs}ms before retrying connection, which failed due to $cause"
               }
+              withTimeoutOrNull(backoffMs.milliseconds) {
+                onRetryBackoffForTesting.get()?.invoke(backoffMs)
+                resetAndRetryEvent.await()
+              }
+              resetAndRetryEvent.clear()
+              true
             }
           }
         }
@@ -239,7 +255,11 @@ internal class DataConnectBidiConnectStream(
           started = SharingStarted.WhileSubscribed(replayExpirationMillis = 0),
           replay = 0,
         )
-        .onSubscription { emit(MessageOrSubscribe.Subscribed) }
+        .onSubscription {
+          retryBackoff.reset()
+          resetAndRetryEvent.signal()
+          emit(MessageOrSubscribe.Subscribed)
+        }
         .transform { messageOrSubscribe ->
           when (messageOrSubscribe) {
             MessageOrSubscribe.Subscribed -> {
@@ -531,6 +551,21 @@ internal class DataConnectBidiConnectStream(
       }
     }
 
+    @VisibleForTesting
+    fun setOnRetryBackoffForTesting(callback: (backoffMillis: Long) -> Unit) {
+      val success = onRetryBackoffForTesting.compareAndSet(null, callback)
+      check(success) { "setOnRetryBackoffForTesting() failed: a value is already set [zxj2r8c95p]" }
+    }
+
+    @VisibleForTesting
+    fun unsetOnRetryBackoffForTesting(callback: (backoffMillis: Long) -> Unit) {
+      val success = onRetryBackoffForTesting.compareAndSet(callback, null)
+      check(success) {
+        "unsetOnRetryBackoffForTesting() failed: " +
+          "the given value is NOT the one currently set [trtd7y682q]"
+      }
+    }
+
     private fun StreamResponseProto.toExecuteResponse(authUid: AuthUid?): ExecuteResponse? =
       if (!hasData() && errorsCount == 0) {
         null
@@ -549,6 +584,8 @@ internal class DataConnectBidiConnectStream(
 
 private val reconnectPendingAuthTokenForTesting =
   AtomicReference<SequencedReference<GetAuthTokenResult>>(null)
+
+private val onRetryBackoffForTesting = AtomicReference<(backoffMillis: Long) -> Unit>(null)
 
 private fun mergeGrpcAndAuth(
   grpcBidiFlow:

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/RetryBackoffCalculator.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/RetryBackoffCalculator.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.dataconnect.core
+
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.math.roundToLong
+
+/**
+ * Calculates exponential backoff durations for connection retries.
+ *
+ * This class is thread-safe.
+ */
+internal class RetryBackoffCalculator {
+  private val nextBackoffMs = AtomicLong(INITIAL_BACKOFF_MS)
+
+  /** Resets the backoff duration to the initial backoff value. */
+  fun reset() {
+    nextBackoffMs.set(INITIAL_BACKOFF_MS)
+  }
+
+  /**
+   * Returns the current backoff duration in milliseconds and calculates the next backoff duration
+   * by applying the growth multiplier, capped at the maximum backoff limit.
+   *
+   * @return The backoff duration in milliseconds for the current attempt.
+   */
+  fun next(): Long {
+    while (true) {
+      val current = nextBackoffMs.get()
+      val next = calculateNextBackoffMs(current)
+      if (nextBackoffMs.compareAndSet(current, next)) {
+        return current
+      }
+    }
+  }
+
+  private companion object {
+
+    const val INITIAL_BACKOFF_MS: Long = 1000L
+    const val MAX_BACKOFF_MS: Long = 600_000L
+    const val MULTIPLIER: Double = 1.75
+
+    fun calculateNextBackoffMs(currentBackoffMs: Long): Long =
+      (currentBackoffMs * MULTIPLIER).roundToLong().coerceAtMost(MAX_BACKOFF_MS)
+  }
+}

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignal.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignal.kt
@@ -45,7 +45,8 @@ import kotlinx.coroutines.flow.flow
  * is called multiple times before any coroutine awaits, only the **most recent** signal value is
  * retained, and all previous values are overwritten and lost. The first subsequent waiter (either
  * via [await] or [signals] collection) will consume this latest value and resume immediately, while
- * any further waiters will suspend.
+ * any further waiters will suspend. The pending signal value can also be discarded without being
+ * consumed by calling [clear].
  *
  * ### Prompt cancellation guarantee
  *
@@ -89,7 +90,7 @@ internal class ConflatedSignal<T : Any> {
 
   /**
    * Whether there is a pending signal from a call to [signal] that has not yet been consumed by a
-   * call to [await] or a collector of [signals].
+   * call to [await], collected by a [signals] collector, or discarded by a call to [clear].
    */
   val hasPendingSignal: Boolean
     get() = signalState.get() != null
@@ -110,9 +111,9 @@ internal class ConflatedSignal<T : Any> {
    * buffered as a pending signal for the next waiter.
    *
    * Because this signal is conflated, multiple sequential calls to [signal] without intervening
-   * consumption (via [await] or [signals]) will overwrite the pending value, retaining only the
-   * **most recent** [value]. Only one waiter will be resumed with this latest value, and all
-   * previously signaled values since the last consumption are lost.
+   * consumption (via [await] or [signals]) or clearance (via [clear]) will overwrite the pending
+   * value, retaining only the **most recent** [value]. Only one waiter will be resumed with this
+   * latest value, and all previously signaled values since the last consumption are lost.
    *
    * This method is non-blocking, thread-safe, and safe to call from any context (including outside
    * of coroutines).
@@ -127,8 +128,8 @@ internal class ConflatedSignal<T : Any> {
   /**
    * Suspends the calling coroutine until a signal value of type [T] is received.
    *
-   * If a signal value has already been emitted and not yet consumed, this method returns
-   * immediately, returning and consuming that value.
+   * If a signal value has already been emitted and not yet consumed (or cleared via [clear]), this
+   * method returns immediately, returning and consuming that value.
    *
    * @return the signal value of type [T] that was emitted.
    *
@@ -155,6 +156,17 @@ internal class ConflatedSignal<T : Any> {
         return current
       }
     }
+  }
+
+  /**
+   * Clears any pending signal, discarding its value.
+   *
+   * After calling this method, any subsequent call to [await] will suspend until a new signal is
+   * emitted via [signal].
+   */
+  fun clear() {
+    signalState.set(null)
+    channel.tryReceive()
   }
 
   override fun toString() = "ConflatedSignal(hasPendingSignal=$hasPendingSignal)"

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -39,6 +39,7 @@ import com.google.firebase.dataconnect.testutil.InProcessDataConnectGrpcStreamin
 import com.google.firebase.dataconnect.testutil.InProcessDataConnectGrpcStreamingServer.Event.StreamRequestReceived
 import com.google.firebase.dataconnect.testutil.LoggedInInternalAuthProvider
 import com.google.firebase.dataconnect.testutil.LoggedInMultiTokenAndUidAuthProvider
+import com.google.firebase.dataconnect.testutil.LoggedInMultiTokenInternalAuthProvider
 import com.google.firebase.dataconnect.testutil.NotLoggedInInternalAuthProvider
 import com.google.firebase.dataconnect.testutil.OperationNameVariablesPair
 import com.google.firebase.dataconnect.testutil.RandomSeedTestRule
@@ -70,6 +71,8 @@ import com.google.firebase.dataconnect.util.IdStringGenerator
 import com.google.firebase.dataconnect.util.ProtoUtil.encodeToStruct
 import com.google.firebase.dataconnect.util.SequencedReference
 import com.google.firebase.dataconnect.util.SequencedReference.Companion.nextSequenceNumber
+import com.google.firebase.dataconnect.util.coroutines.ConflatedSignal
+import com.google.firebase.dataconnect.util.coroutines.signal
 import com.google.firebase.internal.InternalTokenResult
 import google.firebase.dataconnect.proto.StreamRequest
 import google.firebase.dataconnect.proto.StreamRequest.RequestKindCase
@@ -80,6 +83,7 @@ import io.grpc.StatusException
 import io.grpc.StatusRuntimeException
 import io.grpc.stub.StreamObserver
 import io.kotest.assertions.asClue
+import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.print.print
 import io.kotest.assertions.withClue
 import io.kotest.common.DelicateKotest
@@ -114,6 +118,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import kotlin.random.Random
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.asExecutor
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.collect
@@ -1548,6 +1553,211 @@ class QuerySubscriptionImplUnitTest {
 
       clientCollector.cancelAndIgnoreRemainingEvents()
       serverCollector.cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun `new subscription resets backoff and retries immediately`() = runTest {
+    val server = runningInProcessDataConnectServer()
+    val dataConnect = dataConnect(server)
+    val subscription1 = querySubscription(dataConnect, operationName = "op1")
+    val subscription2 = querySubscription(dataConnect, operationName = "op2")
+
+    turbineScope {
+      val serverCollector = server.events.testIn(backgroundScope, name = "serverCollector")
+      val clientCollector1 = subscription1.flow.testIn(backgroundScope, name = "clientCollector1")
+
+      // Wait for subscription1 to connect and subscribe
+      val responseSender = serverCollector.awaitResponseSender()
+      serverCollector.awaitUntilSubscribeStreamRequest()
+
+      // Abort the connection to trigger backoff delay
+      val backoffSignal = ConflatedSignal<Unit>()
+      val backoffCallback: (Long) -> Unit = { backoffSignal.signal() }
+      DataConnectBidiConnectStream.setOnRetryBackoffForTesting(backoffCallback)
+      try {
+        responseSender.onError(Status.UNAVAILABLE.asException())
+        backoffSignal.await()
+      } finally {
+        DataConnectBidiConnectStream.unsetOnRetryBackoffForTesting(backoffCallback)
+      }
+
+      val time1 = @OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime
+
+      // Now, start collecting subscription2.
+      // This should reset the backoff and trigger an immediate retry.
+      val clientCollector2 = subscription2.flow.testIn(backgroundScope, name = "clientCollector2")
+
+      // Wait for the new connection and subscribe request
+      serverCollector.awaitResponseSender()
+      serverCollector.awaitUntilSubscribeStreamRequest()
+
+      val time2 = @OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime
+      (time2 - time1) shouldBe 0L
+
+      clientCollector2.cancelAndIgnoreRemainingEvents()
+      clientCollector1.cancelAndIgnoreRemainingEvents()
+      serverCollector.cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun `initial connection failure respects backoff delay`() = runTest {
+    val server = runningInProcessDataConnectServer()
+    val dataConnect = dataConnect(server)
+    val subscription = querySubscription(dataConnect)
+
+    turbineScope {
+      val serverCollector = server.events.testIn(backgroundScope, name = "serverCollector")
+      val clientCollector = subscription.flow.testIn(backgroundScope, name = "clientCollector")
+
+      // Wait for initial connection and subscribe
+      val responseSender = serverCollector.awaitResponseSender()
+      serverCollector.awaitUntilSubscribeStreamRequest()
+
+      // Abort the connection
+      responseSender.onError(Status.UNAVAILABLE.asException())
+
+      val time1 = @OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime
+
+      // Wait for the next connection attempt (the retry)
+      serverCollector.awaitResponseSender()
+      serverCollector.awaitUntilSubscribeStreamRequest()
+
+      val time2 = @OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime
+      (time2 - time1) shouldBe 1000L
+
+      clientCollector.cancelAndIgnoreRemainingEvents()
+      serverCollector.cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun `subsequent connection failures backoff exponentially`() = runTest {
+    val server = runningInProcessDataConnectServer()
+    val dataConnect = dataConnect(server)
+    val subscription = querySubscription(dataConnect)
+
+    val times = mutableListOf<Long>()
+    turbineScope {
+      val serverCollector = server.events.testIn(backgroundScope, name = "serverCollector")
+      val clientCollector = subscription.flow.testIn(backgroundScope, name = "clientCollector")
+
+      repeat(100) {
+        val responseSender = serverCollector.awaitResponseSender()
+        serverCollector.awaitUntilSubscribeStreamRequest()
+        times.add(@OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime)
+        responseSender.onError(Status.UNAVAILABLE.asException())
+      }
+
+      clientCollector.cancelAndIgnoreRemainingEvents()
+      serverCollector.cancelAndIgnoreRemainingEvents()
+    }
+
+    val waitTimes = times.zipWithNext { a, b -> b - a }
+    check(waitTimes.size == 99) { "internal error dy3gcskmvt: waitTimes.size=${waitTimes.size}" }
+    val expectedWaitTimes =
+      RetryBackoffCalculator().let { retryBackoffCalculator ->
+        List(waitTimes.size) { retryBackoffCalculator.next() }
+      }
+    waitTimes shouldContainExactly expectedWaitTimes
+  }
+
+  @Test
+  fun `healthy connection clears previous wakeup signals and resets backoff`() = runTest {
+    val server = runningInProcessDataConnectServer()
+    val dataConnect = dataConnect(server)
+    val subscription1 = querySubscription(dataConnect, operationName = "op1")
+    val subscription2 = querySubscription(dataConnect, operationName = "op2")
+    val testData = testDataArb().sample()
+
+    turbineScope {
+      val serverCollector = server.events.testIn(backgroundScope, name = "serverCollector")
+      val clientCollector1 = subscription1.flow.testIn(backgroundScope, name = "clientCollector1")
+
+      // 1st connection
+      val responseSender = serverCollector.awaitResponseSender()
+      val requestId = serverCollector.awaitUntilSubscribeStreamRequest().streamRequest.requestId
+
+      // Send a message to the client to make the connection healthy
+      responseSender.onNext(requestId, testData)
+      clientCollector1.awaitItem().result.shouldBeSuccess().data shouldBe testData
+
+      // Now start subscription2. This will emit a wakeup signal.
+      val clientCollector2 = subscription2.flow.testIn(backgroundScope, name = "clientCollector2")
+      serverCollector.awaitUntilSubscribeStreamRequest()
+
+      // Abort the connection
+      val time1 = @OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime
+      responseSender.onError(Status.UNAVAILABLE.asException())
+
+      // Wait for the retry. It should wait for 1000ms.
+      serverCollector.awaitResponseSender()
+      serverCollector.awaitUntilSubscribeStreamRequest()
+
+      val time2 = @OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime
+      (time2 - time1) shouldBe 1000L
+
+      clientCollector2.cancelAndIgnoreRemainingEvents()
+      clientCollector1.cancelAndIgnoreRemainingEvents()
+      serverCollector.cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun `RETRY_IMMEDIATELY resets the exponential backoff`() = runTest {
+    val server = runningInProcessDataConnectServer()
+    val dataConnect =
+      dataConnect(
+        serverLocalBindPort = server.port,
+        deferredAuthProvider =
+          run {
+            val authUid = Arb.dataConnect.authUidString().sample()
+            val tokens =
+              @OptIn(DelicateKotest::class)
+              Arb.dataConnect.authToken().distinct().let { arb -> List(5) { arb.sample() } }
+            val authProvider = LoggedInMultiTokenInternalAuthProvider(tokens.toList(), authUid)
+            ImmediateDeferred(authProvider)
+          }
+      )
+
+    val subscription = querySubscription(dataConnect)
+
+    turbineScope {
+      val serverCollector = server.events.testIn(backgroundScope, name = "serverCollector")
+      val clientCollector = subscription.flow.testIn(backgroundScope, name = "clientCollector")
+
+      // 1st connection: UNAVAILABLE -> triggers RETRY_AFTER_BACKOFF
+      val responseSender1 = serverCollector.awaitResponseSender()
+      serverCollector.awaitUntilSubscribeStreamRequest()
+      val time1 = @OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime
+      responseSender1.onError(Status.UNAVAILABLE.asException())
+
+      // 2nd connection: UNAUTHENTICATED -> triggers RETRY_IMMEDIATELY
+      val responseSender2 = serverCollector.awaitResponseSender()
+      serverCollector.awaitUntilSubscribeStreamRequest()
+      val time2 = @OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime
+      responseSender2.onError(Status.UNAUTHENTICATED.asException())
+
+      // 3rd connection: UNAVAILABLE -> triggers RETRY_AFTER_BACKOFF
+      val responseSender3 = serverCollector.awaitResponseSender()
+      serverCollector.awaitUntilSubscribeStreamRequest()
+      val time3 = @OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime
+      responseSender3.onError(Status.UNAVAILABLE.asException())
+
+      // 4th connection: UNAVAILABLE -> triggers RETRY_AFTER_BACKOFF
+      serverCollector.awaitResponseSender()
+      serverCollector.awaitUntilSubscribeStreamRequest()
+      val time4 = @OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime
+
+      clientCollector.cancelAndIgnoreRemainingEvents()
+      serverCollector.cancelAndIgnoreRemainingEvents()
+
+      assertSoftly {
+        withClue("time2") { time2 shouldBe time1 + 1000L }
+        withClue("time3") { time3 shouldBe time2 }
+        withClue("time4") { time4 shouldBe time3 + 1000L }
+      }
     }
   }
 

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RetryBackoffCalculatorUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RetryBackoffCalculatorUnitTest.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.dataconnect.core
+
+import com.google.firebase.dataconnect.testutil.SuspendingCountDownLatch
+import io.kotest.assertions.withClue
+import io.kotest.common.ExperimentalKotest
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.longs.shouldBeLessThanOrEqual
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.EdgeConfig
+import io.kotest.property.PropTestConfig
+import io.kotest.property.ShrinkingMode
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.list
+import io.kotest.property.checkAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class RetryBackoffCalculatorUnitTest {
+
+  @Test
+  fun `next() first call returns initial backoff`() {
+    val retryBackoffCalculator = RetryBackoffCalculator()
+    retryBackoffCalculator.next() shouldBe 1000L
+  }
+
+  @Test
+  fun `next() after reset() returns initial backoff`() = runTest {
+    checkAll(propTestConfig, Arb.int(0..100)) { nextCallCountBeforeReset ->
+      val retryBackoffCalculator = RetryBackoffCalculator()
+      repeat(nextCallCountBeforeReset) { retryBackoffCalculator.next() }
+      retryBackoffCalculator.reset()
+
+      retryBackoffCalculator.next() shouldBe 1000L
+    }
+  }
+
+  @Test
+  fun `next() returns correct values until reaching the max value`() {
+    val retryBackoffCalculator = RetryBackoffCalculator()
+    retryBackoffCalculator.next() shouldBe 1000L
+    retryBackoffCalculator.next() shouldBe 1750L
+    retryBackoffCalculator.next() shouldBe 3063L
+    retryBackoffCalculator.next() shouldBe 5360L
+    retryBackoffCalculator.next() shouldBe 9380L
+    retryBackoffCalculator.next() shouldBe 16415L
+    retryBackoffCalculator.next() shouldBe 28726L
+    retryBackoffCalculator.next() shouldBe 50271L
+    retryBackoffCalculator.next() shouldBe 87974L
+    retryBackoffCalculator.next() shouldBe 153955L
+    retryBackoffCalculator.next() shouldBe 269421L
+    retryBackoffCalculator.next() shouldBe 471487L
+    retryBackoffCalculator.next() shouldBe 600000L
+  }
+
+  @Test
+  fun `next() never returns greater than the max value`() {
+    val retryBackoffCalculator = RetryBackoffCalculator()
+    repeat(1000) {
+      withClue("iteration=$it") { retryBackoffCalculator.next() shouldBeLessThanOrEqual 600000L }
+    }
+  }
+
+  @Test
+  fun `next() returns the max value once it is reached`() {
+    val retryBackoffCalculator = RetryBackoffCalculator()
+    var lastValue = retryBackoffCalculator.next()
+    while (true) {
+      val value = retryBackoffCalculator.next()
+      if (value == lastValue || value >= 600000L) {
+        break
+      }
+      lastValue = value
+    }
+
+    repeat(1000) { withClue("iteration=$it") { retryBackoffCalculator.next() shouldBe 600000L } }
+  }
+
+  @Test
+  fun `reset() always resets`() = runTest {
+    checkAll(propTestConfig, Arb.list(Arb.int(0..20), 20..20)) { interveningNextCallCounts ->
+      val retryBackoffCalculator = RetryBackoffCalculator()
+      interveningNextCallCounts.forEach { count ->
+        if (count > 0) {
+          retryBackoffCalculator.next() shouldBe 1000L
+        }
+        repeat(count - 1) { retryBackoffCalculator.next() }
+        retryBackoffCalculator.reset()
+      }
+    }
+  }
+
+  @Test
+  fun `next() concurrent calls behave correctly`() = runTest {
+    val retryBackoffCalculator = RetryBackoffCalculator()
+    val latch = SuspendingCountDownLatch(50)
+
+    val jobs =
+      List(latch.count) {
+        backgroundScope.async(Dispatchers.Default) {
+          latch.countDown().await()
+          retryBackoffCalculator.next()
+        }
+      }
+
+    val results = jobs.awaitAll()
+    val expected =
+      RetryBackoffCalculator().let { testCalculator -> List(jobs.size) { testCalculator.next() } }
+    results shouldContainExactlyInAnyOrder expected
+  }
+}
+
+@OptIn(ExperimentalKotest::class)
+private val propTestConfig =
+  PropTestConfig(
+    iterations = 200,
+    edgeConfig = EdgeConfig(edgecasesGenerationProbability = 0.2),
+    shrinkingMode = ShrinkingMode.Off,
+  )

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignalUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/util/coroutines/ConflatedSignalUnitTest.kt
@@ -325,4 +325,35 @@ class ConflatedSignalUnitTest {
       cancelAndIgnoreRemainingEvents()
     }
   }
+
+  @Test
+  fun `clear() discards pending signal and causes subsequent await to suspend`() = runTest {
+    val signal = ConflatedSignal<Unit>()
+    signal.signal()
+    signal.clear()
+
+    val job = backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { signal.await() }
+    job.isCompleted shouldBe false
+  }
+
+  @Test
+  fun `clear() updates hasPendingSignal and pendingSignal`() {
+    val signal = ConflatedSignal<String>()
+    signal.signal("hello")
+    signal.clear()
+
+    signal.hasPendingSignal shouldBe false
+    signal.pendingSignal shouldBe null
+  }
+
+  @Test
+  fun `clear() clears pending signal in signals flow`() = runTest {
+    val signal = ConflatedSignal<String>()
+    signal.signal("hello")
+    signal.clear()
+
+    val job =
+      backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { signal.signals.collect {} }
+    job.isCompleted shouldBe false
+  }
 }


### PR DESCRIPTION
Introduce exponential backoff retry strategy for Data Connect realtime query subscriptions when they disconnect or fail to connect. When connection failures occur, the client backs off progressively before retrying, but resets the delay on successful messages, immediate retry triggers, or when a new subscription is registered.

### Highlights

* **Exponential Backoff Strategy**: Replaced the previous fixed 1-second retry delay with an exponential backoff calculator (`RetryBackoffCalculator`) capped at 10 minutes (600,000ms), using a multiplier of 1.75.
* **Subscription Wakeup**: Configured new query subscriptions to trigger an immediate retry and reset the backoff calculation, avoiding unnecessary waiting when a user actively requests new data.
* **ConflatedSignal Reset Capability**: Added a `clear()` method to `ConflatedSignal` to allow discarding pending signals, which is utilized to manage retry and wakeup events cleanly.
* **Comprehensive Testing**: Added unit tests validating retry intervals, backoff scaling, signal clearing, and the immediate wakeup behavior when new subscribers join.

<details>
<summary><b>Changelog</b></summary>

* **CHANGELOG.md**
  * Added a changelog entry noting that realtime query subscriptions now retry connecting using an exponential backoff strategy.
* **RetryBackoffCalculator.kt**
  * Introduced a new internal thread-safe class to calculate backoff retry delays starting at 1000ms with a 1.75 multiplier and capped at 600,000ms.
* **ConflatedSignal.kt**
  * Added a `clear()` method to discard any pending signals, causing subsequent calls to `await` to suspend until a new signal is emitted.
* **DataConnectBidiConnectStream.kt**
  * Replaced the hardcoded 1-second retry delay with the new `RetryBackoffCalculator` and a `ConflatedSignal` event to handle retries and immediate wakeup actions.
  * Resets the backoff upon new subscriptions or successful message streams.
  * Added testing callback registration methods to allow validation of backoff timings.
* **RetryBackoffCalculatorUnitTest.kt**
  * Added unit tests verifying `RetryBackoffCalculator` next value progression, max value ceiling, reset functionality, and thread-safety under concurrent access.
* **ConflatedSignalUnitTest.kt**
  * Added unit tests verifying the correctness of the new `clear()` method.
* **QuerySubscriptionImplUnitTest.kt**
  * Added unit tests verifying that new subscriptions reset backoff, that initial and subsequent connection failures follow the expected retry delays, and that healthy/immediate retries reset backoff state.

</details>