### PR TITLE
dataconnect(test): QuerySubscriptionImplUnitTest.kt: fix spurious failures in testNetworkConnectivityRestoration() 

### DIFF
--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/QuerySubscriptionImplUnitTest.kt
@@ -1682,6 +1682,7 @@ class QuerySubscriptionImplUnitTest {
           )
 
           clientCollector.cancelAndIgnoreRemainingEvents()
+          serverCollector.awaitUntilClientClosesConnection()
           serverCollector.cancelAndIgnoreRemainingEvents()
         }
       }


### PR DESCRIPTION
Fix spurious test failures in data connect's QuerySubscriptionImplUnitTest.kt function testNetworkConnectivityRestoration() when there is a delay before killing the physical connection after last subscriber unsubscribes.

Although the test is passing at the moment, specifying a non-zero value for the `stopTimeoutMillis` parameter to `SharingStarted.WhileSubscribed()` in `DataConnectBidiConnectStream.kt` causes the following spurious failure:

```
TurbineAssertionError: Unconsumed events found for serverCollector:
 - Item(ErrorReceived(ConnectionId(value=NNNN), StatusRuntimeException(CANCELLED: client cancelled, code=CANCELLED)))
  at app.cash.turbine.TurbineAssertionError$Companion.invoke(TurbineAssertionError.kt:32)
  at app.cash.turbine.ChannelTurbine.ensureAllEventsConsumed(Turbine.kt:246)
  ...
  at QuerySubscriptionImplUnitTest.testNetworkConnectivityRestoration(QuerySubscriptionImplUnitTest.kt:1639)
  at QuerySubscriptionImplUnitTest.network connectivity restoration resets backoff delay to initial value(QuerySubscriptionImplUnitTest.kt:1611)
```

This commit fixes the spurious error by consuming the expected disconnect event that will eventually arrive. The following 2 tests are fixed by this change:

* `network connectivity restoration resets backoff delay to initial value`
* `network connectivity restoration resets retries immediately`