### PR TITLE
dataconnect(test): fix test flake due to unconsumed flow events when cancelling flow collection

### DIFF
--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -373,12 +373,14 @@ class QuerySubscriptionImplUnitTest {
 
       // Specify drop(1) so that we don't close the very last connection as that will shut down
       // the entire connection, confusing the logic below.
+      val droppedClientCollector = clientCollectors[1].first()
       clientCollectors[1].drop(1).forEach { clientCollector ->
         clientCollector.cancelAndIgnoreRemainingEvents()
         val requestId = serverCollector.awaitUntilCancelStreamRequest().streamRequest.requestId
         requestId shouldBeIn requestIds
         requestIds.removeAt(requestIds.indexOf(requestId))
       }
+      droppedClientCollector.cancelAndIgnoreRemainingEvents()
 
       serverCollector.cancelAndIgnoreRemainingEvents()
     }


### PR DESCRIPTION
Fix a bug in the data connect test `cancel message is sent after last unsubscription for a query` in `QuerySubscriptionImplUnitTest`. The bug was exposed when the entire test was wrapped in a try/finally block where the finally block (correctly) called `dataConnect.suspendingClose()`. For some reason, this exposed an uncancelled turbine by failing with this error:

```
TurbineAssertionError: Unconsumed events found for clientCollector5:
 - Complete
	at app.cash.turbine.TurbineAssertionError$Companion.invoke(TurbineAssertionError.kt:32)
	at app.cash.turbine.ChannelTurbine.ensureAllEventsConsumed(Turbine.kt:246)
	at app.cash.turbine.FlowKt.testIn_5_5nbZA$lambda$0(flow.kt:189)
...
	at kotlinx.coroutines.test.TestBuildersKt.runTest-8Mi8wO0$default(Unknown Source)
	at com.google.firebase.dataconnect.core.QuerySubscriptionImplUnitTest.cancel message is sent after last unsubscription for a query(QuerySubscriptionImplUnitTest.kt:340)
```

Ensuring that `cancelAndIgnoreRemainingEvents()` is called on the problematic Turbine fixes this spurious test failure.