### PR TITLE
dataconnect(chore): Update exponential backoff parameters to match firestore

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -6,7 +6,7 @@
   [#8421](https://github.com/firebase/firebase-android-sdk/pull/8421),
   [#8446](https://github.com/firebase/firebase-android-sdk/pull/8446),
   [#8456](https://github.com/firebase/firebase-android-sdk/pull/8456),
-  [#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
+  [#8460](https://github.com/firebase/firebase-android-sdk/pull/8460))
 
 # 17.3.2
 

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -5,7 +5,8 @@
   ([#8381](https://github.com/firebase/firebase-android-sdk/pull/8381),
   [#8421](https://github.com/firebase/firebase-android-sdk/pull/8421),
   [#8446](https://github.com/firebase/firebase-android-sdk/pull/8446),
-  [#8456](https://github.com/firebase/firebase-android-sdk/pull/8456))
+  [#8456](https://github.com/firebase/firebase-android-sdk/pull/8456),
+  [#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
 
 # 17.3.2
 

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/RetryBackoffCalculator.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/RetryBackoffCalculator.kt
@@ -56,8 +56,8 @@ internal class RetryBackoffCalculator(private val getRandomJitter: () -> Double)
   private companion object {
 
     const val INITIAL_BACKOFF_MS: Long = 1000L
-    const val MAX_BACKOFF_MS: Long = 600_000L
-    const val MULTIPLIER: Double = 1.75
+    const val MAX_BACKOFF_MS: Long = 60_000L
+    const val MULTIPLIER: Double = 1.5
 
     fun calculateNextBackoffMs(currentBackoffMs: Long): Long =
       (currentBackoffMs * MULTIPLIER).roundToLong().coerceAtMost(MAX_BACKOFF_MS)

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RetryBackoffCalculatorTesting.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RetryBackoffCalculatorTesting.kt
@@ -26,52 +26,53 @@ object RetryBackoffCalculatorTesting {
   val backoffValues: List<Long> =
     listOf(
       1000,
-      1750,
-      3063,
-      5360,
-      9380,
-      16415,
-      28726,
-      50271,
-      87974,
-      153955,
-      269421,
-      471487,
-      600000,
+      1500,
+      2250,
+      3375,
+      5063,
+      7595,
+      11393,
+      17090,
+      25635,
+      38453,
+      57680,
+      60000,
     )
+
+  val minBackoffValue: Long = backoffValues.first().also { check(it == 1000L) }
+
+  val maxBackoffValue: Long = backoffValues.last().also { check(it == 60_000L) }
 
   val minJitterBackoffValues: List<Long> =
     listOf(
       500,
-      875,
-      1532,
-      2680,
-      4690,
-      8208,
-      14363,
-      25136,
-      43987,
-      76978,
-      134711,
-      235744,
-      300000,
+      750,
+      1125,
+      1688,
+      2532,
+      3798,
+      5697,
+      8545,
+      12818,
+      19227,
+      28840,
+      30000,
     )
 
   val maxJitterBackoffValues: List<Long> =
     listOf(
       1500,
-      2625,
-      4595,
-      8040,
-      14070,
-      24623,
-      43089,
-      75407,
-      131961,
-      230933,
-      404132,
-      707231,
-      900000,
+      2250,
+      3375,
+      5063,
+      7595,
+      11393,
+      17090,
+      25635,
+      38453,
+      57680,
+      86520,
+      90000,
     )
 
   data class JitterTestCase(

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RetryBackoffCalculatorUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/RetryBackoffCalculatorUnitTest.kt
@@ -18,7 +18,9 @@ package com.google.firebase.dataconnect.core
 
 import com.google.firebase.dataconnect.core.RetryBackoffCalculatorTesting.backoffValues
 import com.google.firebase.dataconnect.core.RetryBackoffCalculatorTesting.jitterTestCase
+import com.google.firebase.dataconnect.core.RetryBackoffCalculatorTesting.maxBackoffValue
 import com.google.firebase.dataconnect.core.RetryBackoffCalculatorTesting.maxJitterBackoffValues
+import com.google.firebase.dataconnect.core.RetryBackoffCalculatorTesting.minBackoffValue
 import com.google.firebase.dataconnect.core.RetryBackoffCalculatorTesting.minJitterBackoffValues
 import com.google.firebase.dataconnect.testutil.SuspendingCountDownLatch
 import io.kotest.assertions.withClue
@@ -44,7 +46,7 @@ class RetryBackoffCalculatorUnitTest {
   @Test
   fun `next() first call returns initial backoff`() {
     val retryBackoffCalculator = RetryBackoffCalculator { 0.0 }
-    retryBackoffCalculator.next() shouldBe 1000L
+    retryBackoffCalculator.next() shouldBe minBackoffValue
   }
 
   @Test
@@ -54,7 +56,7 @@ class RetryBackoffCalculatorUnitTest {
       repeat(nextCallCountBeforeReset) { retryBackoffCalculator.next() }
       retryBackoffCalculator.reset()
 
-      retryBackoffCalculator.next() shouldBe 1000L
+      retryBackoffCalculator.next() shouldBe minBackoffValue
     }
   }
 
@@ -68,7 +70,9 @@ class RetryBackoffCalculatorUnitTest {
   fun `next() never returns greater than the max value`() {
     val retryBackoffCalculator = RetryBackoffCalculator { 0.0 }
     repeat(1000) {
-      withClue("iteration=$it") { retryBackoffCalculator.next() shouldBeLessThanOrEqual 600000L }
+      withClue("iteration=$it") {
+        retryBackoffCalculator.next() shouldBeLessThanOrEqual maxBackoffValue
+      }
     }
   }
 
@@ -78,13 +82,15 @@ class RetryBackoffCalculatorUnitTest {
     var lastValue = retryBackoffCalculator.next()
     while (true) {
       val value = retryBackoffCalculator.next()
-      if (value == lastValue || value >= 600000L) {
+      if (value == lastValue || value >= maxBackoffValue) {
         break
       }
       lastValue = value
     }
 
-    repeat(1000) { withClue("iteration=$it") { retryBackoffCalculator.next() shouldBe 600000L } }
+    repeat(1000) {
+      withClue("iteration=$it") { retryBackoffCalculator.next() shouldBe maxBackoffValue }
+    }
   }
 
   @Test
@@ -93,7 +99,7 @@ class RetryBackoffCalculatorUnitTest {
       val retryBackoffCalculator = RetryBackoffCalculator { 0.0 }
       interveningNextCallCounts.forEach { count ->
         if (count > 0) {
-          retryBackoffCalculator.next() shouldBe 1000L
+          retryBackoffCalculator.next() shouldBe minBackoffValue
         }
         repeat(count - 1) { retryBackoffCalculator.next() }
         retryBackoffCalculator.reset()


### PR DESCRIPTION
This PR updates the exponential backoff parameters in the `firebase-dataconnect` module to match those used by Firestore, reducing both the maximum backoff duration and the growth multiplier. It also updates the associated unit tests and testing helper structures to reflect these parameters.

### Highlights

* **Tuned Exponential Backoff Parameters**: Reduced the maximum backoff limit from 10 minutes (`600_000L`) to 1 minute (`60_000L`) and adjusted the growth multiplier from `1.75` to `1.5` in `RetryBackoffCalculator` to match Firestore's retry behavior.
* **Updated Test Values & Refactored Assertions**: Modified the pre-calculated expected backoff sequences in `RetryBackoffCalculatorTesting` and refactored assertions in `RetryBackoffCalculatorUnitTest` to use the new helper constants instead of hardcoded values.

<details>
<summary><b>Changelog</b></summary>

* **CHANGELOG.md**
  * Added a changelog entry.
* **RetryBackoffCalculator.kt**
  * Decreased the maximum backoff limit to 60 seconds (`60_000L`) and the multiplier to `1.5`.
* **RetryBackoffCalculatorTesting.kt**
  * Updated the lists of expected backoff values to match the new multiplier and max limit.
  * Added `minBackoffValue` and `maxBackoffValue` helper constants.
* **RetryBackoffCalculatorUnitTest.kt**
  * Refactored test assertions to use the new `minBackoffValue` and `maxBackoffValue` helper constants instead of hardcoded numbers.

</details>