### PR TITLE
[DataConnect] Update documentation comments to replace latin abbr

### DIFF
--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/ProtoPrune.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/ProtoPrune.kt
@@ -101,7 +101,7 @@ internal object ProtoPrune {
    * given [predicate].
    *
    * This function performs a depth-first traversal of the [Struct]. For each [Struct] and
-   * [ListValue] value encountered that is the value of a field (i.e. not a direct element of a
+   * [ListValue] value encountered that is the value of a field (that is, not a direct element of a
    * [ListValue]), the [predicate] is invoked.
    *
    * If the [predicate] returns `true`:
@@ -144,7 +144,7 @@ internal object ProtoPrune {
    * the given [predicate].
    *
    * This function performs a depth-first traversal of the [ListValue]. For each [Struct] and
-   * [ListValue] value encountered that is the value of a field (i.e. not a direct element of a
+   * [ListValue] value encountered that is the value of a field (that is, not a direct element of a
    * [ListValue]), the [predicate] is invoked.
    *
    * If the [predicate] returns `true`:

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/AbstractEvenNumDigitsDistribution.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/AbstractEvenNumDigitsDistribution.kt
@@ -30,10 +30,10 @@ import io.kotest.property.arbitrary.choice
  *
  * @param T The numeric type (for example, [Int], [Long]).
  * @param R The range type (for example, [IntRange], [LongRange]).
- * @property maxDigitCount The maximum number of digits possible for the numeric type [T] (for example, 10
- * for [Int], 19 for [Long]).
- * @property fullRange The absolute minimum and maximum bounds for the numeric type [T] (for example,
- * `Int.MIN_VALUE..Int.MAX_VALUE`).
+ * @property maxDigitCount The maximum number of digits possible for the numeric type [T] (for
+ * example, 10 for [Int], 19 for [Long]).
+ * @property fullRange The absolute minimum and maximum bounds for the numeric type [T] (for
+ * example, `Int.MIN_VALUE..Int.MAX_VALUE`).
  */
 internal abstract class AbstractEvenNumDigitsDistribution<T : Comparable<T>, R : ClosedRange<T>>(
   private val maxDigitCount: Int,

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/AbstractEvenNumDigitsDistribution.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/property/arbitrary/AbstractEvenNumDigitsDistribution.kt
@@ -28,11 +28,11 @@ import io.kotest.property.arbitrary.choice
  * digit count, clamping them to the requested boundaries, and then using [Arb.choice] to first
  * uniformly pick a digit count, and then pick a value within that count.
  *
- * @param T The numeric type (e.g., [Int], [Long]).
- * @param R The range type (e.g., [IntRange], [LongRange]).
- * @property maxDigitCount The maximum number of digits possible for the numeric type [T] (e.g., 10
+ * @param T The numeric type (for example, [Int], [Long]).
+ * @param R The range type (for example, [IntRange], [LongRange]).
+ * @property maxDigitCount The maximum number of digits possible for the numeric type [T] (for example, 10
  * for [Int], 19 for [Long]).
- * @property fullRange The absolute minimum and maximum bounds for the numeric type [T] (e.g.,
+ * @property fullRange The absolute minimum and maximum bounds for the numeric type [T] (for example,
  * `Int.MIN_VALUE..Int.MAX_VALUE`).
  */
 internal abstract class AbstractEvenNumDigitsDistribution<T : Comparable<T>, R : ClosedRange<T>>(


### PR DESCRIPTION
Updated KDoc comments in ProtoPrune.kt and
AbstractEvenNumDigitsDistribution.kt to replace instances of "i.e." and "e.g." with more formal prose for better readability.

NO_RELEASE_CHANGE