### PR TITLE
dataconnect(test): docker-compose.yml: add postgrest and swagger-ui

### DIFF
--- a/firebase-dataconnect/emulator/docker-compose.yml
+++ b/firebase-dataconnect/emulator/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - PGADMIN_DEFAULT_EMAIL=${PGADMIN_DEFAULT_EMAIL:-admin@google.com}
       - PGADMIN_DEFAULT_PASSWORD=${PGADMIN_DEFAULT_PASSWORD:-hyh5tttjj5}
     ports:
-      - "127.0.0.1:8888:80"
+      - "127.0.0.1:5500:80"
     volumes:
       - ./servers.json:/pgadmin4/servers.json:ro
       - dataconnect_pgadmin_data:/var/lib/pgadmin
@@ -32,6 +32,35 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "wget --spider -q http://localhost/misc/ping || exit 1"]
       start_period: 15s
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  postgrest:
+    # https://hub.docker.com/layers/postgrest/postgrest/v14.16/images/sha256-ff0ef3dd967144c14787825f860d47db57b9c078a5b3c0eb2e20ee5d53eb86f3
+    image: docker.io/postgrest/postgrest@sha256:bea1c76a856fa39d1e542d25911cf95d02fe2bf971992d033044ff209f1504b8
+    ports:
+      - "127.0.0.1:5501:3000"
+    environment:
+      PGRST_DB_URI: postgres://postgres@postgres:5432/dba6g7djscd5
+      PGRST_DB_SCHEMA: public
+      PGRST_DB_ANON_ROLE: postgres
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  swagger-ui:
+    # https://hub.docker.com/layers/swaggerapi/swagger-ui/v5.32.12/images/sha256-183b63db5313004c3dfb4e46359e2c01c02fd8d055dbf45b3453790a4026416e
+    image: docker.io/swaggerapi/swagger-ui@sha256:c6d205b1bb00c697ef55390d49aeddaecc13f672423ffc16ec2c3b602161ed18
+    ports:
+      - "127.0.0.1:5502:8080"
+    environment:
+      API_URL: http://localhost:5501/
+    depends_on:
+      - postgrest
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:8080/ || exit 1"]
+      start_period: 5s
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Add a postgrest server to the `docker-compose.yml` used by data connect integration tests. This server adds an easy, dependency-free way for the integration tests to interact with the raw data in the database (e.g. verifying that rows are correctly inserted).

There are no tests that use it yet, but upcoming test plans make use of it. Since it took some trial and error to get it all set up, and it doesn't really "hurt" being there, I figured I'd just push it up.