### PR TITLE
Deprecate Firebase ML Model Downloader

### DIFF
--- a/firebase-ml-modeldownloader/CHANGELOG.md
+++ b/firebase-ml-modeldownloader/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+- [deprecated] Firebase ML is deprecated and will be shut down on June 15, 2027.
+  To host custom models, you must migrate to another solution. You can use Cloud Storage for Firebase 
+  as an alternative for hosting custom models. For more info, see
+  https://firebase.google.com/docs/ml/migrate-to-cloud-storage.
+
 # 26.0.2
 
 - [changed] Bumped internal dependencies.

--- a/firebase-ml-modeldownloader/CHANGELOG.md
+++ b/firebase-ml-modeldownloader/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 - [deprecated] Firebase ML is deprecated and will be shut down on June 15, 2027.
-  To host custom models, you must migrate to another solution. You can use Cloud Storage for Firebase 
+  To host custom models, you must migrate to another solution. You can use Cloud Storage for Firebase
   as an alternative for hosting custom models. For more info, see
   https://firebase.google.com/docs/ml/migrate-to-cloud-storage.
 

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/CustomModel.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/CustomModel.java
@@ -29,7 +29,13 @@ import java.io.File;
  * Stores information about custom models that are being downloaded or are already downloaded on a
  * device. In the case where an update is available, after the updated model file is fully
  * downloaded, the original model file will be removed once it is safe to do so.
+ *
+ * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+ *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as an
+ *     alternative for hosting custom models. For more info, see
+ *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
  */
+@Deprecated
 public class CustomModel {
   private final ModelFileDownloadService fileDownloadService;
   private final String name;
@@ -105,8 +111,13 @@ public class CustomModel {
    * Retrieves the model name and identifier.
    *
    * @return The name of the model.
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as an
+   *     alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
   @NonNull
+  @Deprecated
   public String getName() {
     return name;
   }
@@ -118,8 +129,13 @@ public class CustomModel {
    * @return The local file associated with the model. If the original file download is still in
    *     progress, returns <code>null</code>. If a file update is in progress, returns the last
    *     fully downloaded model.
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as an
+   *     alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
   @Nullable
+  @Deprecated
   public File getFile() {
     return getFile(fileDownloadService);
   }
@@ -166,7 +182,12 @@ public class CustomModel {
    * will be the size of the current model, not the new model currently being downloaded.
    *
    * @return The local model size.
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as an
+   *     alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
+  @Deprecated
   public long getSize() {
     return fileSize;
   }
@@ -175,8 +196,13 @@ public class CustomModel {
    * Retrieves the model hash.
    *
    * @return The model hash
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as an
+   *     alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
   @NonNull
+  @Deprecated
   public String getModelHash() {
     return modelHash;
   }
@@ -187,7 +213,12 @@ public class CustomModel {
    * be used to populate a progress bar, monitor when an updated model is available, etc.
    *
    * @return The download ID (if download in progress), otherwise returns 0.
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as an
+   *     alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
+  @Deprecated
   public long getDownloadId() {
     return downloadId;
   }

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/CustomModelDownloadConditions.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/CustomModelDownloadConditions.java
@@ -20,7 +20,15 @@ import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import com.google.android.gms.common.internal.Objects;
 
-/** Conditions to allow download of custom models. */
+/**
+ * Conditions to allow download of custom models.
+ *
+ * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+ *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as an
+ *     alternative for hosting custom models. For more info, see
+ *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+ */
+@Deprecated
 public class CustomModelDownloadConditions {
   private final boolean isChargingRequired;
   private final boolean isWifiRequired;
@@ -33,38 +41,83 @@ public class CustomModelDownloadConditions {
     this.isDeviceIdleRequired = isDeviceIdleRequired;
   }
 
-  /** @return True if charging is required for download. */
+  /**
+   * @return True if charging is required for download.
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as an
+   *     alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+   */
+  @Deprecated
   public boolean isChargingRequired() {
     return isChargingRequired;
   }
 
-  /** @return True if wifi is required for download. */
+  /**
+   * @return True if wifi is required for download.
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as an
+   *     alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+   */
+  @Deprecated
   public boolean isWifiRequired() {
     return isWifiRequired;
   }
 
-  /** @return True if device idle is required for download. */
+  /**
+   * @return True if device idle is required for download.
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as an
+   *     alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+   */
+  @Deprecated
   public boolean isDeviceIdleRequired() {
     return isDeviceIdleRequired;
   }
 
-  /** Builder of {@link CustomModelDownloadConditions}. */
+  /**
+   * Builder of {@link CustomModelDownloadConditions}.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as an
+   *     alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+   */
+  @Deprecated
   public static class Builder {
     private boolean isChargingRequired = false;
     private boolean isWifiRequired = false;
     private boolean isDeviceIdleRequired = false;
 
-    /** Sets charging as required. Only works on Android N and above. */
+    /**
+     * Sets charging as required. Only works on Android N and above.
+     *
+     * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+     *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+     *     an alternative for hosting custom models. For more info, see
+     *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+     */
     @NonNull
     @RequiresApi(VERSION_CODES.N)
     @TargetApi(VERSION_CODES.N)
+    @Deprecated
     public Builder requireCharging() {
       this.isChargingRequired = true;
       return this;
     }
 
-    /** Sets wifi as required. */
+    /**
+     * Sets wifi as required.
+     *
+     * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+     *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+     *     an alternative for hosting custom models. For more info, see
+     *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+     */
     @NonNull
+    @Deprecated
     public Builder requireWifi() {
       this.isWifiRequired = true;
       return this;
@@ -77,17 +130,31 @@ public class CustomModelDownloadConditions {
      * in use, and has not been in use for some time.
      *
      * <p>Only works on Android N and above.
+     *
+     * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+     *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+     *     an alternative for hosting custom models. For more info, see
+     *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
      */
     @NonNull
     @RequiresApi(VERSION_CODES.N)
     @TargetApi(VERSION_CODES.N)
+    @Deprecated
     public Builder requireDeviceIdle() {
       this.isDeviceIdleRequired = true;
       return this;
     }
 
-    /** Builds {@link CustomModelDownloadConditions}. */
+    /**
+     * Builds {@link CustomModelDownloadConditions}.
+     *
+     * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+     *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+     *     an alternative for hosting custom models. For more info, see
+     *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+     */
     @NonNull
+    @Deprecated
     public CustomModelDownloadConditions build() {
       return new CustomModelDownloadConditions(
           isChargingRequired, isWifiRequired, isDeviceIdleRequired);

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/DownloadType.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/DownloadType.java
@@ -14,17 +14,44 @@
 
 package com.google.firebase.ml.modeldownloader;
 
+/**
+ * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+ *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as an
+ *     alternative for hosting custom models. For more info, see
+ *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+ */
+@Deprecated
 public enum DownloadType {
-  /** Use local model when present, otherwise download and return latest model */
+  /**
+   * Use local model when present, otherwise download and return latest model
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as an
+   *     alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+   */
+  @Deprecated
   LOCAL_MODEL,
   /**
    * When local model present, use local model and download latest model in background. Otherwise,
    * download and return latest model.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as an
+   *     alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
+  @Deprecated
   LOCAL_MODEL_UPDATE_IN_BACKGROUND,
   /**
    * Always return latest model, check for latest model and download new model (when needed) before
    * returning.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as an
+   *     alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
+  @Deprecated
   LATEST_MODEL
 }

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/FirebaseMlException.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/FirebaseMlException.java
@@ -24,99 +24,227 @@ import java.lang.annotation.RetentionPolicy;
 /**
  * Represents an Exception resulting from an operation on a {@link FirebaseModelDownloader}. Error
  * mappings should remain consistent with the original firebase_ml_sdk whenever possible.
+ *
+ * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+ *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as an
+ *     alternative for hosting custom models. For more info, see
+ *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
  */
+@Deprecated
 public class FirebaseMlException extends FirebaseException {
-  /** The operation was cancelled (typically by the caller). */
-  public static final int CANCELLED = 1;
+  /**
+   * The operation was cancelled (typically by the caller).
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+   */
+  @Deprecated public static final int CANCELLED = 1;
 
-  /** Unknown error or an error from a different error domain. */
-  public static final int UNKNOWN = 2;
+  /**
+   * Unknown error or an error from a different error domain.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+   */
+  @Deprecated public static final int UNKNOWN = 2;
 
   /**
    * Client specified an invalid argument. Note that this differs from <code>FAILED_PRECONDITION
    * </code>. <code>INVALID_ARGUMENT</code> indicates arguments that are problematic regardless of
    * the state of the system (for example, an invalid field name).
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
-  public static final int INVALID_ARGUMENT = 3;
+  @Deprecated public static final int INVALID_ARGUMENT = 3;
 
   /**
    * Deadline expired before operation could complete. For operations that change the state of the
    * system, this error may be returned even if the operation has completed successfully. For
    * example, a successful response from a server could have been delayed long enough for the
    * deadline to expire.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
-  public static final int DEADLINE_EXCEEDED = 4;
+  @Deprecated public static final int DEADLINE_EXCEEDED = 4;
 
-  /** Some requested resource was not found. */
-  public static final int NOT_FOUND = 5;
+  /**
+   * Some requested resource was not found.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+   */
+  @Deprecated public static final int NOT_FOUND = 5;
 
-  /** Some resource that we attempted to create already exists. */
-  public static final int ALREADY_EXISTS = 6;
+  /**
+   * Some resource that we attempted to create already exists.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+   */
+  @Deprecated public static final int ALREADY_EXISTS = 6;
 
-  /** The caller does not have permission to execute the specified operation. */
-  public static final int PERMISSION_DENIED = 7;
+  /**
+   * The caller does not have permission to execute the specified operation.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+   */
+  @Deprecated public static final int PERMISSION_DENIED = 7;
 
   /**
    * Some resource has been exhausted, perhaps a per-user quota, or perhaps the entire file system
    * is out of space.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
-  public static final int RESOURCE_EXHAUSTED = 8;
+  @Deprecated public static final int RESOURCE_EXHAUSTED = 8;
 
   /**
    * Operation was rejected because the system is not in a state required for the operation's
    * execution.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
-  public static final int FAILED_PRECONDITION = 9;
+  @Deprecated public static final int FAILED_PRECONDITION = 9;
 
   /**
    * The operation was aborted, typically due to a concurrency issue like transaction aborts, etc.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
-  public static final int ABORTED = 10;
+  @Deprecated public static final int ABORTED = 10;
 
-  /** Operation was attempted past the valid range. */
-  public static final int OUT_OF_RANGE = 11;
+  /**
+   * Operation was attempted past the valid range.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+   */
+  @Deprecated public static final int OUT_OF_RANGE = 11;
 
-  /** Operation is not implemented or not supported/enabled. */
-  public static final int UNIMPLEMENTED = 12;
+  /**
+   * Operation is not implemented or not supported/enabled.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+   */
+  @Deprecated public static final int UNIMPLEMENTED = 12;
 
   /**
    * Internal errors. Means some invariant expected by underlying system has been broken. If you see
    * one of these errors, something is very broken.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
-  public static final int INTERNAL = 13;
+  @Deprecated public static final int INTERNAL = 13;
 
   /**
    * The service is currently unavailable. This is a most likely a transient condition and may be
    * corrected by retrying with a backoff.
    *
    * <p>In ML Model Downloader, this error is mostly about the models being not available yet.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
-  public static final int UNAVAILABLE = 14;
+  @Deprecated public static final int UNAVAILABLE = 14;
 
-  /** The request does not have valid authentication credentials for the operation. */
-  public static final int UNAUTHENTICATED = 16;
+  /**
+   * The request does not have valid authentication credentials for the operation.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+   */
+  @Deprecated public static final int UNAUTHENTICATED = 16;
 
-  /** There is no network connection. */
-  public static final int NO_NETWORK_CONNECTION = 17;
+  /**
+   * There is no network connection.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+   */
+  @Deprecated public static final int NO_NETWORK_CONNECTION = 17;
 
   // ===============================================================================================
   // Error codes: 100 to 149 reserved for errors during model downloading/loading.
-  /** There is not enough space left on the device. */
-  public static final int NOT_ENOUGH_SPACE = 101;
+  /**
+   * There is not enough space left on the device.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+   */
+  @Deprecated public static final int NOT_ENOUGH_SPACE = 101;
 
-  /** The downloaded model's hash doesn't match the expected value. */
-  public static final int MODEL_HASH_MISMATCH = 102;
+  /**
+   * The downloaded model's hash doesn't match the expected value.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+   */
+  @Deprecated public static final int MODEL_HASH_MISMATCH = 102;
 
   /**
    * The download URL expired before download could complete. Usually, multiple download attempts
    * will be performed before this is returned.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
-  public static final int DOWNLOAD_URL_EXPIRED = 121;
+  @Deprecated public static final int DOWNLOAD_URL_EXPIRED = 121;
 
   /**
    * The set of Firebase ML status codes. The codes are based on <a
    * href="https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto">Canonical
    * error codes for Google APIs</a>
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
   @IntDef({
     CANCELLED,
@@ -140,6 +268,7 @@ public class FirebaseMlException extends FirebaseException {
     DOWNLOAD_URL_EXPIRED
   })
   @Retention(RetentionPolicy.CLASS)
+  @Deprecated
   public @interface Code {}
 
   @Code private final int code;
@@ -150,8 +279,16 @@ public class FirebaseMlException extends FirebaseException {
     this.code = code;
   }
 
-  /** Gets the error code for the Firebase ML operation that failed. */
+  /**
+   * Gets the error code for the Firebase ML operation that failed.
+   *
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+   */
   @Code
+  @Deprecated
   public int getCode() {
     return code;
   }

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/FirebaseModelDownloader.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/FirebaseModelDownloader.java
@@ -39,6 +39,15 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import javax.inject.Inject;
 
+/**
+ * Firebase Model Downloader.
+ *
+ * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+ *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as an
+ *     alternative for hosting custom models. For more info, see
+ *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+ */
+@Deprecated
 public class FirebaseModelDownloader {
 
   private static final String TAG = "FirebaseModelDownld";
@@ -81,8 +90,13 @@ public class FirebaseModelDownloader {
    * Returns the {@link FirebaseModelDownloader} initialized with the default {@link FirebaseApp}.
    *
    * @return A {@link FirebaseModelDownloader} instance
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
   @NonNull
+  @Deprecated
   public static FirebaseModelDownloader getInstance() {
     FirebaseApp defaultFirebaseApp = FirebaseApp.getInstance();
     return getInstance(defaultFirebaseApp);
@@ -93,8 +107,13 @@ public class FirebaseModelDownloader {
    *
    * @param app A custom {@link FirebaseApp}
    * @return A {@link FirebaseModelDownloader} instance
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
   @NonNull
+  @Deprecated
   public static FirebaseModelDownloader getInstance(@NonNull FirebaseApp app) {
     Preconditions.checkArgument(app != null, "Null is not a valid value of FirebaseApp.");
     return app.get(FirebaseModelDownloader.class);
@@ -132,8 +151,13 @@ public class FirebaseModelDownloader {
    * @param downloadType {@link DownloadType} to determine which model to return.
    * @param conditions {@link CustomModelDownloadConditions} to be used during file download.
    * @return Custom model
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
   @NonNull
+  @Deprecated
   public Task<CustomModel> getModel(
       @NonNull String modelName,
       @NonNull DownloadType downloadType,
@@ -433,8 +457,13 @@ public class FirebaseModelDownloader {
    * Lists all models downloaded to device.
    *
    * @return The set of all models that are downloaded to this device.
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
   @NonNull
+  @Deprecated
   public Task<Set<CustomModel>> listDownloadedModels() {
     // trigger completion of file moves for download files.
     fileDownloadService.maybeCheckDownloadingComplete();
@@ -449,8 +478,13 @@ public class FirebaseModelDownloader {
    * Deletes the local model. Removes any information and files associated with the model name.
    *
    * @param modelName Name of the model.
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
   @NonNull
+  @Deprecated
   public Task<Void> deleteDownloadedModel(@NonNull String modelName) {
 
     TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
@@ -484,7 +518,12 @@ public class FirebaseModelDownloader {
    *
    * @param enabled Turns the logging state on or off. To revert to using the Firebase-wide data
    *     collection switch, set this value to <code>null</code>.
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
+  @Deprecated
   public void setModelDownloaderCollectionEnabled(@Nullable Boolean enabled) {
     sharedPreferencesUtil.setCustomModelStatsCollectionEnabled(enabled);
   }
@@ -503,8 +542,13 @@ public class FirebaseModelDownloader {
    * @param modelName Model name.
    * @param getModelTask The most recent getModel task associated with the model name.
    * @return Download ID associated with Android <code>DownloadManager</code>.
+   * @deprecated Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom
+   *     models, you must migrate to another solution. You can use Cloud Storage for Firebase as
+   *     an alternative for hosting custom models. For more info, see
+   *     https://firebase.google.com/docs/ml/migrate-to-cloud-storage
    */
   @NonNull
+  @Deprecated
   public Task<Long> getModelDownloadId(
       @NonNull String modelName, @Nullable Task<CustomModel> getModelTask) {
     if (getModelTask == null) {

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/ModelDownloader.kt
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/ModelDownloader.kt
@@ -23,13 +23,22 @@ import com.google.firebase.components.ComponentRegistrar
 import java.io.File
 
 /** Returns the [FirebaseModelDownloader] instance of the default [FirebaseApp]. */
+@Deprecated(
+  "Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom models, you must migrate to another solution. You can use Cloud Storage for Firebase as an alternative for hosting custom models. For more info, see https://firebase.google.com/docs/ml/migrate-to-cloud-storage"
+)
 val Firebase.modelDownloader: FirebaseModelDownloader
   get() = FirebaseModelDownloader.getInstance()
 
 /** Returns the [FirebaseModelDownloader] instance of a given [FirebaseApp]. */
+@Deprecated(
+  "Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom models, you must migrate to another solution. You can use Cloud Storage for Firebase as an alternative for hosting custom models. For more info, see https://firebase.google.com/docs/ml/migrate-to-cloud-storage"
+)
 fun Firebase.modelDownloader(app: FirebaseApp) = FirebaseModelDownloader.getInstance(app)
 
 /** Returns a [CustomModelDownloadConditions] initialized using the [init] function. */
+@Deprecated(
+  "Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom models, you must migrate to another solution. You can use Cloud Storage for Firebase as an alternative for hosting custom models. For more info, see https://firebase.google.com/docs/ml/migrate-to-cloud-storage"
+)
 fun customModelDownloadConditions(
   init: CustomModelDownloadConditions.Builder.() -> Unit
 ): CustomModelDownloadConditions {
@@ -38,14 +47,29 @@ fun customModelDownloadConditions(
   return builder.build()
 }
 
+@Deprecated(
+  "Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom models, you must migrate to another solution. You can use Cloud Storage for Firebase as an alternative for hosting custom models. For more info, see https://firebase.google.com/docs/ml/migrate-to-cloud-storage"
+)
 operator fun CustomModel.component1(): File? = file
 
+@Deprecated(
+  "Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom models, you must migrate to another solution. You can use Cloud Storage for Firebase as an alternative for hosting custom models. For more info, see https://firebase.google.com/docs/ml/migrate-to-cloud-storage"
+)
 operator fun CustomModel.component2() = size
 
+@Deprecated(
+  "Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom models, you must migrate to another solution. You can use Cloud Storage for Firebase as an alternative for hosting custom models. For more info, see https://firebase.google.com/docs/ml/migrate-to-cloud-storage"
+)
 operator fun CustomModel.component3() = downloadId
 
+@Deprecated(
+  "Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom models, you must migrate to another solution. You can use Cloud Storage for Firebase as an alternative for hosting custom models. For more info, see https://firebase.google.com/docs/ml/migrate-to-cloud-storage"
+)
 operator fun CustomModel.component4() = modelHash
 
+@Deprecated(
+  "Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom models, you must migrate to another solution. You can use Cloud Storage for Firebase as an alternative for hosting custom models. For more info, see https://firebase.google.com/docs/ml/migrate-to-cloud-storage"
+)
 operator fun CustomModel.component5() = name
 
 /** @suppress */


### PR DESCRIPTION
Deprecate the FirebaseMLModelDownloader library within the Firebase Android SDK, reflecting its scheduled shutdown on June 15, 2027.

All public API symbols have been marked with `@Deprecated` and a corresponding javadoc description.
Added a deprecation notice to the changelog.
Further steps to remove the library and prevent release are not in scope of initial deprecation.