### PR TITLE
[Infra] Only set `commitsToIgnoreFile` convention if file exists

### DIFF
--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/PublishingPlugin.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/PublishingPlugin.kt
@@ -665,8 +665,10 @@ abstract class PublishingPlugin : Plugin<Project> {
       currentRelease.convention(project.provideProperty("currentRelease"))
       pastRelease.convention(project.provideProperty("pastRelease"))
       printReleaseConfig.convention(project.provideProperty("printOutput"))
-      commitsToIgnoreFile.convention(project.layout.projectDirectory.file("ignoreCommits.txt"))
-
+      project.layout.projectDirectory.file("ignoreCommits.txt").let {
+        if (it.asFile.exists())
+          commitsToIgnoreFile.convention(it)
+      }
       releaseConfigFile.convention(project.layout.projectDirectory.file(RELEASE_CONFIG_FILE))
       releaseReportJsonFile.convention(
         project.layout.projectDirectory.file(RELEASE_REPORT_JSON_FILE)

--- a/plugins/src/main/java/com/google/firebase/gradle/plugins/PublishingPlugin.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/plugins/PublishingPlugin.kt
@@ -666,8 +666,7 @@ abstract class PublishingPlugin : Plugin<Project> {
       pastRelease.convention(project.provideProperty("pastRelease"))
       printReleaseConfig.convention(project.provideProperty("printOutput"))
       project.layout.projectDirectory.file("ignoreCommits.txt").let {
-        if (it.asFile.exists())
-          commitsToIgnoreFile.convention(it)
+        if (it.asFile.exists()) commitsToIgnoreFile.convention(it)
       }
       releaseConfigFile.convention(project.layout.projectDirectory.file(RELEASE_CONFIG_FILE))
       releaseReportJsonFile.convention(


### PR DESCRIPTION
Updated `PublishingPlugin` to verify the existence of `ignoreCommits.txt` before setting it as the `commitsToIgnoreFile` convention.