### PR TITLE
Annotating blockingRegister with "@CanIgnoreReturnValue" 

### DIFF
--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
@@ -41,6 +41,7 @@ import com.google.android.gms.common.util.concurrent.NamedThreadFactory;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.firebase.DataCollectionDefaultChange;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.analytics.connector.AnalyticsConnector;
@@ -803,6 +804,7 @@ public class FirebaseMessaging {
   /**
    * Returns the cached token, if valid. Otherwise makes a request to the server to get a new token.
    */
+  @CanIgnoreReturnValue
   String blockingRegister(boolean shouldInvokeCallback) throws IOException {
     Store.Token cachedToken = getTokenWithoutTriggeringSync();
     if (!tokenNeedsRefresh(cachedToken)) {

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/FirebaseMessagingRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/FirebaseMessagingRoboTest.java
@@ -1199,6 +1199,7 @@ public final class FirebaseMessagingRoboTest {
   }
 
   @Test
+  @SuppressWarnings("GuardedBy") // Required while importing to G3
   public void testAutoInitEnabled_v1Flow_triggersRegistration() throws Exception {
     resetForTokenTests();
     editManifestApplicationMetadata()
@@ -1239,6 +1240,7 @@ public final class FirebaseMessagingRoboTest {
   }
 
   @Test
+  @SuppressWarnings("GuardedBy") // Required while importing to G3
   public void testAutoInitDisabled_v1Flow_doesNotTriggerRegistration() throws Exception {
     resetForTokenTests();
     editManifestApplicationMetadata()

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/GmsRegistrationClientRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/GmsRegistrationClientRoboTest.java
@@ -255,6 +255,7 @@ public class GmsRegistrationClientRoboTest {
   }
 
   @Test
+  @SuppressWarnings("DoNotMock") // Required while importing to G3
   public void testRegister_v1Flow_withSupport_fidAlreadyUsed_retriesAndSucceeds() throws Exception {
     setV1RegistrationEnabled(true);
     when(metadata.getGmsVersionCode()).thenReturn(261200000); // support V1


### PR DESCRIPTION
Annotating blockingRegister with "@CanIgnoreReturnValue" since some callers doesn't need to rely on its return.

This is for fixing Tap issues while running copybara.