### PR TITLE
[FCM] Improve documentation readability

### DIFF
--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/Constants.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/Constants.java
@@ -226,16 +226,16 @@ public final class Constants {
     public static final String ANALYTICS_DATA = NOTIFICATION_PREFIX + "analytics_data";
 
     /**
-     * For l10n of text parameters (e.g. title & body) a string resource can be specified instead of
+     * For l10n of text parameters (for example, title & body) a string resource can be specified instead of
      * a raw string. The name of that resource would be passed in the bundle under the key named:
-     * <parameter> + suffix (e.g: _loc_key)
+     * <parameter> + suffix (for example: _loc_key)
      */
     public static final String TEXT_RESOURCE_SUFFIX = "_loc_key";
 
     /**
-     * For l10n of text parameters (e.g. title & body) a string containing the localization
+     * For l10n of text parameters (for example, title & body) a string containing the localization
      * parameters can be specified. This would be present in the bundle under the key named:
-     * <parameter> + suffix (e.g: _loc_args)
+     * <parameter> + suffix (for example: _loc_args)
      */
     public static final String TEXT_ARGS_SUFFIX = "_loc_args";
 

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/ServiceStarter.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/ServiceStarter.java
@@ -53,7 +53,7 @@ import java.util.Queue;
  *   <li>1. Incoming message, comes through FirebaseInstanceIdReceiver which is exported but
  *       protected by a permission. It calls {@link #startMessagingService}, which places the intent
  *       on a queue and starts the service.
- *   <li>2. PendingIntents (e.g. for Notifications click or dismissal). Same flow as 1 via
+ *   <li>2. PendingIntents (for example, for Notifications click or dismissal). Same flow as 1 via
  *       FirebaseInstanceIdReceiver.
  *   <li>3. Starting the service through some internal event. Here we don't need to go through the
  *       receiver, as the app will be running the whole time.

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/threads/ThreadPriority.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/threads/ThreadPriority.java
@@ -45,7 +45,7 @@ public enum ThreadPriority {
 
   /**
    * Better performance at the expense of power and execution of other tasks. If the user will be
-   * waiting for your work to complete (i.e. staring at a spinner), then this is a good choice.
+   * waiting for your work to complete (that is, staring at a spinner), then this is a good choice.
    * Often this is the case for handling client app requests. Otherwise, it's best to use {@link
    * #LOW_POWER}.
    *


### PR DESCRIPTION
Updated Javadoc comments to replace shorthand abbreviations like "e.g." and "i.e." with descriptive phrases for improved clarity.

NO_RELEASE_CHANGE