### PR TITLE
[AI] Update location docs and notes for Firebase AI

### DIFF
--- a/ai-logic/firebase-ai/CHANGELOG.md
+++ b/ai-logic/firebase-ai/CHANGELOG.md
@@ -6,9 +6,14 @@
   `GenerativeBackend.agentPlatform` to reflect the renaming of Vertex
   AI to Gemini Enterprise Agent Platform. (#8437)
 
-  Note: The default location is now `global` instead of `us-central1` (no other
-  functionality has changed). To continue using `us-central1`, specify
-  `GenerativeBackend.agentPlatform(location = "us-central1"))`.
+  Note: The only difference for `GenerativeBackend.agentPlatform` is the default
+  [location for accessing the model](https://firebase.google.com/docs/ai-logic/locations?api=vertex).
+  The default location for `GenerativeBackend.agentPlatform` is `global`, whereas
+  the default location for `GenerativeBackend.vertexAI` is `us-central1`. To use
+  `us-central1` with `GenerativeBackend.agentPlatform`, specify
+  `GenerativeBackend.agentPlatform(location = "us-central1")` when
+  initializing the SDK. However, note that most new Gemini models do
+  not support `us-central1`.
 
 # 17.14.0
 

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/common/APIController.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/common/APIController.kt
@@ -466,7 +466,7 @@ private suspend fun validateResponse(response: HttpResponse) {
   if (response.status == HttpStatusCode.NotFound && response.contentType() == htmlContentType)
     throw ServerException(
       """URL not found. Please verify the location used to create the `FirebaseAI` object
-          | See https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#available-regions
+          | See https://firebase.google.com/docs/ai-logic/locations?api=vertex#available-locations
           | for the list of available locations. Raw response: ${response.bodyAsText()}"""
         .trimMargin()
     )

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/Exceptions.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/Exceptions.kt
@@ -125,7 +125,7 @@ internal constructor(message: String, cause: Throwable? = null) :
  * The user's location (region) is not supported by the API.
  *
  * See the documentation for a
- * [list of regions](https://firebase.google.com/docs/vertex-ai/locations?platform=android#available-locations)
+ * [list of regions](https://firebase.google.com/docs/ai-logic/locations?api=vertex#available-locations)
  * (countries and territories) where the API is available.
  */
 // TODO(rlazo): Add secondary constructor to pass through the message?
@@ -178,7 +178,7 @@ internal constructor(
  * The specified Vertex AI location is invalid.
  *
  * For a list of valid locations, see
- * [Vertex AI locations.](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#available-regions)
+ * [locations.](https://firebase.google.com/docs/vertex-ai/locations?platform=android#available-locations)
  */
 public class InvalidLocationException
 internal constructor(location: String, cause: Throwable? = null) :

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/GenerativeBackend.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/type/GenerativeBackend.kt
@@ -49,7 +49,7 @@ internal constructor(internal val location: String, internal val backend: Genera
     }
 
     /**
-     * References the Gemini Enterprise Agent Platform backend.
+     * References the Agent Platform Gemini API.
      *
      * @param location passes a valid cloud server location, defaults to "global"
      */


### PR DESCRIPTION
Update documentation URLs in APIController and Exceptions to point to the latest Firebase location guides. Refine the CHANGELOG notes regarding default locations for GenerativeBackend backends and update the doc comment for agentPlatform.