### PR TITLE
dataconnect(change): Exponential backoff in realtime query subscription reconnection now eagerly retries when network status changes

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -4,7 +4,7 @@
   exponential backoff strategy.
   ([#8381](https://github.com/firebase/firebase-android-sdk/pull/8381),
   [#8421](https://github.com/firebase/firebase-android-sdk/pull/8421),
-  [#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
+  [#8446](https://github.com/firebase/firebase-android-sdk/pull/8446))
 
 # 17.3.2
 

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -3,7 +3,8 @@
 - [changed] Realtime query subscriptions now retry connecting using an
   exponential backoff strategy.
   ([#8381](https://github.com/firebase/firebase-android-sdk/pull/8381),
-  [#8421](https://github.com/firebase/firebase-android-sdk/pull/8421))
+  [#8421](https://github.com/firebase/firebase-android-sdk/pull/8421),
+  [#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
 
 # 17.3.2
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -203,17 +203,14 @@ internal class DataConnectBidiConnectStream(
         // potentially restored, rather than waiting for the entire backoff duration.
         val networkConnectivityRestoredFlowCollectJob =
           launch(CoroutineName("NetworkConnectivityRestoredFlowCollectJob")) {
-            val collectResult = runCatching {
+            try {
               networkConnectivityRestoredFlow.collect {
                 retryBackoff.reset()
                 resetAndRetryEvent.signal()
               }
-            }
-
-            ensureActive()
-
-            collectResult.onFailure {
-              logger.warn(it) {
+            } catch (e: Throwable) {
+              ensureActive()
+              logger.warn(e) {
                 "WARNING: monitoring network connectivity failed; " +
                   "automatic re-connection to the Data Connect server " +
                   "may take longer than strictly necessary [qhrqw5xvxc]"

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -21,6 +21,7 @@ import com.google.firebase.dataconnect.core.DataConnectAuth.AuthUid
 import com.google.firebase.dataconnect.core.DataConnectAuth.GetAuthTokenResult
 import com.google.firebase.dataconnect.core.DataConnectGrpcMetadata.Companion.FIREBASE_AUTH_TOKEN_HEADER
 import com.google.firebase.dataconnect.core.LoggerGlobals.debug
+import com.google.firebase.dataconnect.core.LoggerGlobals.warn
 import com.google.firebase.dataconnect.util.CoroutineUtils.completedFlow
 import com.google.firebase.dataconnect.util.CoroutineUtils.mergeColdAndHotFlow
 import com.google.firebase.dataconnect.util.GrpcBidiFlow
@@ -40,6 +41,7 @@ import google.firebase.dataconnect.proto.StreamRequest as StreamRequestProto
 import google.firebase.dataconnect.proto.StreamResponse as StreamResponseProto
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
@@ -48,6 +50,7 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.onFailure
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
@@ -56,7 +59,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.merge
@@ -191,8 +196,41 @@ internal class DataConnectBidiConnectStream(
         }
       }
 
+    val logicalConnectionWithNetworkMonitoringFlow = flow {
+      coroutineScope {
+        // Monitor for network connectivity restored events concurrently with the downstream flow
+        // collection so that retryWhen can eagerly retry the connection if connectivity is
+        // potentially restored, rather than waiting for the entire backoff duration.
+        val networkConnectivityRestoredFlowCollectJob =
+          launch(CoroutineName("NetworkConnectivityRestoredFlowCollectJob")) {
+            val collectResult = runCatching {
+              networkConnectivityRestoredFlow.collect {
+                retryBackoff.reset()
+                resetAndRetryEvent.signal()
+              }
+            }
+
+            ensureActive()
+
+            collectResult.onFailure {
+              logger.warn(it) {
+                "WARNING: monitoring network connectivity failed; " +
+                  "automatic re-connection to the Data Connect server " +
+                  "may take longer than strictly necessary [qhrqw5xvxc]"
+              }
+            }
+          }
+
+        try {
+          emitAll(logicalConnectionFlow)
+        } finally {
+          networkConnectivityRestoredFlowCollectJob.cancel()
+        }
+      }
+    }
+
     val sharedFlow =
-      logicalConnectionFlow
+      logicalConnectionWithNetworkMonitoringFlow
         .buffer(capacity = 64) // Use a finite buffer to activate gRPC flow control, when needed
         .shareIn(
           coroutineScope,

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -98,6 +98,7 @@ internal class DataConnectBidiConnectStream(
     >,
   authToken: Flow<SequencedReference<GetAuthTokenResult?>>,
   shouldRetry: suspend (Throwable) -> RetryStrategy,
+  networkConnectivityRestoredFlow: Flow<NetworkConnectivityRestored>,
   idStringGenerator: IdStringGenerator,
   private val grpcMetadata: DataConnectGrpcMetadata,
   private val coroutineScope: CoroutineScope,

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -100,6 +100,7 @@ internal class DataConnectGrpcRPCs(
   @get:VisibleForTesting val grpcMetadata: DataConnectGrpcMetadata,
   private val cache: DataConnectCache?,
   parentLogger: Logger,
+  private val networkConnectivityRestoredFlow: Flow<NetworkConnectivityRestored>,
 ) {
   private val logger =
     Logger("DataConnectGrpcRPCs").apply {
@@ -525,6 +526,7 @@ internal class DataConnectGrpcRPCs(
       flow,
       tokenManager.authToken,
       shouldRetry = shouldRetry,
+      networkConnectivityRestoredFlow,
       idStringGenerator,
       grpcMetadata,
       connectCoroutineScope,

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectFactory.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectFactory.kt
@@ -41,6 +41,8 @@ internal class FirebaseDataConnectFactory(
   // all instances generate unique IDs.
   private val idStringGenerator = IdStringGenerator(Random.Default)
 
+  private val networkConnectivityRestoredFlow = networkConnectivityRestoredFlow(context)
+
   init {
     firebaseApp.addLifecycleEventListener { _, _ -> close() }
   }
@@ -92,6 +94,7 @@ internal class FirebaseDataConnectFactory(
       creator = this@FirebaseDataConnectFactory,
       settings = settings ?: DataConnectSettings(),
       idStringGenerator = idStringGenerator,
+      networkConnectivityRestoredFlow = networkConnectivityRestoredFlow,
     )
 
   fun remove(instance: FirebaseDataConnect) {

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImpl.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImpl.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.update
@@ -96,6 +97,7 @@ internal class FirebaseDataConnectImpl(
   private val creator: FirebaseDataConnectFactory,
   override val settings: DataConnectSettings,
   override val idStringGenerator: IdStringGenerator,
+  private val networkConnectivityRestoredFlow: Flow<NetworkConnectivityRestored>,
 ) : FirebaseDataConnectInternal {
 
   override val logger =
@@ -309,6 +311,7 @@ internal class FirebaseDataConnectImpl(
         grpcMetadata = grpcMetadata,
         cache = cache,
         parentLogger = logger,
+        networkConnectivityRestoredFlow = networkConnectivityRestoredFlow,
       )
 
     if (backendInfo.isEmulator) {

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStreamTesting.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStreamTesting.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.firebase.dataconnect.core
+
+import com.google.firebase.dataconnect.util.coroutines.ConflatedSignal
+
+/**
+ * Notifies a signal provided to the given block when any [DataConnectBidiConnectStream] object
+ * enters exponential backoff before retrying a connection.
+ */
+internal inline fun <T> DataConnectBidiConnectStream.Companion.signalOnRetryForTesting(
+  block: (ConflatedSignal<Long>) -> T
+): T {
+  val signal = ConflatedSignal<Long>()
+  val callback = { backoffMillis: Long -> signal.signal(backoffMillis) }
+
+  setOnRetryBackoffForTesting(callback)
+  try {
+    return block(signal)
+  } finally {
+    unsetOnRetryBackoffForTesting(callback)
+  }
+}

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
@@ -107,6 +107,7 @@ import kotlin.time.Duration
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -929,6 +930,7 @@ class DataConnectGrpcRPCsUnitTest {
       grpcMetadata = grpcMetadataArb.bind(),
       cache = cache,
       parentLogger = mockLogger,
+      networkConnectivityRestoredFlow = emptyFlow(),
     )
   }
 

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImplUnitTest.kt
@@ -49,6 +49,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asExecutor
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.DeserializationStrategy
@@ -292,6 +293,7 @@ class FirebaseDataConnectImplUnitTest {
         creator = mockk(relaxed = true),
         settings = Arb.dataConnect.dataConnectSettings().next(rs),
         idStringGenerator = IdStringGenerator(Random.Default),
+        networkConnectivityRestoredFlow = emptyFlow(),
       )
       .also { cleanups.register("close FirebaseDataConnectImpl") { it.close() } }
   }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -122,6 +122,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.asExecutor
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -1978,6 +1979,7 @@ class QuerySubscriptionImplUnitTest {
       creator = mockk(name = "FirebaseDataConnectImpl.creator", relaxed = true),
       settings = settings,
       idStringGenerator = idStringGenerator ?: IdStringGenerator(Random.Default),
+      networkConnectivityRestoredFlow = emptyFlow(),
     )
   }
 

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -71,8 +71,6 @@ import com.google.firebase.dataconnect.util.IdStringGenerator
 import com.google.firebase.dataconnect.util.ProtoUtil.encodeToStruct
 import com.google.firebase.dataconnect.util.SequencedReference
 import com.google.firebase.dataconnect.util.SequencedReference.Companion.nextSequenceNumber
-import com.google.firebase.dataconnect.util.coroutines.ConflatedSignal
-import com.google.firebase.dataconnect.util.coroutines.signal
 import com.google.firebase.internal.InternalTokenResult
 import google.firebase.dataconnect.proto.StreamRequest
 import google.firebase.dataconnect.proto.StreamRequest.RequestKindCase
@@ -118,13 +116,18 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import kotlin.random.Random
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.asExecutor
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
@@ -1573,14 +1576,9 @@ class QuerySubscriptionImplUnitTest {
       serverCollector.awaitUntilSubscribeStreamRequest()
 
       // Abort the connection to trigger backoff delay
-      val backoffSignal = ConflatedSignal<Unit>()
-      val backoffCallback: (Long) -> Unit = { backoffSignal.signal() }
-      DataConnectBidiConnectStream.setOnRetryBackoffForTesting(backoffCallback)
-      try {
+      DataConnectBidiConnectStream.signalOnRetryForTesting { backoffSignal ->
         responseSender.onError(Status.UNAVAILABLE.asException())
         backoffSignal.await()
-      } finally {
-        DataConnectBidiConnectStream.unsetOnRetryBackoffForTesting(backoffCallback)
       }
 
       val time1 = @OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime
@@ -1599,6 +1597,107 @@ class QuerySubscriptionImplUnitTest {
       clientCollector2.cancelAndIgnoreRemainingEvents()
       clientCollector1.cancelAndIgnoreRemainingEvents()
       serverCollector.cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun `network connectivity restoration resets retries immediately`() =
+    testNetworkConnectivityRestoration {
+      // Interrupt the exponential backoff with a NetworkConnectivityRestored event.
+      // Measure the simulated time that the backoff delays for.
+      failConnection()
+      val time1 = @OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime
+      delay(delayMillis.milliseconds)
+      emit(NetworkConnectivityRestored)
+      serverCollector.awaitCall()
+      val time2 = @OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime
+
+      // Verify that the backoff delay was aborted at delayMillis (which is guaranteed to be less
+      // than
+      // the backoff in effect) rather than waiting for the entire backoff.
+      (time2 - time1) shouldBe delayMillis
+    }
+
+  @Test
+  fun `network connectivity restoration resets backoff delay to initial value`() =
+    testNetworkConnectivityRestoration {
+      // Interrupt the exponential backoff with a NetworkConnectivityRestored event.
+      failConnection()
+      delay(delayMillis.milliseconds)
+      emit(NetworkConnectivityRestored)
+
+      // Cause the retry after the NetworkConnectivityRestored event to fail again.
+      failConnection()
+      val time1 = @OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime
+      serverCollector.awaitCall()
+      val time2 = @OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime
+
+      // Verify that the backoff used in the retry after the NetworkConnectivityRestored event
+      // used the initial backoff, rather than continuing with the backoff it had used above.
+      (time2 - time1) shouldBe firstBackoffWaitTime
+    }
+
+  private data class TestNetworkConnectivityRestorationContext(
+    val failConnection: suspend () -> Unit,
+    val testScheduler: TestCoroutineScheduler,
+    val delayMillis: Long,
+    val emit: suspend (NetworkConnectivityRestored) -> Unit,
+    val serverCollector: ReceiveTurbine<InProcessDataConnectGrpcStreamingServer.Event>,
+    val firstBackoffWaitTime: Long,
+  )
+
+  private fun testNetworkConnectivityRestoration(
+    block: suspend TestNetworkConnectivityRestorationContext.() -> Unit
+  ) = runTest {
+    val server = runningInProcessDataConnectServer()
+    val networkConnectivityRestoredFlow = MutableSharedFlow<NetworkConnectivityRestored>()
+    val dataConnect =
+      dataConnect(server, networkConnectivityRestoredFlow = networkConnectivityRestoredFlow)
+    val subscription = querySubscription(dataConnect)
+
+    val backoffWaitTimes = getExpectedBackoffWaitTimes()
+
+    backoffWaitTimes.forEachIndexed { failCountBeforeRetrying, lastBackoffWaitTime ->
+      turbineScope {
+        val serverCollector = server.events.testIn(backgroundScope, name = "serverCollector")
+        val clientCollector = subscription.flow.testIn(backgroundScope, name = "clientCollector")
+        val failConnection: suspend () -> Unit = {
+          val responseSender = serverCollector.awaitResponseSender()
+          DataConnectBidiConnectStream.signalOnRetryForTesting { backoffSignal ->
+            responseSender.onError(Status.UNAVAILABLE.asException())
+            backoffSignal.await()
+          }
+        }
+
+        repeat(failCountBeforeRetrying) { retryIndex ->
+          failConnection()
+          val time1 = @OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime
+          serverCollector.awaitCall()
+          val time2 = @OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime
+          check(time2 - time1 == backoffWaitTimes[retryIndex]) {
+            "internal error m6gwemnpw7: something is wrong with the test logic because the " +
+              "expected backoff was different than expected; once this logic is fixed, " +
+              "make sure to also fix the code after failConnection() below; " +
+              "time2=$time2, time1=$time1 time2-time1=${time2 - time1}, retryIndex=$retryIndex, " +
+              "backoffWaitTimes[retryIndex]=${backoffWaitTimes[retryIndex]}, " +
+              "failCountBeforeRetrying=$failCountBeforeRetrying"
+          }
+        }
+
+        block(
+          TestNetworkConnectivityRestorationContext(
+            failConnection,
+            testScheduler,
+            delayMillis = lastBackoffWaitTime / 3,
+            emit = networkConnectivityRestoredFlow::emit,
+            serverCollector,
+            firstBackoffWaitTime = backoffWaitTimes[0]
+          )
+        )
+
+        clientCollector.cancelAndIgnoreRemainingEvents()
+        serverCollector.cancelAndIgnoreRemainingEvents()
+      }
     }
   }
 
@@ -1646,7 +1745,6 @@ class QuerySubscriptionImplUnitTest {
 
       repeat(100) {
         val responseSender = serverCollector.awaitResponseSender()
-        serverCollector.awaitUntilSubscribeStreamRequest()
         times.add(@OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime)
         responseSender.onError(Status.UNAVAILABLE.asException())
       }
@@ -1657,10 +1755,7 @@ class QuerySubscriptionImplUnitTest {
 
     val waitTimes = times.zipWithNext { a, b -> b - a }
     check(waitTimes.size == 99) { "internal error dy3gcskmvt: waitTimes.size=${waitTimes.size}" }
-    val expectedWaitTimes =
-      RetryBackoffCalculator().let { retryBackoffCalculator ->
-        List(waitTimes.size) { retryBackoffCalculator.next() }
-      }
+    val expectedWaitTimes = getExpectedBackoffWaitTimes(99)
     waitTimes shouldContainExactly expectedWaitTimes
   }
 
@@ -1938,12 +2033,14 @@ class QuerySubscriptionImplUnitTest {
       UnavailableDeferred(),
     deferredAppCheckProvider: com.google.firebase.inject.Deferred<InteropAppCheckTokenProvider> =
       UnavailableDeferred(),
+    networkConnectivityRestoredFlow: Flow<NetworkConnectivityRestored> = emptyFlow(),
   ): FirebaseDataConnectImpl =
     dataConnect(
       server.port,
       idStringGenerator,
       deferredAuthProvider,
       deferredAppCheckProvider,
+      networkConnectivityRestoredFlow,
     )
 
   private fun TestScope.dataConnect(
@@ -1953,6 +2050,7 @@ class QuerySubscriptionImplUnitTest {
       UnavailableDeferred(),
     deferredAppCheckProvider: com.google.firebase.inject.Deferred<InteropAppCheckTokenProvider> =
       UnavailableDeferred(),
+    networkConnectivityRestoredFlow: Flow<NetworkConnectivityRestored> = emptyFlow(),
   ): FirebaseDataConnectImpl {
     val executor = StandardTestDispatcher(testScheduler).asExecutor()
 
@@ -1979,7 +2077,7 @@ class QuerySubscriptionImplUnitTest {
       creator = mockk(name = "FirebaseDataConnectImpl.creator", relaxed = true),
       settings = settings,
       idStringGenerator = idStringGenerator ?: IdStringGenerator(Random.Default),
-      networkConnectivityRestoredFlow = emptyFlow(),
+      networkConnectivityRestoredFlow = networkConnectivityRestoredFlow,
     )
   }
 
@@ -2119,3 +2217,24 @@ private val retryableFailureGrpcStatusCodes: List<Status.Code> =
 
 private fun FirebaseDataConnectImpl.googApiClientHeaderValue(callerSdkType: CallerSdkType): String =
   grpcRPCs.grpcMetadata.googApiClientHeaderValue(callerSdkType)
+
+private fun getExpectedBackoffWaitTimes(count: Int = -1): List<Long> {
+  require(count >= -1) { "invalid count: $count [ht5kab7ehc]" }
+  val calculator = RetryBackoffCalculator()
+  val list = mutableListOf<Long>()
+
+  while (true) {
+    if (count >= 0) {
+      if (list.size == count) {
+        break
+      }
+    } else if (list.size >= 2 && list.last() == list.secondLast()) {
+      break
+    }
+    list.add(calculator.next())
+  }
+
+  return list.toList()
+}
+
+private fun <T> List<T>.secondLast(): T = get(size - 2)


### PR DESCRIPTION
This PR integrates data connect's network status monitoring with the exponential backoff reconnection strategy for realtime query subscriptions. It ensures that when network connectivity is restored, the client immediately aborts any active retry delays and triggers a reconnection attempt using the initial backoff wait time.

This is a follow-up PR to #8421 that completes the network-status-triggered reconnection flow.

### Highlights

* **Eager Reconnection on Network Restore**: Realtime query subscriptions now listen to network restoration events to immediately reset the backoff logic and trigger an active retry.
* **Plumbed Network Connectivity Flow**: Plumbed `networkConnectivityRestoredFlow` from `FirebaseDataConnectFactory` through `FirebaseDataConnectImpl` and `DataConnectGrpcRPCs` down to `DataConnectBidiConnectStream`.
* **Resets to Initial Backoff**: Restored connectivity resets the backoff timer to its initial duration for subsequent failures.
* **Testing Infrastructure & Assertions**: Added custom test helpers and comprehensive unit tests verifying immediate retries and backoff resets.

<details>
<summary><b>Changelog</b></summary>

* **CHANGELOG.md**
  * Associated PR #8446 with the entry for realtime query subscription exponential backoff.
* **DataConnectBidiConnectStream.kt**
  * Added concurrent monitoring of `networkConnectivityRestoredFlow` to reset the `retryBackoff` and trigger an immediate reconnect upon network restoration.
* **DataConnectGrpcRPCs.kt**
  * Updated constructor to accept and pass through `networkConnectivityRestoredFlow`.
* **FirebaseDataConnectFactory.kt**
  * Instantiated and passed the `networkConnectivityRestoredFlow` down to the data connect implementation.
* **FirebaseDataConnectImpl.kt**
  * Updated constructor to accept and pass through `networkConnectivityRestoredFlow`.
* **DataConnectBidiConnectStreamTesting.kt**
  * Added testing helper `signalOnRetryForTesting` to intercept and signal backoff retry triggers during testing.
* **DataConnectGrpcRPCsUnitTest.kt**
  * Updated test setup to pass empty flows for network monitoring.
* **FirebaseDataConnectImplUnitTest.kt**
  * Updated test setup to pass empty flows for network monitoring.
* **QuerySubscriptionImplUnitTest.kt**
  * Plumbed `networkConnectivityRestoredFlow` into the testing instance.
  * Added `network connectivity restoration resets retries immediately` unit test.
  * Added `network connectivity restoration resets backoff delay to initial value` unit test.
  * Extracted and updated the common backoff delay helper `getExpectedBackoffWaitTimes`.

</details>