### PR TITLE
dataconnect(feat): add "jitter" to exponential backoff logic when reconnecting realtime streaming connections

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -4,7 +4,8 @@
   exponential backoff strategy.
   ([#8381](https://github.com/firebase/firebase-android-sdk/pull/8381),
   [#8421](https://github.com/firebase/firebase-android-sdk/pull/8421),
-  [#8446](https://github.com/firebase/firebase-android-sdk/pull/8446))
+  [#8446](https://github.com/firebase/firebase-android-sdk/pull/8446),
+  [#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
 
 # 17.3.2
 

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -5,7 +5,7 @@
   ([#8381](https://github.com/firebase/firebase-android-sdk/pull/8381),
   [#8421](https://github.com/firebase/firebase-android-sdk/pull/8421),
   [#8446](https://github.com/firebase/firebase-android-sdk/pull/8446),
-  [#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
+  [#8456](https://github.com/firebase/firebase-android-sdk/pull/8456))
 
 # 17.3.2
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -112,7 +112,7 @@ internal class DataConnectBidiConnectStream(
   private val random: Random,
 ) {
 
-  private val retryBackoff = RetryBackoffCalculator()
+  private val retryBackoff = RetryBackoffCalculator { random.nextDouble() - 0.5 }
   private val resetAndRetryEvent = ConflatedSignal<Unit>()
 
   val isPermanentlyFailed: Boolean

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectBidiConnectStream.kt
@@ -40,6 +40,7 @@ import google.firebase.dataconnect.proto.ResumeRequest as ResumeRequestProto
 import google.firebase.dataconnect.proto.StreamRequest as StreamRequestProto
 import google.firebase.dataconnect.proto.StreamResponse as StreamResponseProto
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
@@ -108,6 +109,7 @@ internal class DataConnectBidiConnectStream(
   private val grpcMetadata: DataConnectGrpcMetadata,
   private val coroutineScope: CoroutineScope,
   private val logger: Logger,
+  private val random: Random,
 ) {
 
   private val retryBackoff = RetryBackoffCalculator()

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -77,6 +77,7 @@ import io.grpc.android.AndroidChannelBuilder
 import java.lang.System.currentTimeMillis
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
+import kotlin.random.Random
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asExecutor
@@ -101,6 +102,7 @@ internal class DataConnectGrpcRPCs(
   private val cache: DataConnectCache?,
   parentLogger: Logger,
   private val networkConnectivityRestoredFlow: Flow<NetworkConnectivityRestored>,
+  private val random: Random,
 ) {
   private val logger =
     Logger("DataConnectGrpcRPCs").apply {
@@ -532,7 +534,8 @@ internal class DataConnectGrpcRPCs(
       connectCoroutineScope,
       Logger("DataConnectBidiConnectStream[sid=$streamId]").also {
         it.debug { "created by ${logger.nameWithId}" }
-      }
+      },
+      random,
     )
   }
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectFactory.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectFactory.kt
@@ -35,11 +35,12 @@ internal class FirebaseDataConnectFactory(
   private val nonBlockingExecutor: Executor,
   private val deferredAuthProvider: Deferred<InternalAuthProvider>,
   private val deferredAppCheckProvider: Deferred<InteropAppCheckTokenProvider>,
+  private val random: Random,
 ) {
 
   // Use the same instance of IdStringGenerator for every FirebaseDataConnect instance so that
   // all instances generate unique IDs.
-  private val idStringGenerator = IdStringGenerator(Random.Default)
+  private val idStringGenerator = IdStringGenerator(random)
 
   private val networkConnectivityRestoredFlow = networkConnectivityRestoredFlow(context)
 
@@ -95,6 +96,7 @@ internal class FirebaseDataConnectFactory(
       settings = settings ?: DataConnectSettings(),
       idStringGenerator = idStringGenerator,
       networkConnectivityRestoredFlow = networkConnectivityRestoredFlow,
+      random = random,
     )
 
   fun remove(instance: FirebaseDataConnect) {

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImpl.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImpl.kt
@@ -43,6 +43,7 @@ import com.google.firebase.dataconnect.util.ProtoUtil.calculateSha512
 import com.google.firebase.dataconnect.util.throwCombinedException
 import com.google.protobuf.Struct
 import java.util.concurrent.Executor
+import kotlin.random.Random
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -98,6 +99,7 @@ internal class FirebaseDataConnectImpl(
   override val settings: DataConnectSettings,
   override val idStringGenerator: IdStringGenerator,
   private val networkConnectivityRestoredFlow: Flow<NetworkConnectivityRestored>,
+  private val random: Random,
 ) : FirebaseDataConnectInternal {
 
   override val logger =
@@ -312,6 +314,7 @@ internal class FirebaseDataConnectImpl(
         cache = cache,
         parentLogger = logger,
         networkConnectivityRestoredFlow = networkConnectivityRestoredFlow,
+        random = random,
       )
 
     if (backendInfo.isEmulator) {

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectRegistrar.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectRegistrar.kt
@@ -31,6 +31,7 @@ import com.google.firebase.components.Qualified
 import com.google.firebase.dataconnect.*
 import com.google.firebase.platforminfo.LibraryVersionComponent
 import java.util.concurrent.Executor
+import kotlin.random.Random
 
 /**
  * [ComponentRegistrar] for setting up [FirebaseDataConnect].
@@ -60,6 +61,7 @@ internal class FirebaseDataConnectRegistrar : ComponentRegistrar {
             nonBlockingExecutor = container.get(nonBlockingExecutor),
             deferredAuthProvider = container.getDeferred(internalAuthProvider),
             deferredAppCheckProvider = container.getDeferred(interopAppCheckTokenProvider),
+            random = Random.Default,
           )
         }
         .build(),

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/RetryBackoffCalculator.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/RetryBackoffCalculator.kt
@@ -28,7 +28,7 @@ import kotlin.math.roundToLong
  * 0.5) to introduce random jitter into backoff durations. This function must be thread-safe (safe
  * to call concurrently).
  */
-internal class RetryBackoffCalculator(private val getRandomJitter: () -> Double = { 0.0 }) {
+internal class RetryBackoffCalculator(private val getRandomJitter: () -> Double) {
   private val nextBackoffMs = AtomicLong(INITIAL_BACKOFF_MS)
 
   /** Resets the backoff duration to the initial backoff value. */

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
@@ -931,6 +931,7 @@ class DataConnectGrpcRPCsUnitTest {
       cache = cache,
       parentLogger = mockLogger,
       networkConnectivityRestoredFlow = emptyFlow(),
+      random = Random.Default,
     )
   }
 

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectImplUnitTest.kt
@@ -294,6 +294,7 @@ class FirebaseDataConnectImplUnitTest {
         settings = Arb.dataConnect.dataConnectSettings().next(rs),
         idStringGenerator = IdStringGenerator(Random.Default),
         networkConnectivityRestoredFlow = emptyFlow(),
+        random = Random.Default,
       )
       .also { cleanups.register("close FirebaseDataConnectImpl") { it.close() } }
   }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -29,6 +29,7 @@ import com.google.firebase.dataconnect.QueryRef
 import com.google.firebase.dataconnect.core.DataConnectAuth.GetAuthTokenResult
 import com.google.firebase.dataconnect.core.DataConnectBidiConnectStream.Companion.setReconnectPendingAuthTokenForTesting
 import com.google.firebase.dataconnect.core.DataConnectBidiConnectStream.Companion.unsetReconnectPendingAuthTokenForTesting
+import com.google.firebase.dataconnect.core.RetryBackoffCalculatorTesting.backoffValues
 import com.google.firebase.dataconnect.testutil.CleanupsRule
 import com.google.firebase.dataconnect.testutil.DataConnectLogLevelRule
 import com.google.firebase.dataconnect.testutil.FirebaseAppUnitTestingRule
@@ -1655,9 +1656,7 @@ class QuerySubscriptionImplUnitTest {
       dataConnect(server, networkConnectivityRestoredFlow = networkConnectivityRestoredFlow)
     val subscription = querySubscription(dataConnect)
 
-    val backoffWaitTimes = getExpectedBackoffWaitTimes()
-
-    backoffWaitTimes.forEachIndexed { failCountBeforeRetrying, lastBackoffWaitTime ->
+    backoffValues.forEachIndexed { failCountBeforeRetrying, lastBackoffWaitTime ->
       turbineScope {
         val serverCollector = server.events.testIn(backgroundScope, name = "serverCollector")
         val clientCollector = subscription.flow.testIn(backgroundScope, name = "clientCollector")
@@ -1674,12 +1673,12 @@ class QuerySubscriptionImplUnitTest {
           val time1 = @OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime
           serverCollector.awaitCall()
           val time2 = @OptIn(ExperimentalCoroutinesApi::class) testScheduler.currentTime
-          check(time2 - time1 == backoffWaitTimes[retryIndex]) {
+          check(time2 - time1 == backoffValues[retryIndex]) {
             "internal error m6gwemnpw7: something is wrong with the test logic because the " +
               "expected backoff was different than expected; once this logic is fixed, " +
               "make sure to also fix the code after failConnection() below; " +
               "time2=$time2, time1=$time1 time2-time1=${time2 - time1}, retryIndex=$retryIndex, " +
-              "backoffWaitTimes[retryIndex]=${backoffWaitTimes[retryIndex]}, " +
+              "backoffValues[retryIndex]=${backoffValues[retryIndex]}, " +
               "failCountBeforeRetrying=$failCountBeforeRetrying"
           }
         }
@@ -1691,7 +1690,7 @@ class QuerySubscriptionImplUnitTest {
             delayMillis = lastBackoffWaitTime / 3,
             emit = networkConnectivityRestoredFlow::emit,
             serverCollector,
-            firstBackoffWaitTime = backoffWaitTimes[0]
+            firstBackoffWaitTime = backoffValues[0]
           )
         )
 
@@ -1755,7 +1754,10 @@ class QuerySubscriptionImplUnitTest {
 
     val waitTimes = times.zipWithNext { a, b -> b - a }
     check(waitTimes.size == 99) { "internal error dy3gcskmvt: waitTimes.size=${waitTimes.size}" }
-    val expectedWaitTimes = getExpectedBackoffWaitTimes(waitTimes.size)
+    val expectedWaitTimes = buildList {
+      addAll(backoffValues)
+      while (size < waitTimes.size) add(last())
+    }
     waitTimes shouldContainExactly expectedWaitTimes
   }
 
@@ -2218,25 +2220,6 @@ private val retryableFailureGrpcStatusCodes: List<Status.Code> =
 
 private fun FirebaseDataConnectImpl.googApiClientHeaderValue(callerSdkType: CallerSdkType): String =
   grpcRPCs.grpcMetadata.googApiClientHeaderValue(callerSdkType)
-
-private fun getExpectedBackoffWaitTimes(count: Int = -1): List<Long> {
-  require(count >= -1) { "invalid count: $count [ht5kab7ehc]" }
-  val calculator = RetryBackoffCalculator { 0.0 }
-  val list = mutableListOf<Long>()
-
-  while (true) {
-    if (count >= 0) {
-      if (list.size == count) {
-        break
-      }
-    } else if (list.size >= 2 && list.last() == list.secondLast()) {
-      break
-    }
-    list.add(calculator.next())
-  }
-
-  return list.toList()
-}
 
 private fun <T> List<T>.secondLast(): T = get(size - 2)
 

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -2078,7 +2078,7 @@ class QuerySubscriptionImplUnitTest {
       settings = settings,
       idStringGenerator = idStringGenerator ?: IdStringGenerator(Random.Default),
       networkConnectivityRestoredFlow = networkConnectivityRestoredFlow,
-      random = Random.Default,
+      random = ZeroJitterRandom,
     )
   }
 
@@ -2239,3 +2239,8 @@ private fun getExpectedBackoffWaitTimes(count: Int = -1): List<Long> {
 }
 
 private fun <T> List<T>.secondLast(): T = get(size - 2)
+
+private object ZeroJitterRandom : Random() {
+  override fun nextBits(bitCount: Int): Int = 0
+  override fun nextDouble(): Double = 0.5
+}

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -30,6 +30,9 @@ import com.google.firebase.dataconnect.core.DataConnectAuth.GetAuthTokenResult
 import com.google.firebase.dataconnect.core.DataConnectBidiConnectStream.Companion.setReconnectPendingAuthTokenForTesting
 import com.google.firebase.dataconnect.core.DataConnectBidiConnectStream.Companion.unsetReconnectPendingAuthTokenForTesting
 import com.google.firebase.dataconnect.core.RetryBackoffCalculatorTesting.backoffValues
+import com.google.firebase.dataconnect.core.RetryBackoffCalculatorTesting.jitterTestCase
+import com.google.firebase.dataconnect.core.RetryBackoffCalculatorTesting.maxJitterBackoffValues
+import com.google.firebase.dataconnect.core.RetryBackoffCalculatorTesting.minJitterBackoffValues
 import com.google.firebase.dataconnect.testutil.CleanupsRule
 import com.google.firebase.dataconnect.testutil.DataConnectLogLevelRule
 import com.google.firebase.dataconnect.testutil.FirebaseAppUnitTestingRule
@@ -116,6 +119,8 @@ import io.kotest.property.checkAll
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -1732,9 +1737,45 @@ class QuerySubscriptionImplUnitTest {
   }
 
   @Test
-  fun `subsequent connection failures backoff exponentially`() = runTest {
+  fun `subsequent connection failures backoff exponentially, no jitter`() = runTest {
+    testSubsequentConnectionFailuresBackoffExponentially(
+      random = ZeroJitterRandom,
+      expectedBackoffs = backoffValues,
+    )
+  }
+
+  @Test
+  fun `subsequent connection failures backoff exponentially, min jitter`() = runTest {
+    testSubsequentConnectionFailuresBackoffExponentially(
+      random = MinJitterRandom,
+      expectedBackoffs = minJitterBackoffValues,
+    )
+  }
+
+  @Test
+  fun `subsequent connection failures backoff exponentially, max jitter`() = runTest {
+    testSubsequentConnectionFailuresBackoffExponentially(
+      random = MaxJitterRandom,
+      expectedBackoffs = maxJitterBackoffValues,
+    )
+  }
+
+  @Test
+  fun `subsequent connection failures backoff exponentially, varying jitter`() = runTest {
+    checkAll(propTestConfig, Arb.jitterTestCase()) { (jitters, expectedBackoffs) ->
+      testSubsequentConnectionFailuresBackoffExponentially(
+        random = SequenceRandom(jitters.asSequence() + generateSequence { jitters.last() }),
+        expectedBackoffs = expectedBackoffs,
+      )
+    }
+  }
+
+  private suspend fun TestScope.testSubsequentConnectionFailuresBackoffExponentially(
+    random: Random,
+    expectedBackoffs: List<Long>,
+  ) {
     val server = runningInProcessDataConnectServer()
-    val dataConnect = dataConnect(server)
+    val dataConnect = dataConnect(server, random = random)
     val subscription = querySubscription(dataConnect)
 
     val times = mutableListOf<Long>()
@@ -1755,7 +1796,7 @@ class QuerySubscriptionImplUnitTest {
     val waitTimes = times.zipWithNext { a, b -> b - a }
     check(waitTimes.size == 99) { "internal error dy3gcskmvt: waitTimes.size=${waitTimes.size}" }
     val expectedWaitTimes = buildList {
-      addAll(backoffValues)
+      addAll(expectedBackoffs)
       while (size < waitTimes.size) add(last())
     }
     waitTimes shouldContainExactly expectedWaitTimes
@@ -2036,6 +2077,7 @@ class QuerySubscriptionImplUnitTest {
     deferredAppCheckProvider: com.google.firebase.inject.Deferred<InteropAppCheckTokenProvider> =
       UnavailableDeferred(),
     networkConnectivityRestoredFlow: Flow<NetworkConnectivityRestored> = emptyFlow(),
+    random: Random = ZeroJitterRandom,
   ): FirebaseDataConnectImpl =
     dataConnect(
       server.port,
@@ -2043,6 +2085,7 @@ class QuerySubscriptionImplUnitTest {
       deferredAuthProvider,
       deferredAppCheckProvider,
       networkConnectivityRestoredFlow,
+      random,
     )
 
   private fun TestScope.dataConnect(
@@ -2053,6 +2096,7 @@ class QuerySubscriptionImplUnitTest {
     deferredAppCheckProvider: com.google.firebase.inject.Deferred<InteropAppCheckTokenProvider> =
       UnavailableDeferred(),
     networkConnectivityRestoredFlow: Flow<NetworkConnectivityRestored> = emptyFlow(),
+    random: Random = ZeroJitterRandom,
   ): FirebaseDataConnectImpl {
     val executor = StandardTestDispatcher(testScheduler).asExecutor()
 
@@ -2080,7 +2124,7 @@ class QuerySubscriptionImplUnitTest {
       settings = settings,
       idStringGenerator = idStringGenerator ?: IdStringGenerator(Random.Default),
       networkConnectivityRestoredFlow = networkConnectivityRestoredFlow,
-      random = ZeroJitterRandom,
+      random = random,
     )
   }
 
@@ -2226,4 +2270,26 @@ private fun <T> List<T>.secondLast(): T = get(size - 2)
 private object ZeroJitterRandom : Random() {
   override fun nextBits(bitCount: Int): Int = 0
   override fun nextDouble(): Double = 0.5
+}
+
+private object MinJitterRandom : Random() {
+  override fun nextBits(bitCount: Int): Int = 0
+  override fun nextDouble(): Double = 0.0
+}
+
+private object MaxJitterRandom : Random() {
+  override fun nextBits(bitCount: Int): Int = 0
+  override fun nextDouble(): Double = 1.0
+}
+
+private class SequenceRandom(jitters: Sequence<Double>) : Random() {
+
+  private val lock = ReentrantLock()
+  private val iterator = jitters.iterator()
+
+  override fun nextBits(bitCount: Int): Int = 0
+
+  override fun nextDouble(): Double {
+    return lock.withLock { iterator.next() + 0.5 }
+  }
 }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -2078,6 +2078,7 @@ class QuerySubscriptionImplUnitTest {
       settings = settings,
       idStringGenerator = idStringGenerator ?: IdStringGenerator(Random.Default),
       networkConnectivityRestoredFlow = networkConnectivityRestoredFlow,
+      random = Random.Default,
     )
   }
 

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -1755,7 +1755,7 @@ class QuerySubscriptionImplUnitTest {
 
     val waitTimes = times.zipWithNext { a, b -> b - a }
     check(waitTimes.size == 99) { "internal error dy3gcskmvt: waitTimes.size=${waitTimes.size}" }
-    val expectedWaitTimes = getExpectedBackoffWaitTimes(99)
+    val expectedWaitTimes = getExpectedBackoffWaitTimes(waitTimes.size)
     waitTimes shouldContainExactly expectedWaitTimes
   }
 
@@ -2221,7 +2221,7 @@ private fun FirebaseDataConnectImpl.googApiClientHeaderValue(callerSdkType: Call
 
 private fun getExpectedBackoffWaitTimes(count: Int = -1): List<Long> {
   require(count >= -1) { "invalid count: $count [ht5kab7ehc]" }
-  val calculator = RetryBackoffCalculator()
+  val calculator = RetryBackoffCalculator { 0.0 }
   val list = mutableListOf<Long>()
 
   while (true) {

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RetryBackoffCalculatorTesting.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RetryBackoffCalculatorTesting.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.dataconnect.core
+
+import io.kotest.assertions.print.print
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.arbitrary
+import kotlin.math.roundToLong
+
+object RetryBackoffCalculatorTesting {
+
+  val backoffValues: List<Long> =
+    listOf(
+      1000,
+      1750,
+      3063,
+      5360,
+      9380,
+      16415,
+      28726,
+      50271,
+      87974,
+      153955,
+      269421,
+      471487,
+      600000,
+    )
+
+  val minJitterBackoffValues: List<Long> =
+    listOf(
+      500,
+      875,
+      1532,
+      2680,
+      4690,
+      8208,
+      14363,
+      25136,
+      43987,
+      76978,
+      134711,
+      235744,
+      300000,
+    )
+
+  val maxJitterBackoffValues: List<Long> =
+    listOf(
+      1500,
+      2625,
+      4595,
+      8040,
+      14070,
+      24623,
+      43089,
+      75407,
+      131961,
+      230933,
+      404132,
+      707231,
+      900000,
+    )
+
+  data class JitterTestCase(
+    val jitters: List<Double>,
+    val expectedBackoffs: List<Long>,
+  ) {
+
+    init {
+      check(jitters.size == expectedBackoffs.size) {
+        "internal error yds47wscpa: jitters.size=${jitters.size} must equal " +
+          "expectedBackoffs.size=${expectedBackoffs.size}"
+      }
+    }
+
+    override fun toString() =
+      "JitterTestCase(jitters=${jitters.print().value}, " +
+        "expectedBackoffs=${expectedBackoffs.print().value})"
+  }
+
+  fun Arb.Companion.jitterTestCase(): Arb<JitterTestCase> {
+    val unjitteredBackoffValues = backoffValues + List(5) { backoffValues.last() }
+    return arbitrary { rs ->
+      val jitters = List(unjitteredBackoffValues.size) { rs.random.nextDouble() - 0.5 }
+      val jitteredBackoffValues =
+        unjitteredBackoffValues.zip(jitters).map { (backoff, jitter) ->
+          backoff + (backoff * jitter).roundToLong()
+        }
+      JitterTestCase(jitters, jitteredBackoffValues)
+    }
+  }
+}

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RetryBackoffCalculatorUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RetryBackoffCalculatorUnitTest.kt
@@ -42,14 +42,14 @@ class RetryBackoffCalculatorUnitTest {
 
   @Test
   fun `next() first call returns initial backoff`() {
-    val retryBackoffCalculator = RetryBackoffCalculator()
+    val retryBackoffCalculator = RetryBackoffCalculator { 0.0 }
     retryBackoffCalculator.next() shouldBe 1000L
   }
 
   @Test
   fun `next() after reset() returns initial backoff`() = runTest {
     checkAll(propTestConfig, Arb.int(0..100)) { nextCallCountBeforeReset ->
-      val retryBackoffCalculator = RetryBackoffCalculator()
+      val retryBackoffCalculator = RetryBackoffCalculator { 0.0 }
       repeat(nextCallCountBeforeReset) { retryBackoffCalculator.next() }
       retryBackoffCalculator.reset()
 
@@ -59,13 +59,13 @@ class RetryBackoffCalculatorUnitTest {
 
   @Test
   fun `next() returns correct values until reaching the max value`() {
-    val retryBackoffCalculator = RetryBackoffCalculator()
+    val retryBackoffCalculator = RetryBackoffCalculator { 0.0 }
     backoffValues.forEach { expected -> retryBackoffCalculator.next() shouldBe expected }
   }
 
   @Test
   fun `next() never returns greater than the max value`() {
-    val retryBackoffCalculator = RetryBackoffCalculator()
+    val retryBackoffCalculator = RetryBackoffCalculator { 0.0 }
     repeat(1000) {
       withClue("iteration=$it") { retryBackoffCalculator.next() shouldBeLessThanOrEqual 600000L }
     }
@@ -73,7 +73,7 @@ class RetryBackoffCalculatorUnitTest {
 
   @Test
   fun `next() returns the max value once it is reached`() {
-    val retryBackoffCalculator = RetryBackoffCalculator()
+    val retryBackoffCalculator = RetryBackoffCalculator { 0.0 }
     var lastValue = retryBackoffCalculator.next()
     while (true) {
       val value = retryBackoffCalculator.next()
@@ -89,7 +89,7 @@ class RetryBackoffCalculatorUnitTest {
   @Test
   fun `reset() always resets`() = runTest {
     checkAll(propTestConfig, Arb.list(Arb.int(0..20), 20..20)) { interveningNextCallCounts ->
-      val retryBackoffCalculator = RetryBackoffCalculator()
+      val retryBackoffCalculator = RetryBackoffCalculator { 0.0 }
       interveningNextCallCounts.forEach { count ->
         if (count > 0) {
           retryBackoffCalculator.next() shouldBe 1000L
@@ -102,7 +102,7 @@ class RetryBackoffCalculatorUnitTest {
 
   @Test
   fun `next() concurrent calls behave correctly`() = runTest {
-    val retryBackoffCalculator = RetryBackoffCalculator()
+    val retryBackoffCalculator = RetryBackoffCalculator { 0.0 }
     val latch = SuspendingCountDownLatch(50)
 
     val jobs =
@@ -115,7 +115,8 @@ class RetryBackoffCalculatorUnitTest {
 
     val results = jobs.awaitAll()
     val expected =
-      RetryBackoffCalculator().let { testCalculator -> List(jobs.size) { testCalculator.next() } }
+      RetryBackoffCalculator { 0.0 }
+        .let { testCalculator -> List(jobs.size) { testCalculator.next() } }
     results shouldContainExactlyInAnyOrder expected
   }
 

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RetryBackoffCalculatorUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RetryBackoffCalculatorUnitTest.kt
@@ -16,8 +16,11 @@
 
 package com.google.firebase.dataconnect.core
 
+import com.google.firebase.dataconnect.core.RetryBackoffCalculatorTesting.backoffValues
+import com.google.firebase.dataconnect.core.RetryBackoffCalculatorTesting.jitterTestCase
+import com.google.firebase.dataconnect.core.RetryBackoffCalculatorTesting.maxJitterBackoffValues
+import com.google.firebase.dataconnect.core.RetryBackoffCalculatorTesting.minJitterBackoffValues
 import com.google.firebase.dataconnect.testutil.SuspendingCountDownLatch
-import io.kotest.assertions.print.print
 import io.kotest.assertions.withClue
 import io.kotest.common.ExperimentalKotest
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
@@ -27,11 +30,9 @@ import io.kotest.property.Arb
 import io.kotest.property.EdgeConfig
 import io.kotest.property.PropTestConfig
 import io.kotest.property.ShrinkingMode
-import io.kotest.property.arbitrary.arbitrary
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.list
 import io.kotest.property.checkAll
-import kotlin.math.roundToLong
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -134,7 +135,7 @@ class RetryBackoffCalculatorUnitTest {
 
   @Test
   fun `next() with varying jitter scales backoff correctly`() = runTest {
-    checkAll(propTestConfig, jitterTestCaseArb()) { (jitters, expectedBackoffs) ->
+    checkAll(propTestConfig, Arb.jitterTestCase()) { (jitters, expectedBackoffs) ->
       val retryBackoffCalculator = RetryBackoffCalculator(jitters.iterator()::next)
       expectedBackoffs.forEach { expected -> retryBackoffCalculator.next() shouldBe expected }
     }
@@ -148,83 +149,3 @@ private val propTestConfig =
     edgeConfig = EdgeConfig(edgecasesGenerationProbability = 0.2),
     shrinkingMode = ShrinkingMode.Off,
   )
-
-private val backoffValues: List<Long> =
-  listOf(
-    1000,
-    1750,
-    3063,
-    5360,
-    9380,
-    16415,
-    28726,
-    50271,
-    87974,
-    153955,
-    269421,
-    471487,
-    600000,
-  )
-
-private val minJitterBackoffValues: List<Long> =
-  listOf(
-    500,
-    875,
-    1532,
-    2680,
-    4690,
-    8208,
-    14363,
-    25136,
-    43987,
-    76978,
-    134711,
-    235744,
-    300000,
-  )
-
-private val maxJitterBackoffValues: List<Long> =
-  listOf(
-    1500,
-    2625,
-    4595,
-    8040,
-    14070,
-    24623,
-    43089,
-    75407,
-    131961,
-    230933,
-    404132,
-    707231,
-    900000,
-  )
-
-private data class JitterTestCase(
-  val jitters: List<Double>,
-  val expectedBackoffs: List<Long>,
-) {
-
-  init {
-    check(jitters.size == expectedBackoffs.size) {
-      "internal error yds47wscpa: jitters.size=${jitters.size} must equal " +
-        "expectedBackoffs.size=${expectedBackoffs.size}"
-    }
-  }
-
-  override fun toString() =
-    "JitterTestCase(jitters=${jitters.print().value}, " +
-      "expectedBackoffs=${expectedBackoffs.print().value})"
-}
-
-private fun jitterTestCaseArb(): Arb<JitterTestCase> {
-  val unjitteredBackoffValues = backoffValues + List(5) { backoffValues.last() }
-  return arbitrary { rs ->
-    val jitters = List(unjitteredBackoffValues.size) { rs.random.nextDouble() - 0.5 }
-    val jitteredBackoffValues =
-      unjitteredBackoffValues.zip(jitters).map { (backoff, jitter) ->
-        backoff + (backoff * jitter).roundToLong()
-      }
-    JitterTestCase(jitters, jitteredBackoffValues)
-  }
-}


### PR DESCRIPTION
This PR integrates random jitter into the exponential backoff strategy used by `firebase-dataconnect` when reconnecting query subscriptions. This is achieved by wiring a `Random` instance from `FirebaseDataConnectRegistrar` through to `DataConnectBidiConnectStream` to introduce random jitter between -0.5 and 0.5 to the exponential backoff calculation. This helps reduce thundering herd problems on reconnects.

### Highlights

* **Jittered Exponential Backoff**: Configured `DataConnectBidiConnectStream` to use a random jitter factor (varying between -0.5 and 0.5) with `RetryBackoffCalculator` for reconnecting query subscriptions.
* **Random Source Wiring**: Threaded a `Random` instance from `FirebaseDataConnectRegistrar` down through `FirebaseDataConnectFactory`, `FirebaseDataConnectImpl`, and `DataConnectGrpcRPCs` to `DataConnectBidiConnectStream`.
* **Improved Test Coverage**: Expanded the subscription retry tests in `QuerySubscriptionImplUnitTest` to cover zero, minimum, maximum, and varying jitter using property-based tests.
* **Test Code Consolidation**: Created `RetryBackoffCalculatorTesting` to share common backoff test constants and generators, reducing duplication across test files.

<details>

<summary><b>Changelog</b></summary>

* **CHANGELOG.md**
  * Updated to document the jitter addition under the current release section.
* **DataConnectBidiConnectStream.kt**
  * Added a `Random` parameter to the constructor and initialized `RetryBackoffCalculator` with a lambda generating jitter between -0.5 and 0.5.
* **DataConnectGrpcRPCs.kt**
  * Added `random: Random` constructor parameter and passed it when instantiating `DataConnectBidiConnectStream`.
* **FirebaseDataConnectFactory.kt**
  * Added `random: Random` constructor parameter, used it to initialize `idStringGenerator`, and passed it to `FirebaseDataConnectImpl`.
* **FirebaseDataConnectImpl.kt**
  * Added `random: Random` constructor parameter and passed it to `DataConnectGrpcRPCs`.
* **FirebaseDataConnectRegistrar.kt**
  - Configured dependency injection to pass `Random.Default` to `FirebaseDataConnectFactory`.
* **RetryBackoffCalculator.kt**
  * Removed default argument for `getRandomJitter` constructor parameter to require caller-specified jitter strategy.
* **DataConnectGrpcRPCsUnitTest.kt**
  * Updated constructor call to pass `Random.Default`.
* **FirebaseDataConnectImplUnitTest.kt**
  * Updated constructor call to pass `Random.Default`.
* **QuerySubscriptionImplUnitTest.kt**
  * Updated test helper to accept `Random` and verify that connection retry wait times match expected exponential backoff with zero, min, max, or varying jitter.
* **RetryBackoffCalculatorTesting.kt**
  * Created a new test utility object to hold shared constants (`backoffValues`, `minJitterBackoffValues`, `maxJitterBackoffValues`) and an `Arb` generator for jitter test cases.
* **RetryBackoffCalculatorUnitTest.kt**
  * Refactored to use the shared constants in `RetryBackoffCalculatorTesting` and updated calculator instantiation to provide explicit jitter lambdas.

</details>