### PR TITLE
dataconnect(chore): migrate to SQL_CONNECT_PREVIEW when running the data connect cli

### DIFF
--- a/firebase-dataconnect/demo/build.gradle.kts
+++ b/firebase-dataconnect/demo/build.gradle.kts
@@ -241,7 +241,12 @@ abstract class DataConnectGenerateSourcesTask : DefaultTask() {
         execSpec.environment("DATACONNECT_EMULATOR_BINARY_PATH", it.absolutePath)
       }
 
-      dataConnectPreviewFlags?.let { execSpec.environment("DATA_CONNECT_PREVIEW", it) }
+      dataConnectPreviewFlags?.let { 
+        // Set both environment variables to support both old and new emulator versions.
+        // The variable was renamed to SQL_CONNECT_PREVIEW in cl/944678266 (July 2026).
+        execSpec.environment("DATA_CONNECT_PREVIEW", it)
+        execSpec.environment("SQL_CONNECT_PREVIEW", it)
+      }
     }
   }
 }

--- a/firebase-dataconnect/demo/build.gradle.kts
+++ b/firebase-dataconnect/demo/build.gradle.kts
@@ -241,7 +241,7 @@ abstract class DataConnectGenerateSourcesTask : DefaultTask() {
         execSpec.environment("DATACONNECT_EMULATOR_BINARY_PATH", it.absolutePath)
       }
 
-      dataConnectPreviewFlags?.let { 
+      dataConnectPreviewFlags?.let {
         // Set both environment variables to support both old and new emulator versions.
         // The variable was renamed to SQL_CONNECT_PREVIEW in cl/944678266 (July 2026).
         execSpec.environment("DATA_CONNECT_PREVIEW", it)

--- a/firebase-dataconnect/emulator/emulator.zsh
+++ b/firebase-dataconnect/emulator/emulator.zsh
@@ -28,6 +28,7 @@ main() {
   log "FIREBASE_DATACONNECT_POSTGRESQL_STRING=${FIREBASE_DATACONNECT_POSTGRESQL_STRING}"
   log "DATACONNECT_EMULATOR_BINARY_PATH=${DATACONNECT_EMULATOR_BINARY_PATH}"
   log "DATA_CONNECT_PREVIEW=${DATA_CONNECT_PREVIEW}"
+  log "SQL_CONNECT_PREVIEW=${SQL_CONNECT_PREVIEW}"
   run_command firebase --debug emulators:start --only auth,dataconnect
 }
 
@@ -71,7 +72,11 @@ parse_args() {
   fi
 
   export FIREBASE_DATACONNECT_POSTGRESQL_STRING="${postgresql_string}"
+
+  # Set both environment variables to support both old and new emulator versions.
+  # The variable was renamed to SQL_CONNECT_PREVIEW in cl/944678266 (July 2026).
   export DATA_CONNECT_PREVIEW="${preview_flags}"
+  export SQL_CONNECT_PREVIEW="${preview_flags}"
 
   if [[ ${wipe_and_restart_postgres_pod} == "1" ]] ; then
     run_command podman compose down -v

--- a/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableLauncher.kt
+++ b/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableLauncher.kt
@@ -94,7 +94,11 @@ fun Task.runDataConnectExecutable(
         config.schemaExtensionsOutputEnabled?.let { args("-enable_output_schema_extensions=${it}") }
 
         if (previewFlags.isNotEmpty()) {
-          environment("DATA_CONNECT_PREVIEW", previewFlags.joinToString(","))
+          // Set both environment variables to support both old and new emulator versions.
+          // The variable was renamed to SQL_CONNECT_PREVIEW in cl/944678266 (July 2026).
+          val previewFlagsStr = previewFlags.joinToString(",")
+          environment("DATA_CONNECT_PREVIEW", previewFlagsStr)
+          environment("SQL_CONNECT_PREVIEW", previewFlagsStr)
         }
       }
     }


### PR DESCRIPTION
This PR configures the Firebase Data Connect build tooling, Gradle plugin, and emulator scripts to support a renamed environment variable for preview features. It sets both the old `DATA_CONNECT_PREVIEW` and the new `SQL_CONNECT_PREVIEW` environment variables to maintain compatibility with both old and new emulator versions. The variable was renamed to SQL_CONNECT_PREVIEW in cl/944678266 (July 2026).

### Highlights

* **Support renamed environment variable**: Configures the Gradle demo, emulator helper script, and Gradle plugin to set the `SQL_CONNECT_PREVIEW` environment variable alongside the deprecated `DATA_CONNECT_PREVIEW` when launching the Data Connect emulator.

<details>

<summary><b>Changelog</b></summary>

* **build.gradle.kts**
  * Updated the source generation task to set `SQL_CONNECT_PREVIEW` when preview flags are provided.
* **emulator.zsh**
  * Log and export `SQL_CONNECT_PREVIEW` in addition to `DATA_CONNECT_PREVIEW`.
* **DataConnectExecutableLauncher.kt**
  * Updated `runDataConnectExecutable` to set both `DATA_CONNECT_PREVIEW` and `SQL_CONNECT_PREVIEW` environment variables when calling the CLI.

</details>
