### PR TITLE
dataconnect(change): merge "X-Client-Platform" header into "X-Client-Version"

### DIFF
--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -7,9 +7,10 @@
   [#8446](https://github.com/firebase/firebase-android-sdk/pull/8446),
   [#8456](https://github.com/firebase/firebase-android-sdk/pull/8456),
   [#8460](https://github.com/firebase/firebase-android-sdk/pull/8460))
-- [changed] Add grpc request headers for platform name and sdk version
+- [changed] Add grpc request header for platform name and sdk version
   to enable metrics collection in cloud monitoring.
-  ([#8486](https://github.com/firebase/firebase-android-sdk/pull/8486))
+  ([#8486](https://github.com/firebase/firebase-android-sdk/pull/8486),
+  [#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
 - [changed] Wait for 15 seconds before closing realtime streaming connection
   with backend after last subscriber unsubscribes (instead of closing the
   connection immediately).

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -10,7 +10,7 @@
 - [changed] Add grpc request header for platform name and sdk version
   to enable metrics collection in cloud monitoring.
   ([#8486](https://github.com/firebase/firebase-android-sdk/pull/8486),
-  [#NNNN](https://github.com/firebase/firebase-android-sdk/pull/NNNN))
+  [#8495](https://github.com/firebase/firebase-android-sdk/pull/8495))
 - [changed] Wait for 15 seconds before closing realtime streaming connection
   with backend after last subscriber unsubscribes (instead of closing the
   connection immediately).

--- a/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/GrpcMetadataIntegrationTest.kt
+++ b/firebase-dataconnect/src/androidTest/kotlin/com/google/firebase/dataconnect/GrpcMetadataIntegrationTest.kt
@@ -328,7 +328,6 @@ class GrpcMetadataIntegrationTest : DataConnectIntegrationTestBase() {
         .shouldContainAll(
           googRequestParamsHeader.name(),
           googApiClientHeader.name(),
-          clientPlatformHeader.name(),
           clientVersionHeader.name(),
         )
       assertSoftly {
@@ -338,8 +337,7 @@ class GrpcMetadataIntegrationTest : DataConnectIntegrationTestBase() {
           "location=${dataConnect.config.location}&frontend=data"
         metadata.get(googApiClientHeader) shouldBe expectedGoogApiClientHeader(isFromGeneratedSdk)
         metadata.get(gmpAppIdHeader) shouldBe expectedAppId
-        metadata.get(clientPlatformHeader) shouldBe "android"
-        metadata.get(clientVersionHeader) shouldBe BuildConfig.VERSION_NAME
+        metadata.get(clientVersionHeader) shouldBe "android/${BuildConfig.VERSION_NAME}"
       }
     }
   }
@@ -477,9 +475,6 @@ class GrpcMetadataIntegrationTest : DataConnectIntegrationTestBase() {
 
     val googApiClientHeader: Metadata.Key<String> =
       Metadata.Key.of("x-goog-api-client", Metadata.ASCII_STRING_MARSHALLER)
-
-    val clientPlatformHeader: Metadata.Key<String> =
-      Metadata.Key.of("x-client-platform", Metadata.ASCII_STRING_MARSHALLER)
 
     val clientVersionHeader: Metadata.Key<String> =
       Metadata.Key.of("x-client-version", Metadata.ASCII_STRING_MARSHALLER)

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadata.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadata.kt
@@ -83,8 +83,7 @@ internal class DataConnectGrpcMetadata(
       Metadata().also {
         it.put(googRequestParamsHeader, googRequestParamsHeaderValue)
         it.put(googApiClientHeader, googApiClientHeaderValue(callerSdkType))
-        it.put(clientPlatformHeader, "android")
-        it.put(clientVersionHeader, dataConnectSdkVersion)
+        it.put(clientVersionHeader, "android/$dataConnectSdkVersion")
         if (appId.isNotBlank()) {
           it.put(gmpAppIdHeader, appId)
         }
@@ -183,9 +182,6 @@ internal class DataConnectGrpcMetadata(
 
     private val googApiClientHeader: Metadata.Key<String> =
       Metadata.Key.of(GOOG_API_CLIENT_HEADER, Metadata.ASCII_STRING_MARSHALLER)
-
-    private val clientPlatformHeader: Metadata.Key<String> =
-      Metadata.Key.of("x-client-platform", Metadata.ASCII_STRING_MARSHALLER)
 
     private val clientVersionHeader: Metadata.Key<String> =
       Metadata.Key.of("x-client-version", Metadata.ASCII_STRING_MARSHALLER)

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadataUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadataUnitTest.kt
@@ -135,13 +135,6 @@ class DataConnectGrpcMetadataUnitTest {
     )
 
   @Test
-  fun `should include x-client-platform`() =
-    testMetadataIncludesHeader(
-      headerName = "x-client-platform",
-      getExpectedHeaderValue = { "android" },
-    )
-
-  @Test
   fun `should include x-client-version`() =
     testMetadataIncludesHeader(
       dataConnectGrpcMetadataArb =
@@ -149,7 +142,7 @@ class DataConnectGrpcMetadataUnitTest {
           dataConnectSdkVersion = Arb.constant("v3q46qc2ax"),
         ),
       headerName = "x-client-version",
-      getExpectedHeaderValue = { "v3q46qc2ax" },
+      getExpectedHeaderValue = { "android/v3q46qc2ax" },
     )
 
   @Test

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCsUnitTest.kt
@@ -830,45 +830,24 @@ class DataConnectGrpcRPCsUnitTest {
   }
 
   @Test
-  fun `executeQuery sends x-client-platform header`() =
-    testExecuteQuerySendsHeader(
-      headerName = "x-client-platform",
-      getExpectedHeaderValue = { "android" },
-    )
-
-  @Test
   fun `executeQuery sends x-client-version header`() =
     testExecuteQuerySendsHeader(
       headerName = "x-client-version",
-      getExpectedHeaderValue = { it.grpcMetadata.dataConnectSdkVersion },
-    )
-
-  @Test
-  fun `executeMutation sends x-client-platform header`() =
-    testExecuteMutationSendsHeader(
-      headerName = "x-client-platform",
-      getExpectedHeaderValue = { "android" },
+      getExpectedHeaderValue = { "android/${it.grpcMetadata.dataConnectSdkVersion}" },
     )
 
   @Test
   fun `executeMutation sends x-client-version header`() =
     testExecuteMutationSendsHeader(
       headerName = "x-client-version",
-      getExpectedHeaderValue = { it.grpcMetadata.dataConnectSdkVersion },
-    )
-
-  @Test
-  fun `connect sends x-client-platform header`() =
-    testConnectSendsHeader(
-      headerName = "x-client-platform",
-      getExpectedHeaderValue = { "android" },
+      getExpectedHeaderValue = { "android/${it.grpcMetadata.dataConnectSdkVersion}" },
     )
 
   @Test
   fun `connect sends x-client-version header`() =
     testConnectSendsHeader(
       headerName = "x-client-version",
-      getExpectedHeaderValue = { it.grpcMetadata.dataConnectSdkVersion },
+      getExpectedHeaderValue = { "android/${it.grpcMetadata.dataConnectSdkVersion}" },
     )
 
   private fun testExecuteQuerySendsHeader(


### PR DESCRIPTION
This PR updates the gRPC metadata in `firebase-dataconnect` by merging the `X-Client-Platform` header into the `X-Client-Version` header (formatting as `android/<version>`) and removing the standalone `X-Client-Platform` header.

This is an update to PR https://github.com/firebase/firebase-android-sdk/pull/8486 which was merged yesterday and added both of these headers. This update was made to accommodate the firebase-js-sdk because the "X-Client-Platform" header causes the CORS OPTIONS preflight request to fail with a 403 "Permission Denied" error due to that header being absent from Google's list of whitelisted CORS headers. See https://github.com/firebase/firebase-js-sdk/pull/10217 for a few more details, if interested.

### Highlights

* **Header Consolidation**: Merged the platform identifier into the `X-Client-Version` header (e.g. `android/<version>`) and removed the separate `X-Client-Platform` (`x-client-platform`) header.
* **Test Updates**: Updated integration and unit test suites to verify the new `X-Client-Version` header value format.

<details>

<summary><b>Changelog</b></summary>

* **CHANGELOG.md**
  * Updated the gRPC header entry to reference PR #8495 and reflect the updated header structure.
* **DataConnectGrpcMetadata.kt**
  * Removed the `x-client-platform` header definition and updated `x-client-version` to format as `android/$dataConnectSdkVersion`.
* **GrpcMetadataIntegrationTest.kt**
  * Removed test assertions for `x-client-platform` and updated `x-client-version` assertions to expect `android/${BuildConfig.VERSION_NAME}`.
* **DataConnectGrpcMetadataUnitTest.kt**
  * Removed `x-client-platform` test cases and updated `x-client-version` test cases to verify the new header format.
* **DataConnectGrpcRPCsUnitTest.kt**
  * Removed test cases for `x-client-platform` and updated `x-client-version` assertions for `executeQuery`, `executeMutation`, and `connect`.
</details>
