### PR TITLE
[Infra] Upgrade Gradle plugin dependencies and modernize codebase

### DIFF
--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -46,14 +46,14 @@ spotless {
 // https://maven.google.com/web/index.html?q=perf-plugin#com.google.firebase:perf-plugin
 // The System property allows us to integrate with an unreleased version from https://bityl.co/3oYt.
 // Refer go/fireperf-plugin-test-on-head for more details.
-val perfPluginVersion = System.getenv("FIREBASE_PERF_PLUGIN_VERSION") ?: "1.4.1"
+val perfPluginVersion = System.getenv("FIREBASE_PERF_PLUGIN_VERSION") ?: "2.0.2"
 
 dependencies {
   // Firebase performance plugin, it should be added here because of how gradle dependency
   // resolution works, otherwise it breaks Fireperf Test Apps.
   // See https://github.com/gradle/gradle/issues/12286
   implementation("com.google.firebase:perf-plugin:$perfPluginVersion")
-  implementation(kotlin("gradle-plugin", "1.8.22"))
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.21")
   implementation(libs.org.json)
   implementation(libs.bundles.maven.resolver)
 

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/BaseFirebaseLibraryPlugin.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/BaseFirebaseLibraryPlugin.kt
@@ -16,7 +16,7 @@
 
 package com.google.firebase.gradle.plugins
 
-import com.android.build.gradle.LibraryExtension
+import com.android.build.api.dsl.LibraryExtension
 import com.google.firebase.gradle.plugins.ci.Coverage
 import com.google.firebase.gradle.plugins.services.GMavenService
 import java.io.File
@@ -316,7 +316,7 @@ fun FirebaseLibraryExtension.resolveProjectLevelDependencies() =
     .allDependencies
     .mapNotNull { it as? ProjectDependency }
     .map {
-      project.project(it.dependencyProject.path).extensions.findByType<FirebaseLibraryExtension>()
+      project.project(it.path).extensions.findByType<FirebaseLibraryExtension>()
         ?: throw RuntimeException(
           "Project level dependencies must have the firebaseLibrary plugin. The following dependency does not: ${it.artifactName}"
         )

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/BaseFirebaseLibraryPlugin.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/BaseFirebaseLibraryPlugin.kt
@@ -316,7 +316,7 @@ fun FirebaseLibraryExtension.resolveProjectLevelDependencies() =
     .allDependencies
     .mapNotNull { it as? ProjectDependency }
     .map {
-      project.project(it.path).extensions.findByType<FirebaseLibraryExtension>()
+      project.project(it.dependencyProject.path).extensions.findByType<FirebaseLibraryExtension>()
         ?: throw RuntimeException(
           "Project level dependencies must have the firebaseLibrary plugin. The following dependency does not: ${it.artifactName}"
         )

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/GradleExtensions.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/GradleExtensions.kt
@@ -168,7 +168,8 @@ inline fun <reified T : WorkAction<C>, C : WorkParameters> WorkQueue.submit(
  * Attribute.of(name, T::class.java)
  * ```
  */
-inline fun <reified T> attributeFrom(name: String) = Attribute.of(name, T::class.java)
+inline fun <reified T : Any> attributeFrom(name: String): Attribute<T> =
+  Attribute.of(name, T::class.java)
 
 /**
  * Sets an attribute value.

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/ProjectExtensions.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/ProjectExtensions.kt
@@ -95,7 +95,7 @@ val Project.isKTXLibary: Boolean
  *
  * @param property the name of the property to look for
  */
-inline fun <reified T> Project.provideProperty(property: String): Provider<T> = provider {
+inline fun <reified T : Any> Project.provideProperty(property: String): Provider<T> = provider {
   val maybeProperty = findProperty(property)
 
   // using when instead of an if statement so we can expand as needed

--- a/plugins/src/test/kotlin/com/google/firebase/gradle/plugins/FirebaseTestController.kt
+++ b/plugins/src/test/kotlin/com/google/firebase/gradle/plugins/FirebaseTestController.kt
@@ -161,7 +161,7 @@ class FirebaseTestController(val rootDirectory: TemporaryFolder) {
         buildscript {
             repositories {
                 google()
-                jcenter()
+                mavenCentral()
                 maven {
                     url 'https://storage.googleapis.com/android-ci/mvn/'
                     metadataSources {
@@ -177,7 +177,7 @@ class FirebaseTestController(val rootDirectory: TemporaryFolder) {
         configure(subprojects) {
             repositories {
                 google()
-                jcenter()
+                mavenCentral()
                 maven {
                     url 'https://storage.googleapis.com/android-ci/mvn/'
                     metadataSources {

--- a/plugins/src/test/kotlin/com/google/firebase/gradle/plugins/LicenseResolverPluginTests.kt
+++ b/plugins/src/test/kotlin/com/google/firebase/gradle/plugins/LicenseResolverPluginTests.kt
@@ -132,7 +132,7 @@ class LicenseResolverPluginTests {
         buildscript {
             repositories {
                 google()
-                jcenter()
+                mavenCentral()
             }
         }
 
@@ -147,7 +147,7 @@ class LicenseResolverPluginTests {
         }
         
         repositories {
-            jcenter()
+            mavenCentral()
             google()
         }
         dependencies {

--- a/plugins/src/test/kotlin/com/google/firebase/gradle/plugins/VendorTests.kt
+++ b/plugins/src/test/kotlin/com/google/firebase/gradle/plugins/VendorTests.kt
@@ -160,7 +160,7 @@ class VendorPluginTests {
             buildscript {
                 repositories {
                     google()
-                    jcenter()
+                    mavenCentral()
                 }
             }
             plugins {
@@ -169,7 +169,7 @@ class VendorPluginTests {
             }
             repositories {
                 google()
-                jcenter()
+                mavenCentral()
             }
 
             android {
@@ -177,7 +177,7 @@ class VendorPluginTests {
                     buildConfig true
                 }
               namespace 'com.example'
-              compileSdkVersion 26
+              compileSdkVersion 34
             }
             
             dependencies {
@@ -201,6 +201,7 @@ class VendorPluginTests {
       .withArguments("assemble")
       .withProjectDir(testProjectDir.root)
       .withPluginClasspath()
+      .forwardOutput()
       .build()
 
     val aarFile = File(testProjectDir.root, "build/outputs/aar/testlib-release.aar")

--- a/plugins/src/test/kotlin/com/google/firebase/gradle/plugins/publishing.kt
+++ b/plugins/src/test/kotlin/com/google/firebase/gradle/plugins/publishing.kt
@@ -112,7 +112,7 @@ data class Pom(
           "groupId" -> groupId = child.textContent.trim()
           "artifactId" -> artifactId = child.textContent.trim()
           "version" -> version = child.textContent.trim()
-          "packaging" -> type = Type.valueOf(child.textContent.trim().toUpperCase())
+          "packaging" -> type = Type.valueOf(child.textContent.trim().uppercase())
           "licenses" -> license = parseLicense(child.getElementsByTagName("license"))
           "dependencies" -> deps = parseDeps(child.getElementsByTagName("dependency"))
         }
@@ -163,7 +163,7 @@ data class Pom(
           "groupId" -> groupId = child.textContent.trim()
           "artifactId" -> artifactId = child.textContent.trim()
           "version" -> version = child.textContent.trim()
-          "type" -> type = Type.valueOf(child.textContent.trim().toUpperCase())
+          "type" -> type = Type.valueOf(child.textContent.trim().uppercase())
           "scope" -> scope = child.textContent.trim()
         }
       }
@@ -203,7 +203,7 @@ data class Pom(
  *
  * Uses the [LibraryType.format] to make the conversion.
  */
-fun LibraryType.toArtifactType() = Type.valueOf(format.toUpperCase())
+fun LibraryType.toArtifactType() = Type.valueOf(format.uppercase())
 
 /**
  * Converts a [Project] to an [Artifact].


### PR DESCRIPTION
- Bump Firebase Performance plugin to 2.0.2 and Kotlin Gradle plugin to 2.0.21.
- Replace deprecated `jcenter()` repository references with `mavenCentral()` in tests.
- Update internal Kotlin code to use `uppercase()` instead of `toUpperCase()`.
- Refactor type safety for attributes and properties by adding `: Any` bounds.
- Update Android API references and testing configurations for compatibility.