### PR TITLE
[Infra] Fix git status execution in setup_hooks.sh

### DIFF
--- a/tools/setup_hooks.sh
+++ b/tools/setup_hooks.sh
@@ -27,11 +27,11 @@ set -e
 
 echo "Running pre-commit hook: formatting and API generation..."
 
-PRE_STATUS="$(git status --porcelain)"
+PRE_STATUS="\$(git status --porcelain)"
 
 python3 "$REPO_ROOT/tools/firebase_checks.py"
 
-POST_STATUS="$(git status --porcelain)"
+POST_STATUS="\$(git status --porcelain)"
 
 if [ "\$PRE_STATUS" != "\$POST_STATUS" ]; then
     echo ""


### PR DESCRIPTION
Escaped the command substitution for PRE_STATUS and POST_STATUS to ensure the git status check is evaluated at runtime rather than during script initialization.