### PR TITLE
dataconnect(chore): readability improvements to DataConnectBidiConnectStream.kt to initialize physicalConnectionFlow and logicalConnectionFlow separately

### DIFF
--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -131,7 +131,7 @@ internal class DataConnectBidiConnectStream(
       )
     val connectionStateUpdater = ConnectionStateUpdater(idStringGenerator)
 
-    val sharedFlow =
+    val physicalConnectionFlow =
       mergeGrpcAndAuth(flow, authToken)
         .onStart { resetAndRetryEvent.clear() }
         .mapNotNull { event ->
@@ -157,36 +157,41 @@ internal class DataConnectBidiConnectStream(
           }
           throw throwable ?: Exception("to be handled by retryWhen")
         }
-        .retryWhen { cause, _ ->
-          resetAndRetryEvent.clear()
-          val retryStrategy =
-            try {
-              shouldRetry(cause)
-            } catch (e: Throwable) {
-              currentCoroutineContext().ensureActive()
-              _permanentFailureFlow.emit(e)
-              throw e
-            }
 
-          when (retryStrategy) {
-            RetryStrategy.RETRY_IMMEDIATELY -> {
-              retryBackoff.reset()
-              true
+    val logicalConnectionFlow =
+      physicalConnectionFlow.retryWhen { cause, _ ->
+        resetAndRetryEvent.clear()
+        val retryStrategy =
+          try {
+            shouldRetry(cause)
+          } catch (e: Throwable) {
+            currentCoroutineContext().ensureActive()
+            _permanentFailureFlow.emit(e)
+            throw e
+          }
+
+        when (retryStrategy) {
+          RetryStrategy.RETRY_IMMEDIATELY -> {
+            retryBackoff.reset()
+            true
+          }
+          RetryStrategy.RETRY_AFTER_BACKOFF -> {
+            val backoffMs = retryBackoff.next()
+            logger.debug {
+              "waiting ${backoffMs}ms before retrying connection, which failed due to $cause"
             }
-            RetryStrategy.RETRY_AFTER_BACKOFF -> {
-              val backoffMs = retryBackoff.next()
-              logger.debug {
-                "waiting ${backoffMs}ms before retrying connection, which failed due to $cause"
-              }
-              withTimeoutOrNull(backoffMs.milliseconds) {
-                onRetryBackoffForTesting.get()?.invoke(backoffMs)
-                resetAndRetryEvent.await()
-              }
-              resetAndRetryEvent.clear()
-              true
+            withTimeoutOrNull(backoffMs.milliseconds) {
+              onRetryBackoffForTesting.get()?.invoke(backoffMs)
+              resetAndRetryEvent.await()
             }
+            resetAndRetryEvent.clear()
+            true
           }
         }
+      }
+
+    val sharedFlow =
+      logicalConnectionFlow
         .buffer(capacity = 64) // Use a finite buffer to activate gRPC flow control, when needed
         .shareIn(
           coroutineScope,


### PR DESCRIPTION
This PR refactors the connection flow construction in `DataConnectBidiConnectStream.kt` to improve code readability. It breaks up a single, long chained flow expression by introducing intermediate variables `physicalConnectionFlow` and `logicalConnectionFlow` before creating the final `sharedFlow`.

There are no functional or behavioral changes introduced by this PR. When reviewing the changes, ignoring whitespace changes shows the simplicity of the refactoring.

### Highlights

* **Flow Construction Refactoring**: Separated the single, complex flow builder chain in `DataConnectBidiConnectStream` into `physicalConnectionFlow` (physical connection setup), `logicalConnectionFlow` (retry/backoff logic), and `sharedFlow` (buffering and sharing logic).

<details>

<summary><b>Changelog</b></summary>

* **DataConnectBidiConnectStream.kt**
  * Split the unified `sharedFlow` initialization into intermediate flow variables `physicalConnectionFlow`, `logicalConnectionFlow`, and `sharedFlow`.

</details>