### PR TITLE
chore(firestore): fix gradle version

### DIFF
--- a/firebase-firestore/gradle.properties
+++ b/firebase-firestore/gradle.properties
@@ -1,2 +1,2 @@
-version=26.5.2
+version=26.5.0
 latestReleasedVersion=26.4.1


### PR DESCRIPTION
Fix gradle version after accidentally increasing by a minor and two patch versions in recent PR.