### PR TITLE
[Infra] Improve release notes link parsing

### DIFF
--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/MakeReleaseNotesTask.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/MakeReleaseNotesTask.kt
@@ -192,8 +192,8 @@ abstract class MakeReleaseNotesTask : DefaultTask() {
      * indentation to ensure the link appears on a new line.
      */
     private fun getLinkPrefix(linkPrefixRegex: Regex, text: String): String {
-      val linkPrefixMatch = linkPrefixRegex.find(text) ?: return text
-      return if (linkPrefixMatch.firstCapturedValue.isNotBlank()) "\n  " else ""
+      val linkPrefixMatch = linkPrefixRegex.find(text) ?: return ""
+      return if (linkPrefixMatch.firstCapturedValue.isNotBlank()) "\n  " else "  "
     }
 
     /**
@@ -256,7 +256,7 @@ abstract class MakeReleaseNotesTask : DefaultTask() {
      */
     private val LINK_REGEX =
       Regex(
-        "\\s*(?:GitHub )?(?:\\[|\\()#(\\d+)(?:\\]|\\))(?:\\(.+?\\))?(?:\\{:\\s*\\.external\\})?",
+        "\\s*(?:\\()?(?:GitHub )?(?:\\[|\\()#(\\d+)(?:\\]|\\))(?:\\(.+?\\))?(?:\\{:\\s*\\.external\\})?(?:\\))?",
         RegexOption.MULTILINE,
       )
 

--- a/plugins/src/test/resources/BasicProject/firebase-storage/CHANGELOG.md
+++ b/plugins/src/test/resources/BasicProject/firebase-storage/CHANGELOG.md
@@ -45,6 +45,27 @@ Note: We did some super cool stuff here!
 
 - [removed] some stuff that we didn't really like got removed
 
+- [fixed] Realtime query subscriptions now correctly throw an exception when
+  the Firebase Auth user changes, instead of silently stopping emitting.
+  ([#8283](https://github.com/firebase/firebase-android-sdk/pull/8283))
+
+- [fixed] Realtime query subscriptions could fail abruptly if the auth
+  token changed while connected.
+  ([#8312](https://github.com/firebase/firebase-android-sdk/pull/8312))
+
+- [fixed] An infinite loop could occur when Auth and/or App Check tokens were
+  refreshed.
+  ([#8319](https://github.com/firebase/firebase-android-sdk/pull/8319))
+
+- [fixed] Expired Auth and/or App Check tokens were not automatically refreshed
+  when rejected by the server upon connection.
+  ([#8346](https://github.com/firebase/firebase-android-sdk/pull/8346))
+
+- [changed] Realtime query subscriptions now include SDK type metadata
+  (core vs. generated SDK) in request headers, matching the behavior of
+  standard query executions.
+  ([#8356](https://github.com/firebase/firebase-android-sdk/pull/8356))
+
 # 24.5.0
 
 - [fixed] Fixed stack overflow caused by deeply nested server timestamps. (GitHub

--- a/plugins/src/test/resources/MakeReleaseNotes/release-notes.md
+++ b/plugins/src/test/resources/MakeReleaseNotes/release-notes.md
@@ -52,3 +52,24 @@ Note: We did some super cool stuff here!
 * {{unchanged}} Idk ig we did some stuff
 
 * {{removed}} some stuff that we didn't really like got removed
+
+* {{fixed}} Realtime query subscriptions now correctly throw an exception when
+  the Firebase Auth user changes, instead of silently stopping emitting.
+  (GitHub [#8283](//github.com/firebase/firebase-android-sdk/issues/8283){: .external})
+
+* {{fixed}} Realtime query subscriptions could fail abruptly if the auth
+  token changed while connected.
+  (GitHub [#8312](//github.com/firebase/firebase-android-sdk/issues/8312){: .external})
+
+* {{fixed}} An infinite loop could occur when Auth and/or App Check tokens were
+  refreshed.
+  (GitHub [#8319](//github.com/firebase/firebase-android-sdk/issues/8319){: .external})
+
+* {{fixed}} Expired Auth and/or App Check tokens were not automatically refreshed
+  when rejected by the server upon connection.
+  (GitHub [#8346](//github.com/firebase/firebase-android-sdk/issues/8346){: .external})
+
+* {{changed}} Realtime query subscriptions now include SDK type metadata
+  (core vs. generated SDK) in request headers, matching the behavior of
+  standard query executions.
+  (GitHub [#8356](//github.com/firebase/firebase-android-sdk/issues/8356){: .external})


### PR DESCRIPTION
Updated the LINK_REGEX to better capture GitHub issue links and adjusted getLinkPrefix to ensure consistent indentation for link references. These changes improve the formatting of generated release notes when parsing changelog entries.

Internal b/515363195