### PR TITLE
Bump the version for Crashlytics Gradle plugin and buildtools jar

### DIFF
--- a/firebase-crashlytics-buildtools/gradle.properties
+++ b/firebase-crashlytics-buildtools/gradle.properties
@@ -1,2 +1,2 @@
-version=3.0.7
+version=3.0.8
 artifactId=firebase-crashlytics-buildtools

--- a/firebase-crashlytics-gradle/CHANGELOG.md
+++ b/firebase-crashlytics-gradle/CHANGELOG.md
@@ -1,12 +1,17 @@
 ### Unreleased
 
-- [fixed] Fixed an incompatibility between Crashlytics Gradle plugin and Gradle isolated projects when enabling nativeSymbolUploadEnabled. [#8037]
-- [fixed] Preventing orphaned files in FirebaseSymbolFileService when encountering Network issues. [#8157]
+### Crashlytics Gradle plugin version 3.0.8
+
+- [fixed] Fixed an incompatibility between Crashlytics Gradle plugin and Gradle isolated projects
+  when enabling nativeSymbolUploadEnabled. [#8037]
+- [fixed] Preventing orphaned files in FirebaseSymbolFileService when encountering Network
+  issues. [#8157]
 
 ### Crashlytics Gradle plugin version 3.0.7
 
 * [changed] Improved efficiency when extracting breakpad binary files.
-* [fixed] Avoid build breaks when handling unsupported native libraries for injectCrashlyticsBuildIds task [#7780]
+* [fixed] Avoid build breaks when handling unsupported native libraries for
+  injectCrashlyticsBuildIds task [#7780]
 
 ### Crashlytics Gradle plugin version 3.0.6
 

--- a/firebase-crashlytics-gradle/gradle.properties
+++ b/firebase-crashlytics-gradle/gradle.properties
@@ -1,2 +1,2 @@
-version=3.0.7
+version=3.0.8
 artifactId=firebase-crashlytics-gradle


### PR DESCRIPTION
Bump the version for Crashlytics Gradle plugin and buildtools jar to `3.0.8`