### PR TITLE
dataconnect(change): add "X-Client-Platform" and "X-Client-Version" headers

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -7,6 +7,9 @@
   [#8446](https://github.com/firebase/firebase-android-sdk/pull/8446),
   [#8456](https://github.com/firebase/firebase-android-sdk/pull/8456),
   [#8460](https://github.com/firebase/firebase-android-sdk/pull/8460))
+- [changed] Add grpc request headers for platform name and sdk version
+  to enable metrics collection in cloud monitoring.
+  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
 
 # 17.3.2
 

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -9,7 +9,7 @@
   [#8460](https://github.com/firebase/firebase-android-sdk/pull/8460))
 - [changed] Add grpc request headers for platform name and sdk version
   to enable metrics collection in cloud monitoring.
-  ([#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
+  ([#8486](https://github.com/firebase/firebase-android-sdk/pull/8486))
 
 # 17.3.2
 

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/GrpcMetadataIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/GrpcMetadataIntegrationTest.kt
@@ -479,10 +479,10 @@ class GrpcMetadataIntegrationTest : DataConnectIntegrationTestBase() {
       Metadata.Key.of("x-goog-api-client", Metadata.ASCII_STRING_MARSHALLER)
 
     val clientPlatformHeader: Metadata.Key<String> =
-      Metadata.Key.of("X-Client-Platform", Metadata.ASCII_STRING_MARSHALLER)
+      Metadata.Key.of("x-client-platform", Metadata.ASCII_STRING_MARSHALLER)
 
     val clientVersionHeader: Metadata.Key<String> =
-      Metadata.Key.of("X-Client-Version", Metadata.ASCII_STRING_MARSHALLER)
+      Metadata.Key.of("x-client-version", Metadata.ASCII_STRING_MARSHALLER)
 
     private val gmpAppIdHeader: Metadata.Key<String> =
       Metadata.Key.of("x-firebase-gmpid", Metadata.ASCII_STRING_MARSHALLER)

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/GrpcMetadataIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/GrpcMetadataIntegrationTest.kt
@@ -323,7 +323,14 @@ class GrpcMetadataIntegrationTest : DataConnectIntegrationTestBase() {
     val expectedAppId = getFirebaseAppIdFromStrings()
 
     metadata.asClue {
-      metadata.keys().shouldContainAll(googRequestParamsHeader.name(), googApiClientHeader.name())
+      metadata
+        .keys()
+        .shouldContainAll(
+          googRequestParamsHeader.name(),
+          googApiClientHeader.name(),
+          clientPlatformHeader.name(),
+          clientVersionHeader.name(),
+        )
       assertSoftly {
         // Do not verify "x-firebase-auth-token" here since that header is effectively tested by
         // AuthIntegrationTest
@@ -331,6 +338,8 @@ class GrpcMetadataIntegrationTest : DataConnectIntegrationTestBase() {
           "location=${dataConnect.config.location}&frontend=data"
         metadata.get(googApiClientHeader) shouldBe expectedGoogApiClientHeader(isFromGeneratedSdk)
         metadata.get(gmpAppIdHeader) shouldBe expectedAppId
+        metadata.get(clientPlatformHeader) shouldBe "android"
+        metadata.get(clientVersionHeader) shouldBe BuildConfig.VERSION_NAME
       }
     }
   }
@@ -468,6 +477,12 @@ class GrpcMetadataIntegrationTest : DataConnectIntegrationTestBase() {
 
     val googApiClientHeader: Metadata.Key<String> =
       Metadata.Key.of("x-goog-api-client", Metadata.ASCII_STRING_MARSHALLER)
+
+    val clientPlatformHeader: Metadata.Key<String> =
+      Metadata.Key.of("X-Client-Platform", Metadata.ASCII_STRING_MARSHALLER)
+
+    val clientVersionHeader: Metadata.Key<String> =
+      Metadata.Key.of("X-Client-Version", Metadata.ASCII_STRING_MARSHALLER)
 
     private val gmpAppIdHeader: Metadata.Key<String> =
       Metadata.Key.of("x-firebase-gmpid", Metadata.ASCII_STRING_MARSHALLER)

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadata.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadata.kt
@@ -185,10 +185,10 @@ internal class DataConnectGrpcMetadata(
       Metadata.Key.of(GOOG_API_CLIENT_HEADER, Metadata.ASCII_STRING_MARSHALLER)
 
     private val clientPlatformHeader: Metadata.Key<String> =
-      Metadata.Key.of("X-Client-Platform", Metadata.ASCII_STRING_MARSHALLER)
+      Metadata.Key.of("x-client-platform", Metadata.ASCII_STRING_MARSHALLER)
 
     private val clientVersionHeader: Metadata.Key<String> =
-      Metadata.Key.of("X-Client-Version", Metadata.ASCII_STRING_MARSHALLER)
+      Metadata.Key.of("x-client-version", Metadata.ASCII_STRING_MARSHALLER)
 
     @Suppress("SpellCheckingInspection")
     private val gmpAppIdHeader: Metadata.Key<String> =

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadata.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadata.kt
@@ -83,6 +83,8 @@ internal class DataConnectGrpcMetadata(
       Metadata().also {
         it.put(googRequestParamsHeader, googRequestParamsHeaderValue)
         it.put(googApiClientHeader, googApiClientHeaderValue(callerSdkType))
+        it.put(clientPlatformHeader, "android")
+        it.put(clientVersionHeader, dataConnectSdkVersion)
         if (appId.isNotBlank()) {
           it.put(gmpAppIdHeader, appId)
         }
@@ -181,6 +183,12 @@ internal class DataConnectGrpcMetadata(
 
     private val googApiClientHeader: Metadata.Key<String> =
       Metadata.Key.of(GOOG_API_CLIENT_HEADER, Metadata.ASCII_STRING_MARSHALLER)
+
+    private val clientPlatformHeader: Metadata.Key<String> =
+      Metadata.Key.of("X-Client-Platform", Metadata.ASCII_STRING_MARSHALLER)
+
+    private val clientVersionHeader: Metadata.Key<String> =
+      Metadata.Key.of("X-Client-Version", Metadata.ASCII_STRING_MARSHALLER)
 
     @Suppress("SpellCheckingInspection")
     private val gmpAppIdHeader: Metadata.Key<String> =

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadataUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadataUnitTest.kt
@@ -124,39 +124,49 @@ class DataConnectGrpcMetadataUnitTest {
   }
 
   @Test
-  fun `should include x-goog-request-params`() = runTest {
-    val dataConnectGrpcMetadataArb =
-      Arb.dataConnect.dataConnectGrpcMetadata(
-        connectorLocation = Arb.constant("q8mgtztcz2"),
-      )
-
-    checkAll(
-      propTestConfig,
-      dataConnectGrpcMetadataArb,
-      Arb.dataConnect.authTokenResult().orNull(nullProbability = 0.33),
-      Arb.dataConnect.appCheckTokenResult().orNull(nullProbability = 0.33),
-      Arb.enum<CallerSdkType>()
-    ) { dataConnectGrpcMetadata, authToken, appCheckToken, callerSdkType ->
-      val metadata =
-        dataConnectGrpcMetadata.get(
-          authToken = authToken,
-          appCheckToken = appCheckToken,
-          callerSdkType = callerSdkType,
-        )
-
-      metadata.asClue {
-        it.keys() shouldContain "x-goog-request-params"
-        val metadataKey = Metadata.Key.of("x-goog-request-params", Metadata.ASCII_STRING_MARSHALLER)
-        it.get(metadataKey) shouldBe "location=q8mgtztcz2&frontend=data"
-      }
-    }
-  }
+  fun `should include x-goog-request-params`() =
+    testMetadataIncludesHeader(
+      dataConnectGrpcMetadataArb =
+        Arb.dataConnect.dataConnectGrpcMetadata(
+          connectorLocation = Arb.constant("q8mgtztcz2"),
+        ),
+      headerName = "x-goog-request-params",
+      getExpectedHeaderValue = { "location=q8mgtztcz2&frontend=data" },
+    )
 
   @Test
-  fun `should include x-firebase-gmpid`() = runTest {
-    val dataConnectGrpcMetadataArb =
-      Arb.dataConnect.dataConnectGrpcMetadata(appId = Arb.constant("tvsxjeb745.appId"))
+  fun `should include X-Client-Platform`() =
+    testMetadataIncludesHeader(
+      headerName = "X-Client-Platform",
+      getExpectedHeaderValue = { "android" },
+    )
 
+  @Test
+  fun `should include X-Client-Version`() =
+    testMetadataIncludesHeader(
+      dataConnectGrpcMetadataArb =
+        Arb.dataConnect.dataConnectGrpcMetadata(
+          dataConnectSdkVersion = Arb.constant("v3q46qc2ax"),
+        ),
+      headerName = "X-Client-Version",
+      getExpectedHeaderValue = { "v3q46qc2ax" },
+    )
+
+  @Test
+  fun `should include x-firebase-gmpid`() =
+    testMetadataIncludesHeader(
+      dataConnectGrpcMetadataArb =
+        Arb.dataConnect.dataConnectGrpcMetadata(appId = Arb.constant("tvsxjeb745.appId")),
+      headerName = "x-firebase-gmpid",
+      getExpectedHeaderValue = { "tvsxjeb745.appId" },
+    )
+
+  private fun testMetadataIncludesHeader(
+    dataConnectGrpcMetadataArb: Arb<DataConnectGrpcMetadata> =
+      Arb.dataConnect.dataConnectGrpcMetadata(),
+    headerName: String,
+    getExpectedHeaderValue: (DataConnectGrpcMetadata) -> String,
+  ) = runTest {
     checkAll(
       propTestConfig,
       dataConnectGrpcMetadataArb,
@@ -172,9 +182,9 @@ class DataConnectGrpcMetadataUnitTest {
         )
 
       metadata.asClue {
-        it.keys() shouldContain "x-firebase-gmpid"
-        val metadataKey = Metadata.Key.of("x-firebase-gmpid", Metadata.ASCII_STRING_MARSHALLER)
-        it.get(metadataKey) shouldBe "tvsxjeb745.appId"
+        it.keys() shouldContain headerName.lowercase()
+        val metadataKey = Metadata.Key.of(headerName, Metadata.ASCII_STRING_MARSHALLER)
+        it.get(metadataKey) shouldBe getExpectedHeaderValue(dataConnectGrpcMetadata)
       }
     }
   }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadataUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadataUnitTest.kt
@@ -135,20 +135,20 @@ class DataConnectGrpcMetadataUnitTest {
     )
 
   @Test
-  fun `should include X-Client-Platform`() =
+  fun `should include x-client-platform`() =
     testMetadataIncludesHeader(
-      headerName = "X-Client-Platform",
+      headerName = "x-client-platform",
       getExpectedHeaderValue = { "android" },
     )
 
   @Test
-  fun `should include X-Client-Version`() =
+  fun `should include x-client-version`() =
     testMetadataIncludesHeader(
       dataConnectGrpcMetadataArb =
         Arb.dataConnect.dataConnectGrpcMetadata(
           dataConnectSdkVersion = Arb.constant("v3q46qc2ax"),
         ),
-      headerName = "X-Client-Version",
+      headerName = "x-client-version",
       getExpectedHeaderValue = { "v3q46qc2ax" },
     )
 

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
@@ -32,6 +32,7 @@ import com.google.firebase.dataconnect.testutil.DataConnectLogLevelRule
 import com.google.firebase.dataconnect.testutil.DataConnectPath
 import com.google.firebase.dataconnect.testutil.InProcessDataConnectGrpcStreamingServer
 import com.google.firebase.dataconnect.testutil.OperationNameVariablesPair
+import com.google.firebase.dataconnect.testutil.awaitCall
 import com.google.firebase.dataconnect.testutil.awaitUntilInitStreamRequest
 import com.google.firebase.dataconnect.testutil.cleanupsScope
 import com.google.firebase.dataconnect.testutil.loopbackAddressForPort
@@ -60,13 +61,19 @@ import com.google.protobuf.Duration as DurationProto
 import com.google.protobuf.ListValue as ListValueProto
 import com.google.protobuf.Struct as StructProto
 import google.firebase.dataconnect.proto.ConnectorServiceGrpc
+import google.firebase.dataconnect.proto.ExecuteMutationRequest
+import google.firebase.dataconnect.proto.ExecuteMutationResponse
 import google.firebase.dataconnect.proto.ExecuteQueryRequest
 import google.firebase.dataconnect.proto.ExecuteQueryResponse
 import google.firebase.dataconnect.proto.GraphqlResponseExtensions
 import google.firebase.dataconnect.proto.GraphqlResponseExtensions.DataConnectProperties
 import google.firebase.dataconnect.proto.StreamRequest
 import io.grpc.InsecureServerCredentials
+import io.grpc.Metadata
 import io.grpc.Server
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.ServerInterceptor
 import io.grpc.okhttp.OkHttpServerBuilder
 import io.grpc.stub.StreamObserver
 import io.kotest.assertions.assertSoftly
@@ -822,6 +829,155 @@ class DataConnectGrpcRPCsUnitTest {
     }
   }
 
+  @Test
+  fun `executeQuery sends X-Client-Platform header`() =
+    testExecuteQuerySendsHeader(
+      headerName = "X-Client-Platform",
+      getExpectedHeaderValue = { "android" },
+    )
+
+  @Test
+  fun `executeQuery sends X-Client-Version header`() =
+    testExecuteQuerySendsHeader(
+      headerName = "X-Client-Version",
+      getExpectedHeaderValue = { it.grpcMetadata.dataConnectSdkVersion },
+    )
+
+  @Test
+  fun `executeMutation sends X-Client-Platform header`() =
+    testExecuteMutationSendsHeader(
+      headerName = "X-Client-Platform",
+      getExpectedHeaderValue = { "android" },
+    )
+
+  @Test
+  fun `executeMutation sends X-Client-Version header`() =
+    testExecuteMutationSendsHeader(
+      headerName = "X-Client-Version",
+      getExpectedHeaderValue = { it.grpcMetadata.dataConnectSdkVersion },
+    )
+
+  @Test
+  fun `connect sends X-Client-Platform header`() =
+    testConnectSendsHeader(
+      headerName = "X-Client-Platform",
+      getExpectedHeaderValue = { "android" },
+    )
+
+  @Test
+  fun `connect sends X-Client-Version header`() =
+    testConnectSendsHeader(
+      headerName = "X-Client-Version",
+      getExpectedHeaderValue = { it.grpcMetadata.dataConnectSdkVersion },
+    )
+
+  private fun testExecuteQuerySendsHeader(
+    headerName: String,
+    getExpectedHeaderValue: (DataConnectGrpcRPCs) -> String,
+  ) = runTest {
+    checkAll(
+      propTestConfig,
+      Arb.dataConnect.authTokenResult().orNull(nullProbability = 0.3),
+      Arb.dataConnect.appCheckTokenResult().orNull(nullProbability = 0.3),
+    ) { authToken, appCheckToken ->
+      cleanupsScope {
+        val server = startServer()
+        registerCleanup(server)
+        val dataConnectGrpcRPCs = newDataConnectGrpcRPCs(testScheduler, server, cache = null)
+        registerCleanup(dataConnectGrpcRPCs)
+        val request = operationNameVariablesPairArb.bind()
+
+        dataConnectGrpcRPCs.executeQuery(
+          requestIdArb.bind(),
+          request.operationName,
+          request.variables,
+          callerSdkTypeArb.bind(),
+          FetchPolicy.SERVER_ONLY,
+          authToken,
+          appCheckToken,
+        )
+
+        val headerKey = Metadata.Key.of(headerName, Metadata.ASCII_STRING_MARSHALLER)
+        server.lastReceivedHeaders?.get(headerKey) shouldBe
+          getExpectedHeaderValue(dataConnectGrpcRPCs)
+      }
+    }
+  }
+
+  private fun testExecuteMutationSendsHeader(
+    headerName: String,
+    getExpectedHeaderValue: (DataConnectGrpcRPCs) -> String,
+  ) = runTest {
+    checkAll(
+      propTestConfig,
+      Arb.dataConnect.authTokenResult().orNull(nullProbability = 0.3),
+      Arb.dataConnect.appCheckTokenResult().orNull(nullProbability = 0.3),
+    ) { authToken, appCheckToken ->
+      cleanupsScope {
+        val server = startServer()
+        registerCleanup(server)
+        val dataConnectGrpcRPCs = newDataConnectGrpcRPCs(testScheduler, server, cache = null)
+        registerCleanup(dataConnectGrpcRPCs)
+        val request = operationNameVariablesPairArb.bind()
+
+        dataConnectGrpcRPCs.executeMutation(
+          requestIdArb.bind(),
+          request.operationName,
+          request.variables,
+          callerSdkTypeArb.bind(),
+          authToken,
+          appCheckToken,
+        )
+
+        val headerKey = Metadata.Key.of(headerName, Metadata.ASCII_STRING_MARSHALLER)
+        server.lastReceivedHeaders?.get(headerKey) shouldBe
+          getExpectedHeaderValue(dataConnectGrpcRPCs)
+      }
+    }
+  }
+
+  private fun testConnectSendsHeader(
+    headerName: String,
+    getExpectedHeaderValue: (DataConnectGrpcRPCs) -> String,
+  ) = runTest {
+    checkAll(propTestConfig, cacheArb(testScheduler).orNull(nullProbability = 0.2)) { cache ->
+      cleanupsScope {
+        registerCleanup(cache)
+
+        val server = InProcessDataConnectGrpcStreamingServer()
+        registerCleanup(server)
+        server.open()
+        val dataConnectGrpcRPCs = newDataConnectGrpcRPCs(testScheduler, server, cache)
+        registerCleanup(dataConnectGrpcRPCs)
+        val callerSdkType = Arb.enum<CallerSdkType>().bind()
+
+        server.events.test {
+          val stream = dataConnectGrpcRPCs.connect(randomSource())
+          val subscriptionFlow =
+            stream.subscribe(
+              "req1",
+              "opName",
+              StructProto.getDefaultInstance(),
+              callerSdkType,
+            )
+
+          val backgroundCollectJob =
+            backgroundScope.launch(CallerSdkTypeElement(callerSdkType)) {
+              subscriptionFlow.collect()
+            }
+          registerSuspendingCleanup { backgroundCollectJob.cancelAndJoin() }
+
+          val callEvent = awaitCall()
+          val headerKey = Metadata.Key.of(headerName, Metadata.ASCII_STRING_MARSHALLER)
+          callEvent.headers.get(headerKey) shouldBe getExpectedHeaderValue(dataConnectGrpcRPCs)
+
+          backgroundCollectJob.cancelAndJoin()
+          cancelAndIgnoreRemainingEvents()
+        }
+      }
+    }
+  }
+
   private suspend fun DataConnectGrpcRPCs.connect(rs: RandomSource): DataConnectBidiConnectStream {
     val dataConnectAuth: DataConnectAuth =
       mockk(name = "DataConnectAuth@xjk254qsb3") {
@@ -853,13 +1009,17 @@ class DataConnectGrpcRPCsUnitTest {
 
   private class StartServerResult(
     private val grpcServer: Server,
-    private val connectorServiceImpl: ConnectorServiceImpl
+    private val connectorServiceImpl: ConnectorServiceImpl,
+    private val headerInterceptor: HeaderCapturingServerInterceptor,
   ) : AutoCloseable {
 
     val port = grpcServer.port
 
     val executeQueryInvocationCount: Long
       get() = connectorServiceImpl.executeQueryInvocationCount.sum()
+
+    val lastReceivedHeaders: Metadata?
+      get() = headerInterceptor.lastHeaders.get()
 
     var nextResponse: ExecuteQueryResponse
       get() = connectorServiceImpl.nextResponse.get()
@@ -873,22 +1033,38 @@ class DataConnectGrpcRPCsUnitTest {
     }
   }
 
+  private class HeaderCapturingServerInterceptor : ServerInterceptor {
+    val lastHeaders = AtomicReference<Metadata?>(null)
+
+    override fun <ReqT, RespT> interceptCall(
+      call: ServerCall<ReqT, RespT>,
+      headers: Metadata,
+      next: ServerCallHandler<ReqT, RespT>
+    ): ServerCall.Listener<ReqT> {
+      lastHeaders.set(headers)
+      return next.startCall(call, headers)
+    }
+  }
+
   private fun startServer(): StartServerResult {
     val connectorServiceImpl = ConnectorServiceImpl()
+    val headerInterceptor = HeaderCapturingServerInterceptor()
     val grpcServer =
       OkHttpServerBuilder.forPort(loopbackAddressForPort(0), InsecureServerCredentials.create())
         .addService(connectorServiceImpl)
+        .intercept(headerInterceptor)
         .build()
 
     grpcServer.start()
 
-    return StartServerResult(grpcServer, connectorServiceImpl)
+    return StartServerResult(grpcServer, connectorServiceImpl, headerInterceptor)
   }
 
   private class ConnectorServiceImpl : ConnectorServiceGrpc.ConnectorServiceImplBase() {
 
     val executeQueryInvocationCount = LongAdder()
     val nextResponse = AtomicReference(ExecuteQueryResponse.getDefaultInstance())
+    val nextMutationResponse = AtomicReference(ExecuteMutationResponse.getDefaultInstance())
 
     override fun executeQuery(
       request: ExecuteQueryRequest,
@@ -896,6 +1072,14 @@ class DataConnectGrpcRPCsUnitTest {
     ) {
       executeQueryInvocationCount.add(1)
       responseObserver.onNext(nextResponse.get())
+      responseObserver.onCompleted()
+    }
+
+    override fun executeMutation(
+      request: ExecuteMutationRequest,
+      responseObserver: StreamObserver<ExecuteMutationResponse>,
+    ) {
+      responseObserver.onNext(nextMutationResponse.get())
       responseObserver.onCompleted()
     }
   }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
@@ -830,44 +830,44 @@ class DataConnectGrpcRPCsUnitTest {
   }
 
   @Test
-  fun `executeQuery sends X-Client-Platform header`() =
+  fun `executeQuery sends x-client-platform header`() =
     testExecuteQuerySendsHeader(
-      headerName = "X-Client-Platform",
+      headerName = "x-client-platform",
       getExpectedHeaderValue = { "android" },
     )
 
   @Test
-  fun `executeQuery sends X-Client-Version header`() =
+  fun `executeQuery sends x-client-version header`() =
     testExecuteQuerySendsHeader(
-      headerName = "X-Client-Version",
+      headerName = "x-client-version",
       getExpectedHeaderValue = { it.grpcMetadata.dataConnectSdkVersion },
     )
 
   @Test
-  fun `executeMutation sends X-Client-Platform header`() =
+  fun `executeMutation sends x-client-platform header`() =
     testExecuteMutationSendsHeader(
-      headerName = "X-Client-Platform",
+      headerName = "x-client-platform",
       getExpectedHeaderValue = { "android" },
     )
 
   @Test
-  fun `executeMutation sends X-Client-Version header`() =
+  fun `executeMutation sends x-client-version header`() =
     testExecuteMutationSendsHeader(
-      headerName = "X-Client-Version",
+      headerName = "x-client-version",
       getExpectedHeaderValue = { it.grpcMetadata.dataConnectSdkVersion },
     )
 
   @Test
-  fun `connect sends X-Client-Platform header`() =
+  fun `connect sends x-client-platform header`() =
     testConnectSendsHeader(
-      headerName = "X-Client-Platform",
+      headerName = "x-client-platform",
       getExpectedHeaderValue = { "android" },
     )
 
   @Test
-  fun `connect sends X-Client-Version header`() =
+  fun `connect sends x-client-version header`() =
     testConnectSendsHeader(
-      headerName = "X-Client-Version",
+      headerName = "x-client-version",
       getExpectedHeaderValue = { it.grpcMetadata.dataConnectSdkVersion },
     )
 


### PR DESCRIPTION
This PR adds `x-client-platform` and `x-client-version` gRPC request headers to the `firebase-dataconnect` SDK. These headers supply the client platform (`android`) and SDK version to enable metrics collection in Cloud Monitoring.

**NOTE**: Shortly after merging this PR, it was decided to delete the `x-client-platform` header and merge its value into `x-client-version`. See https://github.com/firebase/firebase-android-sdk/pull/8495 for details.

### Highlights

* **New gRPC Metadata Headers**: Added `x-client-platform` (set to `"android"`) and `x-client-version` (set to the SDK version) headers to `DataConnectGrpcMetadata` to enable Cloud Monitoring metrics collection.
* **Comprehensive Test Coverage**: Expanded `DataConnectGrpcMetadataUnitTest`, `DataConnectGrpcRPCsUnitTest`, and `GrpcMetadataIntegrationTest` to verify that `x-client-platform` and `x-client-version` headers are included in all gRPC requests (`executeQuery`, `executeMutation`, and `connect`).
* **Changelog Entry**: Added an entry in `CHANGELOG.md` under `firebase-dataconnect`.

<details>

<summary><b>Changelog</b></summary>

* **CHANGELOG.md**
  * Added a changelog entry for adding gRPC request headers for platform name and SDK version.
* **DataConnectGrpcMetadata.kt**
  * Added `x-client-platform` and `x-client-version` header keys and included them in outgoing gRPC metadata.
* **GrpcMetadataIntegrationTest.kt**
  * Added assertions verifying `x-client-platform` and `x-client-version` headers are present in integration tests.
* **DataConnectGrpcMetadataUnitTest.kt**
  * Refactored test assertions into `testMetadataIncludesHeader` and added unit tests for `x-client-platform` and `x-client-version`.
* **DataConnectGrpcRPCsUnitTest.kt**
  * Added `HeaderCapturingServerInterceptor` and unit tests verifying `x-client-platform` and `x-client-version` headers across `executeQuery`, `executeMutation`, and `connect` RPCs.
</details>
