### PR TITLE
[Firestore] Improve documentation clarity

### DIFF
--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/NetworkConnectivityRestoredFlow.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/NetworkConnectivityRestoredFlow.kt
@@ -132,9 +132,9 @@ private class NetworkCallbackImpl : ConnectivityManager.NetworkCallback() {
   }
 
   /**
-   * Notifies the callback when the network block status changes (for example, background data saver rules
-   * are toggled). We signal when the network becomes unblocked (`blocked == false`) so consumers
-   * can attempt to reconnect.
+   * Notifies the callback when the network block status changes (for example, background data saver
+   * rules are toggled). We signal when the network becomes unblocked (`blocked == false`) so
+   * consumers can attempt to reconnect.
    */
   @RequiresApi(Build.VERSION_CODES.Q)
   override fun onBlockedStatusChanged(network: Network, blocked: Boolean) {

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/NetworkConnectivityRestoredFlow.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/NetworkConnectivityRestoredFlow.kt
@@ -132,7 +132,7 @@ private class NetworkCallbackImpl : ConnectivityManager.NetworkCallback() {
   }
 
   /**
-   * Notifies the callback when the network block status changes (e.g. background data saver rules
+   * Notifies the callback when the network block status changes (for example, background data saver rules
    * are toggled). We signal when the network becomes unblocked (`blocked == false`) so consumers
    * can attempt to reconnect.
    */

--- a/firebase-firestore/api.txt
+++ b/firebase-firestore/api.txt
@@ -257,8 +257,8 @@ package com.google.firebase.firestore {
     method public String getHost();
     method @Deprecated public boolean isPersistenceEnabled();
     method public boolean isSslEnabled();
-    field public static final int DEFAULT_GRPC_FLOW_CONTROL_WINDOW = 262144; // 0x40000
     field public static final long CACHE_SIZE_UNLIMITED = -1L; // 0xffffffffffffffffL
+    field public static final int DEFAULT_GRPC_FLOW_CONTROL_WINDOW = 262144; // 0x40000
   }
 
   public static final class FirebaseFirestoreSettings.Builder {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -906,7 +906,7 @@ public class FirebaseFirestore {
    * }</pre>
    *
    * <p><b>Note on Execution:</b> The stages are conceptual. The Firestore backend may
-   * optimize execution (e.g., reordering or merging stages) as long as the
+   * optimize execution (for example, reordering or merging stages) as long as the
    * final result remains the same.
    *
    * <p><b>Important Limitations:</b>

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Pipeline.kt
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Pipeline.kt
@@ -85,7 +85,7 @@ import com.google.firestore.v1.Value
  * ```
  *
  * **Note on Execution:** The stages are conceptual. The Firestore backend may optimize execution
- * (e.g., reordering or merging stages) as long as the final result remains the same.
+ * (for example, reordering or merging stages) as long as the final result remains the same.
  *
  * **Important Limitations:**
  * - Pipelines operate on a **request/response basis only**.
@@ -590,7 +590,7 @@ internal constructor(
    * - **AggregateFunctions:** One or more accumulation operations to perform within each group.
    * These are defined using [AliasedAggregate] expressions, which are typically created by calling
    * [AggregateFunction.alias] on [AggregateFunction] instances. Each aggregation calculates a value
-   * (e.g., sum, average, count) based on the documents within its group.
+   * (for example, sum, average, count) based on the documents within its group.
    *
    * Example:
    * ```kotlin
@@ -623,7 +623,7 @@ internal constructor(
    * - **AggregateFunctions:** One or more accumulation operations to perform within each group.
    * These are defined using [AliasedAggregate] expressions, which are typically created by calling
    * [AggregateFunction.alias] on [AggregateFunction] instances. Each aggregation calculates a value
-   * (e.g., sum, average, count) based on the documents within its group.
+   * (for example, sum, average, count) based on the documents within its group.
    *
    * @param aggregateStage An [AggregateStage] object that specifies the grouping fields (if any)
    * and the aggregation operations to perform.
@@ -1387,7 +1387,7 @@ internal constructor(
   /**
    * Retrieves the field specified by [field].
    *
-   * @param field The field path (e.g. "foo" or "foo.bar") to a specific field.
+   * @param field The field path (for example, "foo" or "foo.bar") to a specific field.
    * @return The data at the specified field location or null if no such field exists.
    */
   fun get(field: String): Any? = get(FieldPath.fromDotSeparatedPath(field))

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/BasePath.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/BasePath.java
@@ -92,7 +92,7 @@ public abstract class BasePath<B extends BasePath<B>> implements Comparable<B>, 
 
   /**
    * Compare the current path against another Path object. Paths are compared segment by segment,
-   * prioritizing numeric IDs (e.g., "__id123__") in numeric ascending order, followed by string
+   * prioritizing numeric IDs (for example, "__id123__") in numeric ascending order, followed by string
    * segments in lexicographical order.
    */
   @Override

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/pipeline/expressions.kt
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/pipeline/expressions.kt
@@ -334,8 +334,8 @@ abstract class Expression internal constructor() {
     /**
      * Creates a [Field] instance representing the field at the given path.
      *
-     * The path can be a simple field name (e.g., "name") or a dot-separated path to a nested field
-     * (e.g., "address.city").
+     * The path can be a simple field name (for example, "name") or a dot-separated path to a nested
+     * field (for example, "address.city").
      *
      * @param name The path to the field.
      * @return A new [Field] instance representing the specified path.
@@ -353,8 +353,8 @@ abstract class Expression internal constructor() {
     /**
      * Creates a [Field] instance representing the field at the given path.
      *
-     * The path can be a simple field name (e.g., "name") or a dot-separated path to a nested field
-     * (e.g., "address.city").
+     * The path can be a simple field name (for example, "name") or a dot-separated path to a nested
+     * field (for example, "address.city").
      *
      * ```kotlin
      * // Get the 'address.city' field
@@ -4912,7 +4912,7 @@ abstract class Expression internal constructor() {
      * "week(wednesday)", "week(thursday)", "week(friday)", "week(saturday)", "week(sunday)",
      * "isoweek", "month", "quarter", "year", and "isoyear".
      * @param timezone The timezone to use for truncation. Valid values are from the TZ database
-     * (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1".
+     * (for example, "America/Los_Angeles") or in the format "Etc/GMT-1".
      * @return A new [Expression] representing the truncated timestamp.
      */
     @JvmStatic
@@ -4945,7 +4945,7 @@ abstract class Expression internal constructor() {
      * "week(wednesday)", "week(thursday)", "week(friday)", "week(saturday)", "week(sunday)",
      * "isoweek", "month", "quarter", "year", and "isoyear".
      * @param timezone The timezone to use for truncation. Valid values are from the TZ database
-     * (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1".
+     * (for example, "America/Los_Angeles") or in the format "Etc/GMT-1".
      * @return A new [Expression] representing the truncated timestamp.
      */
     @JvmStatic
@@ -4978,7 +4978,7 @@ abstract class Expression internal constructor() {
      * "week(wednesday)", "week(thursday)", "week(friday)", "week(saturday)", "week(sunday)",
      * "isoweek", "month", "quarter", "year", and "isoyear".
      * @param timezone The timezone to use for truncation. Valid values are from the TZ database
-     * (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1".
+     * (for example, "America/Los_Angeles") or in the format "Etc/GMT-1".
      * @return A new [Expression] representing the truncated timestamp.
      */
     @JvmStatic
@@ -5011,7 +5011,7 @@ abstract class Expression internal constructor() {
      * "week(wednesday)", "week(thursday)", "week(friday)", "week(saturday)", "week(sunday)",
      * "isoweek", "month", "quarter", "year", and "isoyear".
      * @param timezone The timezone to use for truncation. Valid values are from the TZ database
-     * (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1".
+     * (for example, "America/Los_Angeles") or in the format "Etc/GMT-1".
      * @return A new [Expression] representing the truncated timestamp.
      */
     @JvmStatic
@@ -5044,7 +5044,7 @@ abstract class Expression internal constructor() {
      * "week(wednesday)", "week(thursday)", "week(friday)", "week(saturday)", "week(sunday)",
      * "isoweek", "month", "quarter", "year", and "isoyear".
      * @param timezone The timezone expression to use for truncation. Valid values are from the TZ
-     * database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1".
+     * database (for example, "America/Los_Angeles") or in the format "Etc/GMT-1".
      * @return A new [Expression] representing the truncated timestamp.
      */
     @JvmStatic
@@ -5077,7 +5077,7 @@ abstract class Expression internal constructor() {
      * "week(wednesday)", "week(thursday)", "week(friday)", "week(saturday)", "week(sunday)",
      * "isoweek", "month", "quarter", "year", and "isoyear".
      * @param timezone The timezone expression to use for truncation. Valid values are from the TZ
-     * database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1".
+     * database (for example, "America/Los_Angeles") or in the format "Etc/GMT-1".
      * @return A new [Expression] representing the truncated timestamp.
      */
     @JvmStatic
@@ -5104,7 +5104,7 @@ abstract class Expression internal constructor() {
      * "week(wednesday)", "week(thursday)", "week(friday)", "week(saturday)", "week(sunday)",
      * "isoweek", "month", "quarter", "year", and "isoyear".
      * @param timezone The timezone expression to use for truncation. Valid values are from the TZ
-     * database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1".
+     * database (for example, "America/Los_Angeles") or in the format "Etc/GMT-1".
      * @return A new [Expression] representing the truncated timestamp.
      */
     @JvmStatic
@@ -5137,7 +5137,7 @@ abstract class Expression internal constructor() {
      * "week(wednesday)", "week(thursday)", "week(friday)", "week(saturday)", "week(sunday)",
      * "isoweek", "month", "quarter", "year", and "isoyear".
      * @param timezone The timezone expression to use for truncation. Valid values are from the TZ
-     * database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1".
+     * database (for example, "America/Los_Angeles") or in the format "Etc/GMT-1".
      * @return A new [Expression] representing the truncated timestamp.
      */
     @JvmStatic
@@ -5330,8 +5330,8 @@ abstract class Expression internal constructor() {
      * "week(monday)", "week(tuesday)", "week(wednesday)", "week(thursday)", "week(friday)",
      * "week(saturday)", "week(sunday)", "isoweek", "month", "quarter", "year", and "isoyear".
      * @param timezone The timezone expression to use for extraction.Valid values are from the TZ
-     * database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC" if not
-     * specified.
+     * database (for example, "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC"
+     * if not specified.
      * @return A new [Expression] representing the extracted part.
      */
     @JvmStatic
@@ -5356,8 +5356,8 @@ abstract class Expression internal constructor() {
      * "week(monday)", "week(tuesday)", "week(wednesday)", "week(thursday)", "week(friday)",
      * "week(saturday)", "week(sunday)", "isoweek", "month", "quarter", "year", and "isoyear".
      * @param timezone The timezone expression to use for extraction.Valid values are from the TZ
-     * database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC" if not
-     * specified.
+     * database (for example, "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC"
+     * if not specified.
      * @return A new [Expression] representing the extracted part.
      */
     @JvmStatic
@@ -5381,8 +5381,8 @@ abstract class Expression internal constructor() {
      * "week(monday)", "week(tuesday)", "week(wednesday)", "week(thursday)", "week(friday)",
      * "week(saturday)", "week(sunday)", "isoweek", "month", "quarter", "year", and "isoyear".
      * @param timezone The timezone expression to use for extraction.Valid values are from the TZ
-     * database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC" if not
-     * specified.
+     * database (for example, "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC"
+     * if not specified.
      * @return A new [Expression] representing the extracted part.
      */
     @JvmStatic
@@ -5406,8 +5406,8 @@ abstract class Expression internal constructor() {
      * "week(monday)", "week(tuesday)", "week(wednesday)", "week(thursday)", "week(friday)",
      * "week(saturday)", "week(sunday)", "isoweek", "month", "quarter", "year", and "isoyear".
      * @param timezone The timezone expression to use for extraction.Valid values are from the TZ
-     * database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC" if not
-     * specified.
+     * database (for example, "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC"
+     * if not specified.
      * @return A new [Expression] representing the extracted part.
      */
     @JvmStatic
@@ -5431,8 +5431,8 @@ abstract class Expression internal constructor() {
      * "week(monday)", "week(tuesday)", "week(wednesday)", "week(thursday)", "week(friday)",
      * "week(saturday)", "week(sunday)", "isoweek", "month", "quarter", "year", and "isoyear".
      * @param timezone The timezone expression to use for extraction.Valid values are from the TZ
-     * database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC" if not
-     * specified.
+     * database (for example, "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC"
+     * if not specified.
      * @return A new [Expression] representing the extracted part.
      */
     @JvmStatic
@@ -5457,8 +5457,8 @@ abstract class Expression internal constructor() {
      * "week(monday)", "week(tuesday)", "week(wednesday)", "week(thursday)", "week(friday)",
      * "week(saturday)", "week(sunday)", "isoweek", "month", "quarter", "year", and "isoyear".
      * @param timezone The timezone expression to use for extraction.Valid values are from the TZ
-     * database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC" if not
-     * specified.
+     * database (for example, "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC"
+     * if not specified.
      * @return A new [Expression] representing the extracted part.
      */
     @JvmStatic
@@ -5482,8 +5482,8 @@ abstract class Expression internal constructor() {
      * "week(monday)", "week(tuesday)", "week(wednesday)", "week(thursday)", "week(friday)",
      * "week(saturday)", "week(sunday)", "isoweek", "month", "quarter", "year", and "isoyear".
      * @param timezone The timezone expression to use for extraction.Valid values are from the TZ
-     * database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC" if not
-     * specified.
+     * database (for example, "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC"
+     * if not specified.
      * @return A new [Expression] representing the extracted part.
      */
     @JvmStatic
@@ -5507,8 +5507,8 @@ abstract class Expression internal constructor() {
      * "week(monday)", "week(tuesday)", "week(wednesday)", "week(thursday)", "week(friday)",
      * "week(saturday)", "week(sunday)", "isoweek", "month", "quarter", "year", and "isoyear".
      * @param timezone The timezone expression to use for extraction.Valid values are from the TZ
-     * database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC" if not
-     * specified.
+     * database (for example, "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC"
+     * if not specified.
      * @return A new [Expression] representing the extracted part.
      */
     @JvmStatic
@@ -9839,8 +9839,8 @@ abstract class Expression internal constructor() {
    * "millisecond", "second", "minute", "hour", "day", "week", "week(monday)", "week(tuesday)",
    * "week(wednesday)", "week(thursday)", "week(friday)", "week(saturday)", "week(sunday)",
    * "isoweek", "month", "quarter", "year", and "isoyear".
-   * @param timezone The timezone to use for truncation. Valid values are from the TZ database
-   * (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1".
+   * @param timezone The timezone to use for truncation. Valid values are from the TZ database (for
+   * example, "America/Los_Angeles") or in the format "Etc/GMT-1".
    * @return A new [Expression] representing the truncated timestamp.
    */
   fun timestampTruncateWithTimezone(granularity: String, timezone: String): Expression =
@@ -9860,8 +9860,8 @@ abstract class Expression internal constructor() {
    * "millisecond", "second", "minute", "hour", "day", "week", "week(monday)", "week(tuesday)",
    * "week(wednesday)", "week(thursday)", "week(friday)", "week(saturday)", "week(sunday)",
    * "isoweek", "month", "quarter", "year", and "isoyear".
-   * @param timezone The timezone to use for truncation. Valid values are from the TZ database
-   * (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1".
+   * @param timezone The timezone to use for truncation. Valid values are from the TZ database (for
+   * example, "America/Los_Angeles") or in the format "Etc/GMT-1".
    * @return A new [Expression] representing the truncated timestamp.
    */
   fun timestampTruncateWithTimezone(granularity: Expression, timezone: String): Expression =
@@ -9882,7 +9882,7 @@ abstract class Expression internal constructor() {
    * "week(wednesday)", "week(thursday)", "week(friday)", "week(saturday)", "week(sunday)",
    * "isoweek", "month", "quarter", "year", and "isoyear".
    * @param timezone The timezone expression to use for truncation. Valid values are from the TZ
-   * database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1".
+   * database (for example, "America/Los_Angeles") or in the format "Etc/GMT-1".
    * @return A new [Expression] representing the truncated timestamp.
    */
   fun timestampTruncateWithTimezone(granularity: String, timezone: Expression): Expression =
@@ -9903,7 +9903,7 @@ abstract class Expression internal constructor() {
    * "week(wednesday)", "week(thursday)", "week(friday)", "week(saturday)", "week(sunday)",
    * "isoweek", "month", "quarter", "year", and "isoyear".
    * @param timezone The timezone expression to use for truncation. Valid values are from the TZ
-   * database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1".
+   * database (for example, "America/Los_Angeles") or in the format "Etc/GMT-1".
    * @return A new [Expression] representing the truncated timestamp.
    */
   fun timestampTruncateWithTimezone(granularity: Expression, timezone: Expression): Expression =
@@ -10002,8 +10002,9 @@ abstract class Expression internal constructor() {
    * "minute", "hour", "dayofweek", "day", "dayofyear", "week", "week(monday)", "week(tuesday)",
    * "week(wednesday)", "week(thursday)", "week(friday)", "week(saturday)", "week(sunday)",
    * "isoweek", "month", "quarter", "year", and "isoyear".
-   * @param timezone The timezone to use for extraction. Valid values are from the TZ database
-   * (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC" if not specified.
+   * @param timezone The timezone to use for extraction. Valid values are from the TZ database (for
+   * example, "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC" if not
+   * specified.
    * @return A new [Expression] representing the extracted part.
    */
   fun timestampExtractWithTimezone(part: Expression, timezone: String): Expression =
@@ -10022,8 +10023,9 @@ abstract class Expression internal constructor() {
    * "minute", "hour", "dayofweek", "day", "dayofyear", "week", "week(monday)", "week(tuesday)",
    * "week(wednesday)", "week(thursday)", "week(friday)", "week(saturday)", "week(sunday)",
    * "isoweek", "month", "quarter", "year", and "isoyear".
-   * @param timezone The timezone to use for extraction. Valid values are from the TZ database
-   * (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC" if not specified.
+   * @param timezone The timezone to use for extraction. Valid values are from the TZ database (for
+   * example, "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC" if not
+   * specified.
    * @return A new [Expression] representing the extracted part.
    */
   fun timestampExtractWithTimezone(part: String, timezone: String): Expression =
@@ -10044,8 +10046,8 @@ abstract class Expression internal constructor() {
    * "week(wednesday)", "week(thursday)", "week(friday)", "week(saturday)", "week(sunday)",
    * "isoweek", "month", "quarter", "year", and "isoyear".
    * @param timezone The timezone expression to use for extraction. Valid values are from the TZ
-   * database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC" if not
-   * specified.
+   * database (for example, "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC"
+   * if not specified.
    * @return A new [Expression] representing the extracted part.
    */
   fun timestampExtractWithTimezone(part: Expression, timezone: Expression): Expression =
@@ -10066,8 +10068,8 @@ abstract class Expression internal constructor() {
    * "week(wednesday)", "week(thursday)", "week(friday)", "week(saturday)", "week(sunday)",
    * "isoweek", "month", "quarter", "year", and "isoyear".
    * @param timezone The timezone expression to use for extraction. Valid values are from the TZ
-   * database (e.g., "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC" if not
-   * specified.
+   * database (for example, "America/Los_Angeles") or in the format "Etc/GMT-1". Defaults to "UTC"
+   * if not specified.
    * @return A new [Expression] representing the extracted part.
    */
   fun timestampExtractWithTimezone(part: String, timezone: Expression): Expression =

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/pipeline/stage.kt
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/pipeline/stage.kt
@@ -499,7 +499,7 @@ internal constructor(
  * - **AggregateFunctions:** One or more accumulation operations to perform within each group. These
  * are defined using [AliasedAggregate] expressions, which are typically created by calling
  * [AggregateFunction.alias] on [AggregateFunction] instances. Each aggregation calculates a value
- * (e.g., sum, average, count) based on the documents within its group.
+ * (for example, sum, average, count) based on the documents within its group.
  */
 class AggregateStage
 private constructor(


### PR DESCRIPTION
Replaced abbreviations like "e.g." with "for example" throughout the codebase to improve readability and conform to style guidelines.

NO_RELEASE_CHANGE