### PR TITLE
Update testing to Gemini 3 models

### DIFF
--- a/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/AIModels.kt
+++ b/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/AIModels.kt
@@ -32,10 +32,10 @@ public class AIModels {
     public var app: FirebaseApp? = null
 
     public val vertexAIFlashModel: GenerativeModel by lazy {
-      getGenerativeModel(GenerativeBackend.vertexAI(), "gemini-2.5-flash")
+      getGenerativeModel(GenerativeBackend.vertexAI("global"), "gemini-3.5-flash")
     }
     public val vertexAIFlashLiteModel: GenerativeModel by lazy {
-      getGenerativeModel(GenerativeBackend.vertexAI(), "gemini-2.5-flash-lite")
+      getGenerativeModel(GenerativeBackend.vertexAI("global"), "gemini-3.1-flash-lite")
     }
     public val vertexAI3_5FlashModel: GenerativeModel by lazy {
       getGenerativeModel(GenerativeBackend.vertexAI("global"), "gemini-3.5-flash")
@@ -44,7 +44,7 @@ public class AIModels {
       getGenerativeModel(GenerativeBackend.googleAI(), "gemini-3.1-flash-lite")
     }
     public val googleAIFlashLiteModel: GenerativeModel by lazy {
-      getGenerativeModel(GenerativeBackend.googleAI(), "gemini-2.5-flash-lite")
+      getGenerativeModel(GenerativeBackend.googleAI(), "gemini-3.1-flash-lite")
     }
     public val googleAI3_5FlashModel: GenerativeModel by lazy {
       getGenerativeModel(GenerativeBackend.googleAI(), "gemini-3.5-flash")
@@ -70,7 +70,7 @@ public class AIModels {
 
     public fun getGenerativeModel(
       backend: GenerativeBackend,
-      modelName: String = "gemini-2.5-flash",
+      modelName: String = "gemini-3.5-flash",
       config: GenerationConfig? = null
     ): GenerativeModel {
       return FirebaseAI.getInstance(app(), backend)
@@ -78,11 +78,11 @@ public class AIModels {
     }
 
     public fun getGenerativeModels(
-      modelName: String = "gemini-2.5-flash",
+      modelName: String = "gemini-3.5-flash",
       config: GenerationConfig? = null
     ): List<GenerativeModel> {
       return listOf(
-        getGenerativeModel(GenerativeBackend.vertexAI(), modelName, config),
+        getGenerativeModel(GenerativeBackend.vertexAI("global"), modelName, config),
         getGenerativeModel(GenerativeBackend.googleAI(), modelName, config),
       )
     }

--- a/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/GroundingTests.kt
+++ b/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/GroundingTests.kt
@@ -62,9 +62,9 @@ class GroundingTests {
   @Test
   fun groundingTests_canSearchWeather(): Unit = runBlocking {
     val model =
-      FirebaseAI.getInstance(app(), GenerativeBackend.vertexAI())
+      FirebaseAI.getInstance(app(), GenerativeBackend.vertexAI("global"))
         .generativeModel(
-          modelName = "gemini-2.5-flash",
+          modelName = "gemini-3.5-flash",
           tools = listOf(Tool.googleSearch()),
         )
     val response = model.generateContent("What temperature is it today in Cancún?")
@@ -79,9 +79,9 @@ class GroundingTests {
     @JvmStatic
     fun setupModel(config: ToolConfig): GenerativeModel {
       val model =
-        FirebaseAI.getInstance(app(), GenerativeBackend.vertexAI())
+        FirebaseAI.getInstance(app(), GenerativeBackend.vertexAI("global"))
           .generativeModel(
-            modelName = "gemini-2.5-flash",
+            modelName = "gemini-3.5-flash",
             toolConfig = config,
             tools = listOf(Tool.googleMaps()),
           )

--- a/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/ToolTests.kt
+++ b/ai-logic/firebase-ai/src/androidTest/kotlin/com/google/firebase/ai/ToolTests.kt
@@ -300,9 +300,9 @@ class ToolTests {
     @JvmStatic
     fun setupModel(vararg functions: FunctionDeclaration): GenerativeModel {
       val model =
-        FirebaseAI.getInstance(app(), GenerativeBackend.vertexAI())
+        FirebaseAI.getInstance(app(), GenerativeBackend.vertexAI("global"))
           .generativeModel(
-            modelName = "gemini-2.5-flash",
+            modelName = "gemini-3.5-flash",
             toolConfig =
               ToolConfig(
                 functionCallingConfig = FunctionCallingConfig(FunctionCallingConfig.Mode.ANY)

--- a/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/DevAPIStreamingSnapshotTests.kt
+++ b/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/DevAPIStreamingSnapshotTests.kt
@@ -78,7 +78,7 @@ internal class DevAPIStreamingSnapshotTests {
           finishReason shouldBe FinishReason.STOP
           finishMessage shouldBe "Finished successfully"
         }
-        responseList.last().modelVersion shouldBe "gemini-3.1-flash-lite"
+        responseList.last().modelVersion shouldStartWith "gemini-"
       }
     }
 
@@ -94,7 +94,7 @@ internal class DevAPIStreamingSnapshotTests {
           finishReason shouldBe FinishReason.STOP
           content.parts.isEmpty() shouldBe false
         }
-        responseList.last().modelVersion shouldBe "gemini-3.1-flash-lite"
+        responseList.last().modelVersion shouldStartWith "gemini-"
       }
     }
 
@@ -112,7 +112,7 @@ internal class DevAPIStreamingSnapshotTests {
           finishReason shouldBe FinishReason.STOP
           content.parts.isEmpty() shouldBe false
         }
-        responseList.last().modelVersion shouldBe "gemini-2.5-flash-image-preview"
+        responseList.last().modelVersion shouldStartWith "gemini-"
       }
     }
 
@@ -132,7 +132,7 @@ internal class DevAPIStreamingSnapshotTests {
           it.thoughtSignature.shouldNotBeNull()
           it.thoughtSignature.shouldStartWith("CiIBVKhc7vB")
         }
-        responseList.last().modelVersion shouldBe "gemini-2.5-flash"
+        responseList.last().modelVersion shouldStartWith "gemini-"
       }
     }
 

--- a/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/DevAPIUnarySnapshotTests.kt
+++ b/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/DevAPIUnarySnapshotTests.kt
@@ -33,6 +33,7 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
 import io.ktor.http.HttpStatusCode
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.withTimeout
@@ -52,7 +53,7 @@ internal class DevAPIUnarySnapshotTests {
         response.candidates.shouldNotBeEmpty()
         response.candidates.first().finishReason shouldBe FinishReason.STOP
         response.candidates.first().content.parts.shouldNotBeEmpty()
-        response.modelVersion shouldBe "gemini-3.1-flash-lite"
+        response.modelVersion shouldStartWith "gemini-"
       }
     }
 
@@ -80,7 +81,7 @@ internal class DevAPIUnarySnapshotTests {
         response.candidates.shouldNotBeEmpty()
         response.candidates.first().finishReason shouldBe FinishReason.STOP
         response.candidates.first().content.parts.shouldNotBeEmpty()
-        response.modelVersion shouldBe "gemini-3.1-flash-lite"
+        response.modelVersion shouldStartWith "gemini-"
       }
     }
 
@@ -96,7 +97,7 @@ internal class DevAPIUnarySnapshotTests {
           it.startIndex.shouldNotBeNull()
           it.endIndex.shouldNotBeNull()
         }
-        response.modelVersion shouldBe "gemini-3.1-flash-lite"
+        response.modelVersion shouldStartWith "gemini-"
       }
     }
 
@@ -139,7 +140,7 @@ internal class DevAPIUnarySnapshotTests {
 
         groundingMetadata.groundingChunks.shouldNotBeEmpty()
         groundingMetadata.groundingChunks.forEach { it.web.shouldBeNull() }
-        response.modelVersion shouldBe "gemini-3.1-flash-lite"
+        response.modelVersion shouldStartWith "gemini-"
       }
     }
 

--- a/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/GenerativeModelBuilderTests.kt
+++ b/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/GenerativeModelBuilderTests.kt
@@ -19,6 +19,7 @@ package com.google.firebase.ai
 import android.content.Context
 import android.net.ConnectivityManager
 import com.google.firebase.FirebaseApp
+import com.google.firebase.ai.common.util.TEST_MODEL_NAME
 import com.google.firebase.ai.generativemodel.CloudGenerativeModelProvider
 import com.google.firebase.ai.generativemodel.FallbackGenerativeModelProvider
 import com.google.firebase.ai.type.GenerativeBackend
@@ -49,7 +50,7 @@ internal class GenerativeModelBuilderTests {
   fun `getModelProvider uses hybrid suffix in PREFER_ON_DEVICE mode`() {
     val builder =
       GenerativeModel.Builder(
-          modelName = "gemini-2.5-flash",
+          modelName = TEST_MODEL_NAME,
           apiKey = "apiKey",
           firebaseApp = firebaseApp,
           useLimitedUseAppCheckTokens = false,
@@ -73,7 +74,7 @@ internal class GenerativeModelBuilderTests {
   fun `getModelProvider uses hybrid suffix in PREFER_IN_CLOUD mode`() {
     val builder =
       GenerativeModel.Builder(
-          modelName = "gemini-2.5-flash",
+          modelName = TEST_MODEL_NAME,
           apiKey = "apiKey",
           firebaseApp = firebaseApp,
           useLimitedUseAppCheckTokens = false,
@@ -97,7 +98,7 @@ internal class GenerativeModelBuilderTests {
   fun `getModelProvider does NOT use hybrid suffix in ONLY_IN_CLOUD mode`() {
     val builder =
       GenerativeModel.Builder(
-          modelName = "gemini-2.5-flash",
+          modelName = TEST_MODEL_NAME,
           apiKey = "apiKey",
           firebaseApp = firebaseApp,
           useLimitedUseAppCheckTokens = false,

--- a/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/GenerativeModelTesting.kt
+++ b/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/GenerativeModelTesting.kt
@@ -23,6 +23,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.firebase.FirebaseApp
 import com.google.firebase.ai.common.APIController
 import com.google.firebase.ai.common.JSON
+import com.google.firebase.ai.common.util.TEST_MODEL_NAME
 import com.google.firebase.ai.common.util.doBlocking
 import com.google.firebase.ai.generativemodel.CloudGenerativeModelProvider
 import com.google.firebase.ai.type.Candidate
@@ -98,7 +99,7 @@ internal class GenerativeModelTesting {
     val apiController =
       APIController(
         "super_cool_test_key",
-        "gemini-2.5-flash",
+        TEST_MODEL_NAME,
         RequestOptions(
           timeout = 5.seconds,
           endpoint = "https://my.custom.endpoint",
@@ -116,7 +117,7 @@ internal class GenerativeModelTesting {
       GenerativeModel(
         actualModel =
           CloudGenerativeModelProvider(
-            "gemini-2.5-flash",
+            TEST_MODEL_NAME,
             systemInstruction = content { text("system instruction") },
             controller = apiController
           ),
@@ -215,7 +216,7 @@ internal class GenerativeModelTesting {
     val apiController =
       APIController(
         "super_cool_test_key",
-        "gemini-2.5-flash",
+        TEST_MODEL_NAME,
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -227,7 +228,7 @@ internal class GenerativeModelTesting {
 
     val generativeModel =
       GenerativeModel(
-        actualModel = CloudGenerativeModelProvider("gemini-2.5-flash", controller = apiController),
+        actualModel = CloudGenerativeModelProvider(TEST_MODEL_NAME, controller = apiController),
         requestOptions = RequestOptions()
       )
 
@@ -256,7 +257,7 @@ internal class GenerativeModelTesting {
     val apiController =
       APIController(
         "super_cool_test_key",
-        "gemini-2.5-flash",
+        TEST_MODEL_NAME,
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -271,7 +272,7 @@ internal class GenerativeModelTesting {
       GenerativeModel(
         actualModel =
           CloudGenerativeModelProvider(
-            "projects/PROJECTID/locations/INVALID_LOCATION/publishers/google/models/gemini-2.5-flash",
+            "projects/PROJECTID/locations/INVALID_LOCATION/publishers/google/models/$TEST_MODEL_NAME",
             controller = apiController
           ),
         requestOptions = RequestOptions()
@@ -299,7 +300,7 @@ internal class GenerativeModelTesting {
     val apiController =
       APIController(
         "super_cool_test_key",
-        "gemini-2.5-flash",
+        TEST_MODEL_NAME,
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -322,7 +323,7 @@ internal class GenerativeModelTesting {
       GenerativeModel(
         actualModel =
           CloudGenerativeModelProvider(
-            "gemini-2.5-flash",
+            TEST_MODEL_NAME,
             safetySettings = safetySettings,
             generativeBackend = GenerativeBackend.googleAI(),
             controller = apiController
@@ -349,7 +350,7 @@ internal class GenerativeModelTesting {
     val apiController =
       APIController(
         "super_cool_test_key",
-        "gemini-2.5-flash",
+        TEST_MODEL_NAME,
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -372,7 +373,7 @@ internal class GenerativeModelTesting {
       GenerativeModel(
         actualModel =
           CloudGenerativeModelProvider(
-            "gemini-2.5-flash",
+            TEST_MODEL_NAME,
             safetySettings = safetySettings,
             generativeBackend = GenerativeBackend.vertexAI("us-central1"),
             controller = apiController
@@ -417,7 +418,7 @@ internal class GenerativeModelTesting {
     val apiController =
       APIController(
         "super_cool_test_key",
-        "gemini-2.5-flash",
+        TEST_MODEL_NAME,
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -431,7 +432,7 @@ internal class GenerativeModelTesting {
       GenerativeModel(
         actualModel =
           CloudGenerativeModelProvider(
-            "gemini-2.5-flash",
+            TEST_MODEL_NAME,
             generationConfig =
               generationConfig {
                 thinkingConfig = thinkingConfig { thinkingLevel = ThinkingLevel.MEDIUM }
@@ -467,7 +468,7 @@ internal class GenerativeModelTesting {
     val apiController =
       APIController(
         "super_cool_test_key",
-        "gemini-2.5-flash",
+        TEST_MODEL_NAME,
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -481,7 +482,7 @@ internal class GenerativeModelTesting {
       GenerativeModel(
         actualModel =
           CloudGenerativeModelProvider(
-            "gemini-2.5-flash",
+            TEST_MODEL_NAME,
             generationConfig =
               generationConfig {
                 speechConfig = SpeechConfig(voice = Voice("Puck"), languageCode = "en-US")
@@ -521,7 +522,7 @@ internal class GenerativeModelTesting {
     val apiController =
       APIController(
         "super_cool_test_key",
-        "gemini-2.5-flash",
+        TEST_MODEL_NAME,
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -535,7 +536,7 @@ internal class GenerativeModelTesting {
       GenerativeModel(
         actualModel =
           CloudGenerativeModelProvider(
-            "gemini-2.5-flash",
+            TEST_MODEL_NAME,
             generationConfig =
               generationConfig {
                 speechConfig =
@@ -589,7 +590,7 @@ internal class GenerativeModelTesting {
     val apiController =
       APIController(
         "super_cool_test_key",
-        "gemini-2.5-flash",
+        TEST_MODEL_NAME,
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -600,7 +601,7 @@ internal class GenerativeModelTesting {
       )
 
     return GenerativeModel(
-      actualModel = CloudGenerativeModelProvider("gemini-2.5-flash", controller = apiController),
+      actualModel = CloudGenerativeModelProvider(TEST_MODEL_NAME, controller = apiController),
       requestOptions = RequestOptions()
     )
   }

--- a/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/common/APIControllerTests.kt
+++ b/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/common/APIControllerTests.kt
@@ -21,6 +21,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.firebase.FirebaseApp
 import com.google.firebase.ai.BuildConfig
+import com.google.firebase.ai.common.util.TEST_MODEL_NAME
 import com.google.firebase.ai.common.util.commonTest
 import com.google.firebase.ai.common.util.createResponses
 import com.google.firebase.ai.common.util.doBlocking
@@ -117,7 +118,7 @@ internal class RequestFormatTests {
     val controller =
       APIController(
         "super_cool_test_key",
-        "gemini-pro-2.5",
+        TEST_MODEL_NAME,
         RequestOptions(),
         mockEngine,
         "genai-android/${BuildConfig.VERSION_NAME}",
@@ -147,7 +148,7 @@ internal class RequestFormatTests {
     val controller =
       APIController(
         "super_cool_test_key",
-        "gemini-pro-2.5",
+        TEST_MODEL_NAME,
         RequestOptions(
           timeout = 5.seconds,
           endpoint = "https://my.custom.endpoint",
@@ -181,7 +182,7 @@ internal class RequestFormatTests {
     val controller =
       APIController(
         "super_cool_test_key",
-        "gemini-pro-2.5",
+        TEST_MODEL_NAME,
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -208,7 +209,7 @@ internal class RequestFormatTests {
     val controller =
       APIController(
         "super_cool_test_key",
-        "gemini-pro-2.5",
+        TEST_MODEL_NAME,
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -236,7 +237,7 @@ internal class RequestFormatTests {
     val controller =
       APIController(
         "super_cool_test_key",
-        "gemini-pro-2.5",
+        TEST_MODEL_NAME,
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -283,7 +284,7 @@ internal class RequestFormatTests {
     val controller =
       APIController(
         "super_cool_test_key",
-        "gemini-pro-2.5",
+        TEST_MODEL_NAME,
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -322,7 +323,7 @@ internal class RequestFormatTests {
     val controller =
       APIController(
         "super_cool_test_key",
-        "gemini-pro-2.5",
+        TEST_MODEL_NAME,
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -369,7 +370,7 @@ internal class RequestFormatTests {
     val controller =
       APIController(
         "super_cool_test_key",
-        "gemini-pro-2.5",
+        TEST_MODEL_NAME,
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -406,7 +407,7 @@ internal class RequestFormatTests {
     val controller =
       APIController(
         "super_cool_test_key",
-        "gemini-pro-2.5",
+        TEST_MODEL_NAME,
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -442,7 +443,7 @@ internal class RequestFormatTests {
     val controller =
       APIController(
         "super_cool_test_key",
-        "gemini-pro-2.5",
+        TEST_MODEL_NAME,
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -468,7 +469,7 @@ internal class RequestFormatTests {
     val controller =
       APIController(
         "super_cool_test_key",
-        "gemini-pro-2.5",
+        TEST_MODEL_NAME,
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -507,7 +508,7 @@ internal class RequestFormatTests {
     val controller =
       APIController(
         "super_cool_test_key",
-        "gemini-pro-2.5",
+        TEST_MODEL_NAME,
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -589,9 +590,9 @@ internal class ModelNamingTests(private val modelName: String, private val actua
     @ParameterizedRobolectricTestRunner.Parameters
     fun data() =
       listOf(
-        arrayOf("gemini-pro", "models/gemini-pro"),
-        arrayOf("x/gemini-pro", "x/gemini-pro"),
-        arrayOf("models/gemini-pro", "models/gemini-pro"),
+        arrayOf(TEST_MODEL_NAME, "models/$TEST_MODEL_NAME"),
+        arrayOf("x/$TEST_MODEL_NAME", "x/$TEST_MODEL_NAME"),
+        arrayOf("models/$TEST_MODEL_NAME", "models/$TEST_MODEL_NAME"),
         arrayOf("/modelname", "/modelname"),
         arrayOf("modifiedNaming/mymodel", "modifiedNaming/mymodel"),
       )

--- a/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/common/util/tests.kt
+++ b/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/common/util/tests.kt
@@ -41,6 +41,7 @@ import org.mockito.Mockito
 private val TEST_CLIENT_ID = "genai-android/test"
 private val TEST_APP_ID = "1:android:12345"
 private val TEST_VERSION = 1
+internal const val TEST_MODEL_NAME = "gemini-3.5-flash"
 
 internal fun prepareStreamingResponse(
   response: List<GenerateContentResponse.Internal>
@@ -105,7 +106,7 @@ internal fun commonTest(
   val apiController =
     APIController(
       "super_cool_test_key",
-      "gemini-pro",
+      TEST_MODEL_NAME,
       requestOptions,
       MockEngine {
         respond(channel, status, headersOf(HttpHeaders.ContentType, "application/json"))

--- a/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/util/tests.kt
+++ b/ai-logic/firebase-ai/src/test/java/com/google/firebase/ai/util/tests.kt
@@ -24,6 +24,7 @@ import com.google.firebase.FirebaseApp
 import com.google.firebase.ai.GenerativeModel
 import com.google.firebase.ai.ImagenModel
 import com.google.firebase.ai.common.APIController
+import com.google.firebase.ai.common.util.TEST_MODEL_NAME
 import com.google.firebase.ai.generativemodel.CloudGenerativeModelProvider
 import com.google.firebase.ai.type.GenerativeBackend
 import com.google.firebase.ai.type.PublicPreviewAPI
@@ -122,7 +123,7 @@ internal fun commonTest(
   val apiController =
     APIController(
       "super_cool_test_key",
-      "gemini-pro",
+      TEST_MODEL_NAME,
       requestOptions,
       MockEngine {
         requestHandler(it)
@@ -191,7 +192,7 @@ internal fun commonMultiTurnTest(
   val apiController =
     APIController(
       "super_cool_test_key",
-      "gemini-pro",
+      TEST_MODEL_NAME,
       requestOptions,
       MockEngine {
         requestHandler(it)


### PR DESCRIPTION
Updates AI Logic testing to use Gemini 3 models. Additionally migrates to constants and removes testing against verifying specific model names to futureproof for further edits.