### PR TITLE
dataconnect(test): Use LongAdder to count concurrent invocations instead of AtomicInteger

### DIFF
--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectAuthUnitTest.kt
@@ -59,7 +59,7 @@ import io.kotest.matchers.collections.shouldBeUnique
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.ints.shouldBeLessThan
-import io.kotest.matchers.ints.shouldBeLessThanOrEqual
+import io.kotest.matchers.longs.shouldBeLessThanOrEqual
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -88,6 +88,7 @@ import io.mockk.slot
 import io.mockk.verify
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.LongAdder
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -492,10 +493,10 @@ class DataConnectAuthUnitTest {
     dataConnectAuth.initialize()
     advanceUntilIdle()
     val tokens = CopyOnWriteArrayList<String>()
-    val getAccessTokenCallCount = AtomicInteger(0)
+    val getAccessTokenCallCount = LongAdder()
     coEvery { mockInternalAuthProvider.getAccessToken(any()) } answers
       {
-        getAccessTokenCallCount.incrementAndGet()
+        getAccessTokenCallCount.add(1)
         taskForToken(accessTokenGenerator.next().also { tokens.add(it) })
       }
 
@@ -512,7 +513,7 @@ class DataConnectAuthUnitTest {
     actualTokens.forEachIndexed { index, token ->
       withClue("actualTokens[$index]") { tokens shouldContain token }
     }
-    withClue("getAccessTokenCallCount") { getAccessTokenCallCount.get() shouldBeLessThanOrEqual 80 }
+    withClue("getAccessTokenCallCount") { getAccessTokenCallCount.sum() shouldBeLessThanOrEqual 80 }
   }
 
   @Test

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
@@ -100,8 +100,8 @@ import io.mockk.every
 import io.mockk.mockk
 import java.io.File
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.LongAdder
 import kotlin.random.Random
 import kotlin.time.Duration
 import kotlinx.coroutines.cancelAndJoin
@@ -857,8 +857,8 @@ class DataConnectGrpcRPCsUnitTest {
 
     val port = grpcServer.port
 
-    val executeQueryInvocationCount: Int
-      get() = connectorServiceImpl.executeQueryInvocationCount.get()
+    val executeQueryInvocationCount: Long
+      get() = connectorServiceImpl.executeQueryInvocationCount.sum()
 
     var nextResponse: ExecuteQueryResponse
       get() = connectorServiceImpl.nextResponse.get()
@@ -886,14 +886,14 @@ class DataConnectGrpcRPCsUnitTest {
 
   private class ConnectorServiceImpl : ConnectorServiceGrpc.ConnectorServiceImplBase() {
 
-    val executeQueryInvocationCount = AtomicInteger(0)
+    val executeQueryInvocationCount = LongAdder()
     val nextResponse = AtomicReference(ExecuteQueryResponse.getDefaultInstance())
 
     override fun executeQuery(
       request: ExecuteQueryRequest,
       responseObserver: StreamObserver<ExecuteQueryResponse>,
     ) {
-      executeQueryInvocationCount.incrementAndGet()
+      executeQueryInvocationCount.add(1)
       responseObserver.onNext(nextResponse.get())
       responseObserver.onCompleted()
     }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/util/ObjectLifecycleManagerUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/util/ObjectLifecycleManagerUnitTest.kt
@@ -35,8 +35,8 @@ import java.util.concurrent.Callable
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CyclicBarrier
 import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.LongAdder
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CancellationException
@@ -70,7 +70,7 @@ class ObjectLifecycleManagerUnitTest {
 
       objectLifecycleManager.close()
 
-      objectLifecycleManager.createCallCount.get() shouldBe 0
+      objectLifecycleManager.createCallCount.sum() shouldBe 0
     }
 
   @Test
@@ -100,7 +100,7 @@ class ObjectLifecycleManagerUnitTest {
 
       repeat(100) { objectLifecycleManager.close() }
 
-      objectLifecycleManager.createCallCount.get() shouldBe 0
+      objectLifecycleManager.createCallCount.sum() shouldBe 0
       objectLifecycleManager.initializeCalls.shouldBeEmpty()
       objectLifecycleManager.destroyCalls.shouldBeEmpty()
     }
@@ -120,7 +120,7 @@ class ObjectLifecycleManagerUnitTest {
 
       jobs.joinAll()
 
-      objectLifecycleManager.createCallCount.get() shouldBe 0
+      objectLifecycleManager.createCallCount.sum() shouldBe 0
       objectLifecycleManager.initializeCalls.shouldBeEmpty()
       objectLifecycleManager.destroyCalls.shouldBeEmpty()
     }
@@ -145,7 +145,7 @@ class ObjectLifecycleManagerUnitTest {
 
       objectLifecycleManager.open()
 
-      objectLifecycleManager.createCallCount.get() shouldBe 1
+      objectLifecycleManager.createCallCount.sum() shouldBe 1
     }
 
   @Test
@@ -197,7 +197,7 @@ class ObjectLifecycleManagerUnitTest {
 
       jobs.joinAll()
 
-      objectLifecycleManager.createCallCount.get() shouldBe 1
+      objectLifecycleManager.createCallCount.sum() shouldBe 1
       objectLifecycleManager.initializeCalls shouldHaveSize 1
       objectLifecycleManager.initializeCalls.single() shouldBeSameInstanceAs testObject
     }
@@ -588,12 +588,12 @@ class ObjectLifecycleManagerUnitTest {
     logger: Logger = newMockLogger(),
   ) : ObjectLifecycleManager<TestType>(coroutineDispatcher, logger) {
 
-    val createCallCount = AtomicInteger(0)
+    val createCallCount = LongAdder()
     val initializeCalls = CopyOnWriteArrayList<TestType>()
     val destroyCalls = CopyOnWriteArrayList<TestType>()
 
     override fun create(): TestType {
-      createCallCount.incrementAndGet()
+      createCallCount.add(1)
       return createImpl()
     }
 


### PR DESCRIPTION
Switch concurrent invocation counting in data connect unit tests from AtomicInteger to java.util.concurrent.atomic.LongAdder. Under heavily multithreaded test suites, traditional atomic counters create artificial thread-synchronization points and severe hardware-level performance bottlenecks. LongAdder completely eliminates these issues by decoupling parallel increment operations from global read coordination.

Since these tests run strictly on the host desktop JVM (and are never executed on an Android target device), we can safely bypass Android's minSdkVersion (API 23) constraints and leverage the modern JVM's standard library concurrent utilities.

Both AtomicInteger and VarHandle (even when configured with relaxed memory ordering like `VALUE.getAndAdd(this, 1)`) target a single memory address. Under multi-threaded stress:
- Each thread must execute a Read-Modify-Write (RMW) instruction (typically an LL/SC loop or `lock xadd` on x86).
- When Thread A successfully increments the counter, the CPU's cache coherence protocol (e.g., MESI) immediately invalidates the L1/L2 cache line containing that memory address across all other CPU cores.
- This triggers a storm of cache misses ("cache-line bouncing") forcing cores to serialize accesses and fetch the updated value from L3 cache or main memory.
- Consequently, the counter becomes a global synchronization bottleneck, introducing artificial latency and masking the true concurrent performance of the method under test.

LongAdder (which extends Striped64) mitigates this by using a thread-local probed hashing mechanism. Threads are mapped to a dynamically sized internal array of isolated "Cell" structures. Increments are applied locally to these separate cells, preventing CPU cores from repeatedly invalidating each other's caches.

By specification, LongAdder's `increment()` method returns `void` and completely lacks compound operations like `compareAndSet` or `incrementAndGet`.
- Because there is no immediate feedback loop of the current state back to the invoking thread, no "happens-before" memory visibility relationship needs to be established between the incrementing threads.
- In contrast, AtomicInteger forces threads to synchronize state on every modification. Even a relaxed VarHandle requires thread-level coordination over a single reference point.
- LongAdder explicitly isolates the write-path (extremely cheap thread-local writes) from the read-path (calculating the sum, which only occurs once at the end of the test via `.sum()`).

| Metric / Detail      | AtomicInteger               | VarHandle (Relaxed)         | LongAdder                   |
| -------------------- | --------------------------- | --------------------------- | --------------------------- |
| **Throughput**       | Low (highly throttled)      | Medium (contention bound)   | Extremely High (scales O(N))|
| **Contention Risk**  | Critical bottleneck         | High bottleneck             | Virtually Zero              |
| **Write Barrier**    | Full Volatile (Seq_Cst)     | Relaxed (Opaque)            | None (Thread-Local CAS)     |
| **Cache Behavior**   | Constant cache invalidations| Constant cache invalidations| Core-isolated L1/L2 hits    |

Although our production `minSdkVersion` is set to API 23 (which lacks `VarHandle` and limits native JDK 8+ modern concurrency optimization), our unit tests execute exclusively within a desktop host JVM environment (OpenJDK). Restricting the use of LongAdder to the `test` source set ensures we utilize the host machine's full parallel hardware potential without introducing incompatible APIs into the Android production binary.