### PR TITLE
dataconnect(test): dataconnect.yml: only start the "postgres" service from docker-compose.yml

### DIFF
--- a/.github/workflows/dataconnect.yml
+++ b/.github/workflows/dataconnect.yml
@@ -207,7 +207,7 @@ jobs:
         working-directory: firebase-dataconnect/emulator
         run: |
           set -xveuo pipefail
-          docker compose up -d --quiet-pull
+          docker compose up -d --quiet-pull postgres
 
       - name: Wait for Postgres Server to be Ready
         working-directory: firebase-dataconnect/emulator


### PR DESCRIPTION
This avoids wasting time downloading and spinning up the pgadmin4 container, since pgadmin4 is just for interactive debugging and is not used in any way during CI.