### PR TITLE
[Config] Fix Javadoc style in Code.java

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/Code.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/Code.java
@@ -79,7 +79,7 @@ public @interface Code {
   /**
    * Client specified an invalid argument. Note that this differs from FAILED_PRECONDITION.
    * INVALID_ARGUMENT indicates arguments that are problematic regardless of the state of the system
-   * (e.g., an invalid field name).
+   * (for example, an invalid field name).
    */
   int INVALID_ARGUMENT = 3;
 


### PR DESCRIPTION
Updated the documentation for INVALID_ARGUMENT to use "for example" instead of the abbreviation "e.g." to align with style guidelines.

NO_RELEASE_CHANGE