### PR TITLE
feat(firestore): add DML stages, literals source, and atomic execution option to Android SDK pipelines

### DIFF
--- a/firebase-firestore/api.txt
+++ b/firebase-firestore/api.txt
@@ -441,7 +441,7 @@ package com.google.firebase.firestore {
     method public com.google.firebase.firestore.Pipeline findNearest(com.google.firebase.firestore.pipeline.Field vectorField, double[] vectorValue, com.google.firebase.firestore.pipeline.FindNearestStage.DistanceMeasure distanceMeasure);
     method public com.google.firebase.firestore.Pipeline findNearest(String vectorField, com.google.firebase.firestore.pipeline.Expression vectorValue, com.google.firebase.firestore.pipeline.FindNearestStage.DistanceMeasure distanceMeasure, com.google.firebase.firestore.pipeline.FindNearestOptions options);
     method public com.google.firebase.firestore.Pipeline findNearest(String vectorField, double[] vectorValue, com.google.firebase.firestore.pipeline.FindNearestStage.DistanceMeasure distanceMeasure);
-    method public com.google.firebase.firestore.Pipeline insert(String collectionPath, com.google.firebase.firestore.pipeline.Expression documentIdExpr);
+    method public com.google.firebase.firestore.Pipeline insert(String collectionPath, com.google.firebase.firestore.pipeline.Expression? documentIdExpr);
     method public com.google.firebase.firestore.Pipeline limit(int limit);
     method public com.google.firebase.firestore.Pipeline offset(int offset);
     method public com.google.firebase.firestore.Pipeline rawStage(com.google.firebase.firestore.pipeline.RawStage rawStage);

--- a/firebase-firestore/api.txt
+++ b/firebase-firestore/api.txt
@@ -433,6 +433,7 @@ package com.google.firebase.firestore {
     method public com.google.firebase.firestore.Pipeline aggregate(com.google.firebase.firestore.pipeline.AggregateStage aggregateStage, com.google.firebase.firestore.pipeline.AggregateOptions options);
     method public com.google.firebase.firestore.Pipeline aggregate(com.google.firebase.firestore.pipeline.AliasedAggregate accumulator, com.google.firebase.firestore.pipeline.AliasedAggregate... additionalAccumulators);
     method public com.google.firebase.firestore.Pipeline define(com.google.firebase.firestore.pipeline.AliasedExpression aliasedExpression, com.google.firebase.firestore.pipeline.AliasedExpression... additionalExpressions);
+    method public com.google.firebase.firestore.Pipeline delete();
     method public com.google.firebase.firestore.Pipeline distinct(com.google.firebase.firestore.pipeline.Selectable group, java.lang.Object... additionalGroups);
     method public com.google.firebase.firestore.Pipeline distinct(String groupField, java.lang.Object... additionalGroups);
     method public com.google.android.gms.tasks.Task<com.google.firebase.firestore.Pipeline.Snapshot> execute();
@@ -440,6 +441,7 @@ package com.google.firebase.firestore {
     method public com.google.firebase.firestore.Pipeline findNearest(com.google.firebase.firestore.pipeline.Field vectorField, double[] vectorValue, com.google.firebase.firestore.pipeline.FindNearestStage.DistanceMeasure distanceMeasure);
     method public com.google.firebase.firestore.Pipeline findNearest(String vectorField, com.google.firebase.firestore.pipeline.Expression vectorValue, com.google.firebase.firestore.pipeline.FindNearestStage.DistanceMeasure distanceMeasure, com.google.firebase.firestore.pipeline.FindNearestOptions options);
     method public com.google.firebase.firestore.Pipeline findNearest(String vectorField, double[] vectorValue, com.google.firebase.firestore.pipeline.FindNearestStage.DistanceMeasure distanceMeasure);
+    method public com.google.firebase.firestore.Pipeline insert(String collectionPath, com.google.firebase.firestore.pipeline.Expression documentIdExpr);
     method public com.google.firebase.firestore.Pipeline limit(int limit);
     method public com.google.firebase.firestore.Pipeline offset(int offset);
     method public com.google.firebase.firestore.Pipeline rawStage(com.google.firebase.firestore.pipeline.RawStage rawStage);
@@ -460,11 +462,14 @@ package com.google.firebase.firestore {
     method public com.google.firebase.firestore.Pipeline unnest(com.google.firebase.firestore.pipeline.Selectable arrayWithAlias, com.google.firebase.firestore.pipeline.UnnestOptions options);
     method public com.google.firebase.firestore.Pipeline unnest(com.google.firebase.firestore.pipeline.UnnestStage unnestStage);
     method public com.google.firebase.firestore.Pipeline unnest(String arrayField, String alias);
+    method public com.google.firebase.firestore.Pipeline update(com.google.firebase.firestore.pipeline.Selectable... fields);
+    method public com.google.firebase.firestore.Pipeline upsert(com.google.firebase.firestore.pipeline.Selectable[] transforms, String? collectionPath, com.google.firebase.firestore.pipeline.Expression? documentIdExpr);
     method public com.google.firebase.firestore.Pipeline where(com.google.firebase.firestore.pipeline.BooleanExpression condition);
   }
 
   public static final class Pipeline.ExecuteOptions extends com.google.firebase.firestore.pipeline.AbstractOptions<com.google.firebase.firestore.Pipeline.ExecuteOptions> {
     ctor public Pipeline.ExecuteOptions();
+    method public com.google.firebase.firestore.Pipeline.ExecuteOptions withAtomic(boolean atomic);
     method public com.google.firebase.firestore.Pipeline.ExecuteOptions withIndexMode(com.google.firebase.firestore.Pipeline.ExecuteOptions.IndexMode indexMode);
   }
 
@@ -508,6 +513,8 @@ package com.google.firebase.firestore {
     method public com.google.firebase.firestore.Pipeline database();
     method public com.google.firebase.firestore.Pipeline documents(com.google.firebase.firestore.DocumentReference... documents);
     method public com.google.firebase.firestore.Pipeline documents(java.lang.String... documents);
+    method public com.google.firebase.firestore.Pipeline literals(java.util.List<? extends java.util.Map<java.lang.String, ?>> data);
+    method public com.google.firebase.firestore.Pipeline literals(java.util.Map<java.lang.String, ?>... data);
     method public static com.google.firebase.firestore.Pipeline subcollection(com.google.firebase.firestore.pipeline.SubcollectionSource source);
     method public static com.google.firebase.firestore.Pipeline subcollection(String path);
     field public static final com.google.firebase.firestore.PipelineSource.Companion Companion;

--- a/firebase-firestore/api.txt
+++ b/firebase-firestore/api.txt
@@ -441,7 +441,7 @@ package com.google.firebase.firestore {
     method public com.google.firebase.firestore.Pipeline findNearest(com.google.firebase.firestore.pipeline.Field vectorField, double[] vectorValue, com.google.firebase.firestore.pipeline.FindNearestStage.DistanceMeasure distanceMeasure);
     method public com.google.firebase.firestore.Pipeline findNearest(String vectorField, com.google.firebase.firestore.pipeline.Expression vectorValue, com.google.firebase.firestore.pipeline.FindNearestStage.DistanceMeasure distanceMeasure, com.google.firebase.firestore.pipeline.FindNearestOptions options);
     method public com.google.firebase.firestore.Pipeline findNearest(String vectorField, double[] vectorValue, com.google.firebase.firestore.pipeline.FindNearestStage.DistanceMeasure distanceMeasure);
-    method public com.google.firebase.firestore.Pipeline insert(String collectionPath, com.google.firebase.firestore.pipeline.Expression? documentIdExpr);
+    method public com.google.firebase.firestore.Pipeline insert(String collectionPath, com.google.firebase.firestore.pipeline.Expression? documentIdExpression);
     method public com.google.firebase.firestore.Pipeline limit(int limit);
     method public com.google.firebase.firestore.Pipeline offset(int offset);
     method public com.google.firebase.firestore.Pipeline rawStage(com.google.firebase.firestore.pipeline.RawStage rawStage);
@@ -463,7 +463,7 @@ package com.google.firebase.firestore {
     method public com.google.firebase.firestore.Pipeline unnest(com.google.firebase.firestore.pipeline.UnnestStage unnestStage);
     method public com.google.firebase.firestore.Pipeline unnest(String arrayField, String alias);
     method public com.google.firebase.firestore.Pipeline update(com.google.firebase.firestore.pipeline.Selectable... fields);
-    method public com.google.firebase.firestore.Pipeline upsert(com.google.firebase.firestore.pipeline.Selectable[] transforms, String? collectionPath, com.google.firebase.firestore.pipeline.Expression? documentIdExpr);
+    method public com.google.firebase.firestore.Pipeline upsert(com.google.firebase.firestore.pipeline.Selectable[] transforms, String? collectionPath, com.google.firebase.firestore.pipeline.Expression? documentIdExpression);
     method public com.google.firebase.firestore.Pipeline where(com.google.firebase.firestore.pipeline.BooleanExpression condition);
   }
 

--- a/firebase-firestore/api.txt
+++ b/firebase-firestore/api.txt
@@ -463,7 +463,12 @@ package com.google.firebase.firestore {
     method public com.google.firebase.firestore.Pipeline unnest(com.google.firebase.firestore.pipeline.UnnestStage unnestStage);
     method public com.google.firebase.firestore.Pipeline unnest(String arrayField, String alias);
     method public com.google.firebase.firestore.Pipeline update(com.google.firebase.firestore.pipeline.Selectable... fields);
-    method public com.google.firebase.firestore.Pipeline upsert(com.google.firebase.firestore.pipeline.Selectable[] transforms, String? collectionPath, com.google.firebase.firestore.pipeline.Expression? documentIdExpression);
+    method public com.google.firebase.firestore.Pipeline upsert(com.google.firebase.firestore.pipeline.Selectable... additionalFields);
+    method public com.google.firebase.firestore.Pipeline upsert(java.util.List<? extends com.google.firebase.firestore.pipeline.Selectable> additionalFields);
+    method public com.google.firebase.firestore.Pipeline upsert(String collectionPath);
+    method public com.google.firebase.firestore.Pipeline upsert(String collectionPath, com.google.firebase.firestore.pipeline.Expression? documentIdExpression);
+    method public com.google.firebase.firestore.Pipeline upsert(String collectionPath, com.google.firebase.firestore.pipeline.Expression? documentIdExpression, com.google.firebase.firestore.pipeline.Selectable[] additionalFields);
+    method public com.google.firebase.firestore.Pipeline upsert(String collectionPath, com.google.firebase.firestore.pipeline.Expression? documentIdExpression, java.util.List<? extends com.google.firebase.firestore.pipeline.Selectable> additionalFields);
     method public com.google.firebase.firestore.Pipeline where(com.google.firebase.firestore.pipeline.BooleanExpression condition);
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/PipelineTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/PipelineTest.java
@@ -4290,4 +4290,57 @@ public class PipelineTest {
     }
     return Collections.unmodifiableMap(res);
   }
+
+  @Test
+  public void testDeleteStage() {
+    CollectionReference collection = testCollection();
+    Pipeline.Snapshot snapshot =
+        waitFor(collection.toPipeline().where(equal(field("__name__"), constant("book1"))).delete().execute());
+    assertThat(snapshot).isNotNull();
+  }
+
+  @Test
+  public void testUpdateStage() {
+    CollectionReference collection = testCollection();
+    Pipeline.Snapshot snapshot =
+        waitFor(
+            collection
+                .toPipeline()
+                .where(equal(field("__name__"), constant("book1")))
+                .update(constant("Updated").as("status"))
+                .execute());
+    assertThat(snapshot).isNotNull();
+  }
+
+  @Test
+  public void testInsertStage() {
+    CollectionReference collection = testCollection();
+    Map<String, Object> data = new HashMap<>();
+    data.put("title", "New Book");
+    Pipeline.Snapshot snapshot =
+        waitFor(
+            db.pipeline()
+                .literals(data)
+                .insert(collection.getPath(), constant("newBook_insert_1"))
+                .execute());
+    assertThat(snapshot).isNotNull();
+  }
+
+  @Test
+  public void testUpsertStage() {
+    CollectionReference collection = testCollection();
+    Map<String, Object> data = new HashMap<>();
+    data.put("title", "Upsert Book");
+    data.put("count", 1);
+    Pipeline.Snapshot snapshot =
+        waitFor(
+            db.pipeline()
+                .literals(data)
+                .upsert(
+                    add(field("count"), constant(1)).as("count"),
+                    collection.getPath(),
+                    constant("upsertBook_1"))
+                .execute(new Pipeline.ExecuteOptions().withAtomic(true)));
+    assertThat(snapshot).isNotNull();
+  }
 }

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/PipelineTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/PipelineTest.java
@@ -4295,7 +4295,12 @@ public class PipelineTest {
   public void testDeleteStage() {
     CollectionReference collection = testCollection();
     Pipeline.Snapshot snapshot =
-        waitFor(collection.toPipeline().where(equal(field("__name__"), constant("book1"))).delete().execute());
+        waitFor(
+            collection
+                .toPipeline()
+                .where(equal(field("__name__"), constant("book1")))
+                .delete()
+                .execute());
     assertThat(snapshot).isNotNull();
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Pipeline.kt
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Pipeline.kt
@@ -1127,8 +1127,11 @@ internal constructor(
 
   fun update(vararg fields: Selectable): Pipeline = append(UpdateStage(fields))
 
+  @JvmOverloads
   fun insert(collectionPath: String, documentIdExpr: Expression? = null): Pipeline =
     append(InsertStage(collectionPath, documentIdExpr))
+
+  fun upsert(vararg transforms: Selectable): Pipeline = append(UpsertStage(transforms))
 
   fun upsert(
     vararg transforms: Selectable,
@@ -1140,9 +1143,7 @@ internal constructor(
 /** Start of a Firestore Pipeline */
 class PipelineSource internal constructor(private val firestore: FirebaseFirestore) {
 
-  /**
-   * Set the pipeline's source to literal document maps.
-   */
+  /** Set the pipeline's source to literal document maps. */
   fun literals(vararg data: Map<String, Any?>): Pipeline = literals(data.toList())
 
   fun literals(data: List<Map<String, Any?>>): Pipeline =
@@ -1275,6 +1276,9 @@ class PipelineSource internal constructor(private val firestore: FirebaseFiresto
    * @throws [IllegalArgumentException] Thrown if the [documents] provided targets a different
    * project or database than the pipeline.
    */
+  @JvmName("documents")
+  fun documents(documents: List<DocumentReference>): Pipeline = documents(*documents.toTypedArray())
+
   fun documents(vararg documents: DocumentReference): Pipeline {
     val databaseId = firestore.databaseId
     for (document in documents) {
@@ -1290,6 +1294,9 @@ class PipelineSource internal constructor(private val firestore: FirebaseFiresto
       DocumentsSource(documents.map { ResourcePath.fromString(it.path) }.toTypedArray())
     )
   }
+
+  @JvmName("documentsByPath")
+  fun documents(documents: List<String>): Pipeline = documents(*documents.toTypedArray())
 
   companion object {
     /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Pipeline.kt
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Pipeline.kt
@@ -1127,7 +1127,7 @@ internal constructor(
 
   fun update(vararg fields: Selectable): Pipeline = append(UpdateStage(fields))
 
-  fun insert(collectionPath: String, documentIdExpr: Expression): Pipeline =
+  fun insert(collectionPath: String, documentIdExpr: Expression? = null): Pipeline =
     append(InsertStage(collectionPath, documentIdExpr))
 
   fun upsert(

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Pipeline.kt
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Pipeline.kt
@@ -36,6 +36,7 @@ import com.google.firebase.firestore.pipeline.CollectionSource
 import com.google.firebase.firestore.pipeline.CollectionSourceOptions
 import com.google.firebase.firestore.pipeline.DatabaseSource
 import com.google.firebase.firestore.pipeline.DefineStage
+import com.google.firebase.firestore.pipeline.DeleteStage
 import com.google.firebase.firestore.pipeline.DistinctStage
 import com.google.firebase.firestore.pipeline.DocumentsSource
 import com.google.firebase.firestore.pipeline.Expression
@@ -44,8 +45,10 @@ import com.google.firebase.firestore.pipeline.Field
 import com.google.firebase.firestore.pipeline.FindNearestOptions
 import com.google.firebase.firestore.pipeline.FindNearestStage
 import com.google.firebase.firestore.pipeline.FunctionExpression
+import com.google.firebase.firestore.pipeline.InsertStage
 import com.google.firebase.firestore.pipeline.InternalOptions
 import com.google.firebase.firestore.pipeline.LimitStage
+import com.google.firebase.firestore.pipeline.LiteralsSource
 import com.google.firebase.firestore.pipeline.OffsetStage
 import com.google.firebase.firestore.pipeline.Ordering
 import com.google.firebase.firestore.pipeline.RawStage
@@ -61,6 +64,8 @@ import com.google.firebase.firestore.pipeline.SubcollectionSource
 import com.google.firebase.firestore.pipeline.UnionStage
 import com.google.firebase.firestore.pipeline.UnnestOptions
 import com.google.firebase.firestore.pipeline.UnnestStage
+import com.google.firebase.firestore.pipeline.UpdateStage
+import com.google.firebase.firestore.pipeline.UpsertStage
 import com.google.firebase.firestore.pipeline.WhereStage
 import com.google.firebase.firestore.pipeline.evaluation.notImplemented
 import com.google.firebase.firestore.remote.RemoteSerializer
@@ -68,6 +73,7 @@ import com.google.firebase.firestore.util.Logger
 import com.google.firestore.v1.ExecutePipelineRequest
 import com.google.firestore.v1.Pipeline as ProtoPipeline
 import com.google.firestore.v1.StructuredPipeline
+import com.google.firestore.v1.TransactionOptions
 import com.google.firestore.v1.Value
 
 /**
@@ -112,6 +118,8 @@ internal constructor(
     }
 
     fun withIndexMode(indexMode: IndexMode): ExecuteOptions = with("index_mode", indexMode.value)
+
+    fun withAtomic(atomic: Boolean): ExecuteOptions = with("atomic", atomic)
   }
 
   /**
@@ -176,6 +184,13 @@ internal constructor(
     val builder = ExecutePipelineRequest.newBuilder()
     builder.database = "projects/${database.projectId}/databases/${database.databaseId}"
     builder.structuredPipeline = toStructuredPipelineProto(options, firestore.userDataReader)
+    if (options != null && options.hasAtomic()) {
+      builder.newTransaction =
+        TransactionOptions.newBuilder()
+          .setReadWrite(TransactionOptions.ReadWrite.getDefaultInstance())
+          .build()
+      builder.autoCommitTransaction = true
+    }
     return builder.build()
   }
 
@@ -1107,10 +1122,31 @@ internal constructor(
    * @return A new `Pipeline` object with this stage appended to the stage list.
    */
   @Beta fun search(searchStage: SearchStage): Pipeline = append(searchStage)
+
+  fun delete(): Pipeline = append(DeleteStage())
+
+  fun update(vararg fields: Selectable): Pipeline = append(UpdateStage(fields))
+
+  fun insert(collectionPath: String, documentIdExpr: Expression): Pipeline =
+    append(InsertStage(collectionPath, documentIdExpr))
+
+  fun upsert(
+    vararg transforms: Selectable,
+    collectionPath: String? = null,
+    documentIdExpr: Expression? = null
+  ): Pipeline = append(UpsertStage(transforms, collectionPath, documentIdExpr))
 }
 
 /** Start of a Firestore Pipeline */
 class PipelineSource internal constructor(private val firestore: FirebaseFirestore) {
+
+  /**
+   * Set the pipeline's source to literal document maps.
+   */
+  fun literals(vararg data: Map<String, Any?>): Pipeline = literals(data.toList())
+
+  fun literals(data: List<Map<String, Any?>>): Pipeline =
+    Pipeline(firestore, firestore.userDataReader, listOf(LiteralsSource(data)))
 
   /**
    * Convert the given Query into an equivalent Pipeline.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Pipeline.kt
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Pipeline.kt
@@ -1131,13 +1131,61 @@ internal constructor(
   fun insert(collectionPath: String, documentIdExpression: Expression? = null): Pipeline =
     append(InsertStage(collectionPath, documentIdExpression))
 
-  fun upsert(vararg transforms: Selectable): Pipeline = append(UpsertStage(transforms))
+  /**
+   * Modifies pipeline documents in-place by setting or updating the specified fields.
+   *
+   * @param additionalFields The fields to set or update.
+   * @return A new [Pipeline] object with this stage appended to the stage list.
+   */
+  fun upsert(vararg additionalFields: Selectable): Pipeline =
+    append(UpsertStage(fields = additionalFields))
 
+  /**
+   * Modifies pipeline documents in-place by setting or updating the specified fields.
+   *
+   * @param additionalFields The list of fields to set or update.
+   * @return A new [Pipeline] object with this stage appended to the stage list.
+   */
+  fun upsert(additionalFields: List<Selectable>): Pipeline =
+    append(UpsertStage(fields = additionalFields.toTypedArray()))
+
+  /**
+   * Writes pipeline documents to a destination collection, creating or updating them.
+   *
+   * @param collectionPath The target collection path to write documents to.
+   * @param documentIdExpression An optional expression that evaluates to the document ID. If null,
+   * an auto-generated document ID will be used.
+   * @param additionalFields Additional fields to set or update during the upsert.
+   * @return A new [Pipeline] object with this stage appended to the stage list.
+   */
+  @JvmOverloads
   fun upsert(
-    vararg transforms: Selectable,
-    collectionPath: String? = null,
-    documentIdExpression: Expression? = null
-  ): Pipeline = append(UpsertStage(transforms, collectionPath, documentIdExpression))
+    collectionPath: String,
+    documentIdExpression: Expression? = null,
+    additionalFields: Array<Selectable> = emptyArray()
+  ): Pipeline =
+    append(
+      UpsertStage(
+        fields = additionalFields,
+        collectionPath = collectionPath,
+        documentIdExpression = documentIdExpression
+      )
+    )
+
+  /**
+   * Writes pipeline documents to a destination collection, creating or updating them.
+   *
+   * @param collectionPath The target collection path to write documents to.
+   * @param documentIdExpression An optional expression that evaluates to the document ID. If null,
+   * an auto-generated document ID will be used.
+   * @param additionalFields The list of additional fields to set or update during the upsert.
+   * @return A new [Pipeline] object with this stage appended to the stage list.
+   */
+  fun upsert(
+    collectionPath: String,
+    documentIdExpression: Expression? = null,
+    additionalFields: List<Selectable>
+  ): Pipeline = upsert(collectionPath, documentIdExpression, additionalFields.toTypedArray())
 }
 
 /** Start of a Firestore Pipeline */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Pipeline.kt
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Pipeline.kt
@@ -1128,16 +1128,16 @@ internal constructor(
   fun update(vararg fields: Selectable): Pipeline = append(UpdateStage(fields))
 
   @JvmOverloads
-  fun insert(collectionPath: String, documentIdExpr: Expression? = null): Pipeline =
-    append(InsertStage(collectionPath, documentIdExpr))
+  fun insert(collectionPath: String, documentIdExpression: Expression? = null): Pipeline =
+    append(InsertStage(collectionPath, documentIdExpression))
 
   fun upsert(vararg transforms: Selectable): Pipeline = append(UpsertStage(transforms))
 
   fun upsert(
     vararg transforms: Selectable,
     collectionPath: String? = null,
-    documentIdExpr: Expression? = null
-  ): Pipeline = append(UpsertStage(transforms, collectionPath, documentIdExpr))
+    documentIdExpression: Expression? = null
+  ): Pipeline = append(UpsertStage(transforms, collectionPath, documentIdExpression))
 }
 
 /** Start of a Firestore Pipeline */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/pipeline/expressions.kt
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/pipeline/expressions.kt
@@ -8215,6 +8215,8 @@ abstract class Expression internal constructor() {
    */
   open fun alias(alias: String): AliasedExpression = AliasedExpression(alias, this)
 
+  open fun `as`(alias: String): AliasedExpression = alias(alias)
+
   /**
    * Creates an expression that returns the document ID from this path expression.
    *

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/pipeline/options.kt
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/pipeline/options.kt
@@ -64,6 +64,10 @@ internal constructor(private val options: ImmutableMap<String, Value>) {
     }
   }
 
+  internal fun hasAtomic(): Boolean {
+    return options.containsKey("atomic") && options["atomic"]?.booleanValue == true
+  }
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other !is InternalOptions) return false

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/pipeline/stage.kt
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/pipeline/stage.kt
@@ -1737,10 +1737,8 @@ internal constructor(
   }
 }
 
-internal class DeleteStage
-internal constructor(
-  options: InternalOptions = InternalOptions.EMPTY
-) : Stage<DeleteStage>("delete", options) {
+internal class DeleteStage internal constructor(options: InternalOptions = InternalOptions.EMPTY) :
+  Stage<DeleteStage>("delete", options) {
   override fun self(options: InternalOptions) = DeleteStage(options)
   override fun canonicalId(): String = "delete()"
   override fun args(userDataReader: UserDataReader): Sequence<Value> = emptySequence()
@@ -1789,11 +1787,19 @@ internal constructor(
   internal val collectionPath: String?,
   internal val documentIdExpr: Expression?,
   options: InternalOptions = InternalOptions.EMPTY
-) : Stage<InsertStage>("insert", buildOptions(collectionPath, documentIdExpr, options)) {
+) : Stage<InsertStage>("insert", buildOptions(collectionPath, options)) {
 
   override fun self(options: InternalOptions) = InsertStage(collectionPath, documentIdExpr, options)
   override fun canonicalId(): String = "insert($collectionPath)"
   override fun args(userDataReader: UserDataReader): Sequence<Value> = emptySequence()
+
+  override fun toProtoStage(userDataReader: UserDataReader): Pipeline.Stage {
+    var completeOptions = options
+    if (documentIdExpr != null) {
+      completeOptions = completeOptions.with("document_id", documentIdExpr.toProto(userDataReader))
+    }
+    return toProtoStage(name, args(userDataReader), completeOptions, userDataReader)
+  }
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
@@ -1813,16 +1819,12 @@ internal constructor(
   companion object {
     private fun buildOptions(
       collectionPath: String?,
-      documentIdExpr: Expression?,
       baseOptions: InternalOptions
     ): InternalOptions {
       var opts = baseOptions
       if (collectionPath != null) {
         val path = if (collectionPath.startsWith("/")) collectionPath else "/$collectionPath"
         opts = opts.with("collection", Value.newBuilder().setReferenceValue(path).build())
-      }
-      if (documentIdExpr != null) {
-        opts = opts.with("document_id", documentIdExpr.toProto())
       }
       return opts
     }
@@ -1832,10 +1834,10 @@ internal constructor(
 internal class UpsertStage
 internal constructor(
   private val fields: Array<out Selectable>,
-  internal val collectionPath: String?,
-  internal val documentIdExpr: Expression?,
+  internal val collectionPath: String? = null,
+  internal val documentIdExpr: Expression? = null,
   options: InternalOptions = InternalOptions.EMPTY
-) : Stage<UpsertStage>("upsert", buildOptions(collectionPath, documentIdExpr, options)) {
+) : Stage<UpsertStage>("upsert", buildOptions(collectionPath, options)) {
 
   override fun self(options: InternalOptions) =
     UpsertStage(fields, collectionPath, documentIdExpr, options)
@@ -1847,6 +1849,14 @@ internal constructor(
     } else {
       emptySequence()
     }
+  }
+
+  override fun toProtoStage(userDataReader: UserDataReader): Pipeline.Stage {
+    var completeOptions = options
+    if (documentIdExpr != null) {
+      completeOptions = completeOptions.with("document_id", documentIdExpr.toProto(userDataReader))
+    }
+    return toProtoStage(name, args(userDataReader), completeOptions, userDataReader)
   }
 
   override fun equals(other: Any?): Boolean {
@@ -1869,16 +1879,12 @@ internal constructor(
   companion object {
     private fun buildOptions(
       collectionPath: String?,
-      documentIdExpr: Expression?,
       baseOptions: InternalOptions
     ): InternalOptions {
       var opts = baseOptions
       if (collectionPath != null) {
         val path = if (collectionPath.startsWith("/")) collectionPath else "/$collectionPath"
         opts = opts.with("collection", Value.newBuilder().setReferenceValue(path).build())
-      }
-      if (documentIdExpr != null) {
-        opts = opts.with("document_id", documentIdExpr.toProto())
       }
       return opts
     }
@@ -1902,9 +1908,12 @@ internal constructor(
     val mapValue = com.google.firestore.v1.MapValue.newBuilder()
     for ((key, value) in map) {
       when (value) {
-        is Expression -> mapValue.putFields(key, value.toProto())
-        is Map<*, *> -> @Suppress("UNCHECKED_CAST") mapValue.putFields(key, encodeLiteralMap(value as Map<String, Any?>, userDataReader))
-        else -> mapValue.putFields(key, Values.encodeValue(value))
+        null -> mapValue.putFields(key, Values.NULL_VALUE)
+        is Expression -> mapValue.putFields(key, value.toProto(userDataReader))
+        is Map<*, *> ->
+          @Suppress("UNCHECKED_CAST")
+          mapValue.putFields(key, encodeLiteralMap(value as Map<String, Any?>, userDataReader))
+        else -> mapValue.putFields(key, userDataReader.parseQueryValue(value))
       }
     }
     return Value.newBuilder().setMapValue(mapValue).build()

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/pipeline/stage.kt
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/pipeline/stage.kt
@@ -1736,3 +1736,190 @@ internal constructor(
     return result
   }
 }
+
+internal class DeleteStage
+internal constructor(
+  options: InternalOptions = InternalOptions.EMPTY
+) : Stage<DeleteStage>("delete", options) {
+  override fun self(options: InternalOptions) = DeleteStage(options)
+  override fun canonicalId(): String = "delete()"
+  override fun args(userDataReader: UserDataReader): Sequence<Value> = emptySequence()
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is DeleteStage) return false
+    return options == other.options
+  }
+
+  override fun hashCode(): Int = options.hashCode()
+}
+
+internal class UpdateStage
+internal constructor(
+  private val fields: Array<out Selectable>,
+  options: InternalOptions = InternalOptions.EMPTY
+) : Stage<UpdateStage>("update", options) {
+  override fun self(options: InternalOptions) = UpdateStage(fields, options)
+  override fun canonicalId(): String = "update()"
+
+  override fun args(userDataReader: UserDataReader): Sequence<Value> {
+    return if (fields.isNotEmpty()) {
+      sequenceOf(encodeValue(associateWithoutDuplications(fields, userDataReader)))
+    } else {
+      sequenceOf(encodeValue(emptyMap<String, Value>()))
+    }
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is UpdateStage) return false
+    if (!fields.contentEquals(other.fields)) return false
+    return options == other.options
+  }
+
+  override fun hashCode(): Int {
+    var result = fields.contentHashCode()
+    result = 31 * result + options.hashCode()
+    return result
+  }
+}
+
+internal class InsertStage
+internal constructor(
+  internal val collectionPath: String?,
+  internal val documentIdExpr: Expression?,
+  options: InternalOptions = InternalOptions.EMPTY
+) : Stage<InsertStage>("insert", buildOptions(collectionPath, documentIdExpr, options)) {
+
+  override fun self(options: InternalOptions) = InsertStage(collectionPath, documentIdExpr, options)
+  override fun canonicalId(): String = "insert($collectionPath)"
+  override fun args(userDataReader: UserDataReader): Sequence<Value> = emptySequence()
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is InsertStage) return false
+    if (collectionPath != other.collectionPath) return false
+    if (documentIdExpr != other.documentIdExpr) return false
+    return options == other.options
+  }
+
+  override fun hashCode(): Int {
+    var result = collectionPath?.hashCode() ?: 0
+    result = 31 * result + (documentIdExpr?.hashCode() ?: 0)
+    result = 31 * result + options.hashCode()
+    return result
+  }
+
+  companion object {
+    private fun buildOptions(
+      collectionPath: String?,
+      documentIdExpr: Expression?,
+      baseOptions: InternalOptions
+    ): InternalOptions {
+      var opts = baseOptions
+      if (collectionPath != null) {
+        val path = if (collectionPath.startsWith("/")) collectionPath else "/$collectionPath"
+        opts = opts.with("collection", Value.newBuilder().setReferenceValue(path).build())
+      }
+      if (documentIdExpr != null) {
+        opts = opts.with("document_id", documentIdExpr.toProto())
+      }
+      return opts
+    }
+  }
+}
+
+internal class UpsertStage
+internal constructor(
+  private val fields: Array<out Selectable>,
+  internal val collectionPath: String?,
+  internal val documentIdExpr: Expression?,
+  options: InternalOptions = InternalOptions.EMPTY
+) : Stage<UpsertStage>("upsert", buildOptions(collectionPath, documentIdExpr, options)) {
+
+  override fun self(options: InternalOptions) =
+    UpsertStage(fields, collectionPath, documentIdExpr, options)
+  override fun canonicalId(): String = "upsert($collectionPath)"
+
+  override fun args(userDataReader: UserDataReader): Sequence<Value> {
+    return if (fields.isNotEmpty()) {
+      sequenceOf(encodeValue(associateWithoutDuplications(fields, userDataReader)))
+    } else {
+      emptySequence()
+    }
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is UpsertStage) return false
+    if (!fields.contentEquals(other.fields)) return false
+    if (collectionPath != other.collectionPath) return false
+    if (documentIdExpr != other.documentIdExpr) return false
+    return options == other.options
+  }
+
+  override fun hashCode(): Int {
+    var result = fields.contentHashCode()
+    result = 31 * result + (collectionPath?.hashCode() ?: 0)
+    result = 31 * result + (documentIdExpr?.hashCode() ?: 0)
+    result = 31 * result + options.hashCode()
+    return result
+  }
+
+  companion object {
+    private fun buildOptions(
+      collectionPath: String?,
+      documentIdExpr: Expression?,
+      baseOptions: InternalOptions
+    ): InternalOptions {
+      var opts = baseOptions
+      if (collectionPath != null) {
+        val path = if (collectionPath.startsWith("/")) collectionPath else "/$collectionPath"
+        opts = opts.with("collection", Value.newBuilder().setReferenceValue(path).build())
+      }
+      if (documentIdExpr != null) {
+        opts = opts.with("document_id", documentIdExpr.toProto())
+      }
+      return opts
+    }
+  }
+}
+
+class LiteralsSource
+internal constructor(
+  internal val data: List<Map<String, Any?>>,
+  options: InternalOptions = InternalOptions.EMPTY
+) : Stage<LiteralsSource>("literals", options) {
+
+  override fun self(options: InternalOptions) = LiteralsSource(data, options)
+  override fun canonicalId(): String = "literals()"
+
+  override fun args(userDataReader: UserDataReader): Sequence<Value> {
+    return data.asSequence().map { encodeLiteralMap(it, userDataReader) }
+  }
+
+  private fun encodeLiteralMap(map: Map<String, Any?>, userDataReader: UserDataReader): Value {
+    val mapValue = com.google.firestore.v1.MapValue.newBuilder()
+    for ((key, value) in map) {
+      when (value) {
+        is Expression -> mapValue.putFields(key, value.toProto())
+        is Map<*, *> -> @Suppress("UNCHECKED_CAST") mapValue.putFields(key, encodeLiteralMap(value as Map<String, Any?>, userDataReader))
+        else -> mapValue.putFields(key, Values.encodeValue(value))
+      }
+    }
+    return Value.newBuilder().setMapValue(mapValue).build()
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is LiteralsSource) return false
+    if (data != other.data) return false
+    return options == other.options
+  }
+
+  override fun hashCode(): Int {
+    var result = data.hashCode()
+    result = 31 * result + options.hashCode()
+    return result
+  }
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/pipeline/stage.kt
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/pipeline/stage.kt
@@ -1835,11 +1835,21 @@ internal constructor(
 
 internal class UpsertStage
 internal constructor(
-  private val fields: Array<out Selectable>,
+  private val fields: Array<out Selectable> = emptyArray(),
   internal val collectionPath: String? = null,
   internal val documentIdExpression: Expression? = null,
   options: InternalOptions = InternalOptions.EMPTY
 ) : Stage<UpsertStage>("upsert", buildOptions(collectionPath, options)) {
+
+  internal val additionalFields: Array<out Selectable>
+    get() = fields
+
+  internal constructor(
+    collectionPath: String?,
+    documentIdExpression: Expression? = null,
+    additionalFields: Array<out Selectable> = emptyArray(),
+    options: InternalOptions = InternalOptions.EMPTY
+  ) : this(additionalFields, collectionPath, documentIdExpression, options)
 
   override fun self(options: InternalOptions) =
     UpsertStage(fields, collectionPath, documentIdExpression, options)

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/pipeline/stage.kt
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/pipeline/stage.kt
@@ -1785,18 +1785,20 @@ internal constructor(
 internal class InsertStage
 internal constructor(
   internal val collectionPath: String?,
-  internal val documentIdExpr: Expression?,
+  internal val documentIdExpression: Expression?,
   options: InternalOptions = InternalOptions.EMPTY
 ) : Stage<InsertStage>("insert", buildOptions(collectionPath, options)) {
 
-  override fun self(options: InternalOptions) = InsertStage(collectionPath, documentIdExpr, options)
+  override fun self(options: InternalOptions) =
+    InsertStage(collectionPath, documentIdExpression, options)
   override fun canonicalId(): String = "insert($collectionPath)"
   override fun args(userDataReader: UserDataReader): Sequence<Value> = emptySequence()
 
   override fun toProtoStage(userDataReader: UserDataReader): Pipeline.Stage {
     var completeOptions = options
-    if (documentIdExpr != null) {
-      completeOptions = completeOptions.with("document_id", documentIdExpr.toProto(userDataReader))
+    if (documentIdExpression != null) {
+      completeOptions =
+        completeOptions.with("document_id", documentIdExpression.toProto(userDataReader))
     }
     return toProtoStage(name, args(userDataReader), completeOptions, userDataReader)
   }
@@ -1805,13 +1807,13 @@ internal constructor(
     if (this === other) return true
     if (other !is InsertStage) return false
     if (collectionPath != other.collectionPath) return false
-    if (documentIdExpr != other.documentIdExpr) return false
+    if (documentIdExpression != other.documentIdExpression) return false
     return options == other.options
   }
 
   override fun hashCode(): Int {
     var result = collectionPath?.hashCode() ?: 0
-    result = 31 * result + (documentIdExpr?.hashCode() ?: 0)
+    result = 31 * result + (documentIdExpression?.hashCode() ?: 0)
     result = 31 * result + options.hashCode()
     return result
   }
@@ -1835,12 +1837,12 @@ internal class UpsertStage
 internal constructor(
   private val fields: Array<out Selectable>,
   internal val collectionPath: String? = null,
-  internal val documentIdExpr: Expression? = null,
+  internal val documentIdExpression: Expression? = null,
   options: InternalOptions = InternalOptions.EMPTY
 ) : Stage<UpsertStage>("upsert", buildOptions(collectionPath, options)) {
 
   override fun self(options: InternalOptions) =
-    UpsertStage(fields, collectionPath, documentIdExpr, options)
+    UpsertStage(fields, collectionPath, documentIdExpression, options)
   override fun canonicalId(): String = "upsert($collectionPath)"
 
   override fun args(userDataReader: UserDataReader): Sequence<Value> {
@@ -1853,8 +1855,9 @@ internal constructor(
 
   override fun toProtoStage(userDataReader: UserDataReader): Pipeline.Stage {
     var completeOptions = options
-    if (documentIdExpr != null) {
-      completeOptions = completeOptions.with("document_id", documentIdExpr.toProto(userDataReader))
+    if (documentIdExpression != null) {
+      completeOptions =
+        completeOptions.with("document_id", documentIdExpression.toProto(userDataReader))
     }
     return toProtoStage(name, args(userDataReader), completeOptions, userDataReader)
   }
@@ -1864,14 +1867,14 @@ internal constructor(
     if (other !is UpsertStage) return false
     if (!fields.contentEquals(other.fields)) return false
     if (collectionPath != other.collectionPath) return false
-    if (documentIdExpr != other.documentIdExpr) return false
+    if (documentIdExpression != other.documentIdExpression) return false
     return options == other.options
   }
 
   override fun hashCode(): Int {
     var result = fields.contentHashCode()
     result = 31 * result + (collectionPath?.hashCode() ?: 0)
-    result = 31 * result + (documentIdExpr?.hashCode() ?: 0)
+    result = 31 * result + (documentIdExpression?.hashCode() ?: 0)
     result = 31 * result + options.hashCode()
     return result
   }

--- a/firebase-firestore/src/proto/google/firestore/v1/firestore.proto
+++ b/firebase-firestore/src/proto/google/firestore/v1/firestore.proto
@@ -617,6 +617,10 @@ message ExecutePipelineRequest {
 
   // Explain / analyze options for the pipeline.
   // ExplainOptions explain_options = 8 [(google.api.field_behavior) = OPTIONAL];
+
+  // Automatically commits the transaction after the pipeline has been executed.
+  // Only permitted in combination with `transaction` or `new_transaction`.
+  bool auto_commit_transaction = 9 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // The response for [Firestore.Execute][].

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/PipelineProtoTest.kt
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/PipelineProtoTest.kt
@@ -53,6 +53,8 @@ class PipelineProtoTest {
     val request = pipeline.toExecutePipelineRequest(null)
 
     assertThat(request.database).isEqualTo("projects/new-project/databases/(default)")
+    assertThat(request.hasNewTransaction()).isFalse()
+    assertThat(request.autoCommitTransaction).isFalse()
 
     val structuredPipeline = request.structuredPipeline
     val protoPipeline = structuredPipeline.pipeline

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/pipeline/DmlTests.kt
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/pipeline/DmlTests.kt
@@ -16,6 +16,7 @@ package com.google.firebase.firestore.pipeline
 
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.firestore.Pipeline
+import com.google.firebase.firestore.Pipeline.ExecuteOptions
 import com.google.firebase.firestore.TestUtil
 import com.google.firebase.firestore.pipeline.Expression.Companion.add
 import com.google.firebase.firestore.pipeline.Expression.Companion.constant
@@ -32,7 +33,7 @@ internal class DmlTests {
   @Test
   fun `delete stage generates delete proto`() {
     val pipeline = db.pipeline().collection("books").delete()
-    val proto = pipeline.toPipelineProto(db.userDataReader)
+    val proto = pipeline.toExecutePipelineRequest(null).structuredPipeline.pipeline
     assertThat(proto.stagesCount).isEqualTo(2)
 
     val stage = proto.getStages(1)
@@ -42,11 +43,8 @@ internal class DmlTests {
 
   @Test
   fun `update stage generates update proto with fields`() {
-    val pipeline =
-      db.pipeline()
-        .collection("books")
-        .update(constant("Updated").as("status"))
-    val proto = pipeline.toPipelineProto(db.userDataReader)
+    val pipeline = db.pipeline().collection("books").update(constant("Updated").`as`("status"))
+    val proto = pipeline.toExecutePipelineRequest(null).structuredPipeline.pipeline
     assertThat(proto.stagesCount).isEqualTo(2)
 
     val stage = proto.getStages(1)
@@ -58,10 +56,8 @@ internal class DmlTests {
   @Test
   fun `insert stage generates insert proto with options`() {
     val pipeline =
-      db.pipeline()
-        .literals(mapOf("title" to "New Book"))
-        .insert("books", constant("book1"))
-    val proto = pipeline.toPipelineProto(db.userDataReader)
+      db.pipeline().literals(mapOf("title" to "New Book")).insert("books", constant("book1"))
+    val proto = pipeline.toExecutePipelineRequest(null).structuredPipeline.pipeline
     assertThat(proto.stagesCount).isEqualTo(2)
 
     val stage = proto.getStages(1)
@@ -72,11 +68,8 @@ internal class DmlTests {
 
   @Test
   fun `insert stage without documentIdExpr generates insert proto with only collection option`() {
-    val pipeline =
-      db.pipeline()
-        .literals(mapOf("title" to "New Book"))
-        .insert("books")
-    val proto = pipeline.toPipelineProto(db.userDataReader)
+    val pipeline = db.pipeline().literals(mapOf("title" to "New Book")).insert("books")
+    val proto = pipeline.toExecutePipelineRequest(null).structuredPipeline.pipeline
     assertThat(proto.stagesCount).isEqualTo(2)
 
     val stage = proto.getStages(1)
@@ -88,10 +81,15 @@ internal class DmlTests {
   @Test
   fun `upsert stage generates upsert proto with transforms and options`() {
     val pipeline =
-      db.pipeline()
+      db
+        .pipeline()
         .literals(mapOf("title" to "Upserted Book", "count" to 1))
-        .upsert(add(field("count"), constant(1)).as("count"), collectionPath = "books", documentIdExpr = constant("book1"))
-    val proto = pipeline.toPipelineProto(db.userDataReader)
+        .upsert(
+          add(field("count"), constant(1)).`as`("count"),
+          collectionPath = "books",
+          documentIdExpr = constant("book1")
+        )
+    val proto = pipeline.toExecutePipelineRequest(null).structuredPipeline.pipeline
     assertThat(proto.stagesCount).isEqualTo(2)
 
     val stage = proto.getStages(1)
@@ -104,13 +102,31 @@ internal class DmlTests {
   @Test
   fun `atomic execution options configure newTransaction and autoCommitTransaction`() {
     val pipeline =
-      db.pipeline()
-        .literals(mapOf("title" to "Atomic"))
-        .insert("books", constant("book1"))
+      db.pipeline().literals(mapOf("title" to "Atomic")).insert("books", constant("book1"))
     val executeOptions = Pipeline.ExecuteOptions().withAtomic(true)
     val request = pipeline.toExecutePipelineRequest(executeOptions.options)
     assertThat(request.hasNewTransaction()).isTrue()
     assertThat(request.newTransaction.hasReadWrite()).isTrue()
     assertThat(request.autoCommitTransaction).isTrue()
+  }
+
+  @Test
+  fun `non-atomic execution options do not configure newTransaction or autoCommitTransaction`() {
+    val pipeline =
+      db.pipeline().literals(mapOf("title" to "Non-Atomic")).insert("books", constant("book1"))
+
+    val executeOptionsDisabled = Pipeline.ExecuteOptions().withAtomic(false)
+    val requestDisabled = pipeline.toExecutePipelineRequest(executeOptionsDisabled.options)
+    assertThat(requestDisabled.hasNewTransaction()).isFalse()
+    assertThat(requestDisabled.autoCommitTransaction).isFalse()
+
+    val executeOptionsDefault = Pipeline.ExecuteOptions()
+    val requestDefault = pipeline.toExecutePipelineRequest(executeOptionsDefault.options)
+    assertThat(requestDefault.hasNewTransaction()).isFalse()
+    assertThat(requestDefault.autoCommitTransaction).isFalse()
+
+    val requestNull = pipeline.toExecutePipelineRequest(null)
+    assertThat(requestNull.hasNewTransaction()).isFalse()
+    assertThat(requestNull.autoCommitTransaction).isFalse()
   }
 }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/pipeline/DmlTests.kt
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/pipeline/DmlTests.kt
@@ -1,0 +1,101 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.pipeline
+
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.firestore.Pipeline
+import com.google.firebase.firestore.TestUtil
+import com.google.firebase.firestore.pipeline.Expression.Companion.add
+import com.google.firebase.firestore.pipeline.Expression.Companion.constant
+import com.google.firebase.firestore.pipeline.Expression.Companion.field
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class DmlTests {
+
+  private val db = TestUtil.firestore()
+
+  @Test
+  fun `delete stage generates delete proto`() {
+    val pipeline = db.pipeline().collection("books").delete()
+    val proto = pipeline.toPipelineProto(db.userDataReader)
+    assertThat(proto.stagesCount).isEqualTo(2)
+
+    val stage = proto.getStages(1)
+    assertThat(stage.name).isEqualTo("delete")
+    assertThat(stage.argsCount).isEqualTo(0)
+  }
+
+  @Test
+  fun `update stage generates update proto with fields`() {
+    val pipeline =
+      db.pipeline()
+        .collection("books")
+        .update(constant("Updated").as("status"))
+    val proto = pipeline.toPipelineProto(db.userDataReader)
+    assertThat(proto.stagesCount).isEqualTo(2)
+
+    val stage = proto.getStages(1)
+    assertThat(stage.name).isEqualTo("update")
+    assertThat(stage.argsCount).isEqualTo(1)
+    assertThat(stage.getArgs(0).mapValue.fieldsMap["status"]?.stringValue).isEqualTo("Updated")
+  }
+
+  @Test
+  fun `insert stage generates insert proto with options`() {
+    val pipeline =
+      db.pipeline()
+        .literals(mapOf("title" to "New Book"))
+        .insert("books", constant("book1"))
+    val proto = pipeline.toPipelineProto(db.userDataReader)
+    assertThat(proto.stagesCount).isEqualTo(2)
+
+    val stage = proto.getStages(1)
+    assertThat(stage.name).isEqualTo("insert")
+    assertThat(stage.optionsMap["collection"]?.referenceValue).isEqualTo("/books")
+    assertThat(stage.optionsMap["document_id"]?.stringValue).isEqualTo("book1")
+  }
+
+  @Test
+  fun `upsert stage generates upsert proto with transforms and options`() {
+    val pipeline =
+      db.pipeline()
+        .literals(mapOf("title" to "Upserted Book", "count" to 1))
+        .upsert(add(field("count"), constant(1)).as("count"), collectionPath = "books", documentIdExpr = constant("book1"))
+    val proto = pipeline.toPipelineProto(db.userDataReader)
+    assertThat(proto.stagesCount).isEqualTo(2)
+
+    val stage = proto.getStages(1)
+    assertThat(stage.name).isEqualTo("upsert")
+    assertThat(stage.argsCount).isEqualTo(1)
+    assertThat(stage.optionsMap["collection"]?.referenceValue).isEqualTo("/books")
+    assertThat(stage.optionsMap["document_id"]?.stringValue).isEqualTo("book1")
+  }
+
+  @Test
+  fun `atomic execution options configure newTransaction and autoCommitTransaction`() {
+    val pipeline =
+      db.pipeline()
+        .literals(mapOf("title" to "Atomic"))
+        .insert("books", constant("book1"))
+    val executeOptions = Pipeline.ExecuteOptions().withAtomic(true)
+    val request = pipeline.toExecutePipelineRequest(executeOptions.options)
+    assertThat(request.hasNewTransaction()).isTrue()
+    assertThat(request.newTransaction.hasReadWrite()).isTrue()
+    assertThat(request.autoCommitTransaction).isTrue()
+  }
+}

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/pipeline/DmlTests.kt
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/pipeline/DmlTests.kt
@@ -71,6 +71,21 @@ internal class DmlTests {
   }
 
   @Test
+  fun `insert stage without documentIdExpr generates insert proto with only collection option`() {
+    val pipeline =
+      db.pipeline()
+        .literals(mapOf("title" to "New Book"))
+        .insert("books")
+    val proto = pipeline.toPipelineProto(db.userDataReader)
+    assertThat(proto.stagesCount).isEqualTo(2)
+
+    val stage = proto.getStages(1)
+    assertThat(stage.name).isEqualTo("insert")
+    assertThat(stage.optionsMap["collection"]?.referenceValue).isEqualTo("/books")
+    assertThat(stage.optionsMap.containsKey("document_id")).isFalse()
+  }
+
+  @Test
   fun `upsert stage generates upsert proto with transforms and options`() {
     val pipeline =
       db.pipeline()

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/pipeline/DmlTests.kt
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/pipeline/DmlTests.kt
@@ -67,7 +67,7 @@ internal class DmlTests {
   }
 
   @Test
-  fun `insert stage without documentIdExpr generates insert proto with only collection option`() {
+  fun `insert stage without documentIdExpression generates insert proto with only collection option`() {
     val pipeline = db.pipeline().literals(mapOf("title" to "New Book")).insert("books")
     val proto = pipeline.toExecutePipelineRequest(null).structuredPipeline.pipeline
     assertThat(proto.stagesCount).isEqualTo(2)
@@ -87,7 +87,7 @@ internal class DmlTests {
         .upsert(
           add(field("count"), constant(1)).`as`("count"),
           collectionPath = "books",
-          documentIdExpr = constant("book1")
+          documentIdExpression = constant("book1")
         )
     val proto = pipeline.toExecutePipelineRequest(null).structuredPipeline.pipeline
     assertThat(proto.stagesCount).isEqualTo(2)

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/pipeline/DmlTests.kt
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/pipeline/DmlTests.kt
@@ -85,9 +85,86 @@ internal class DmlTests {
         .pipeline()
         .literals(mapOf("title" to "Upserted Book", "count" to 1))
         .upsert(
-          add(field("count"), constant(1)).`as`("count"),
           collectionPath = "books",
-          documentIdExpression = constant("book1")
+          documentIdExpression = constant("book1"),
+          additionalFields = arrayOf(add(field("count"), constant(1)).`as`("count"))
+        )
+    val proto = pipeline.toExecutePipelineRequest(null).structuredPipeline.pipeline
+    assertThat(proto.stagesCount).isEqualTo(2)
+
+    val stage = proto.getStages(1)
+    assertThat(stage.name).isEqualTo("upsert")
+    assertThat(stage.argsCount).isEqualTo(1)
+    assertThat(stage.optionsMap["collection"]?.referenceValue).isEqualTo("/books")
+    assertThat(stage.optionsMap["document_id"]?.stringValue).isEqualTo("book1")
+  }
+
+  @Test
+  fun `in-place upsert with varargs generates upsert proto without options`() {
+    val pipeline =
+      db.pipeline().collection("books").upsert(add(field("count"), constant(1)).`as`("count"))
+    val proto = pipeline.toExecutePipelineRequest(null).structuredPipeline.pipeline
+    assertThat(proto.stagesCount).isEqualTo(2)
+
+    val stage = proto.getStages(1)
+    assertThat(stage.name).isEqualTo("upsert")
+    assertThat(stage.argsCount).isEqualTo(1)
+    assertThat(stage.optionsCount).isEqualTo(0)
+  }
+
+  @Test
+  fun `in-place upsert with list generates upsert proto without options`() {
+    val pipeline =
+      db
+        .pipeline()
+        .collection("books")
+        .upsert(listOf(add(field("count"), constant(1)).`as`("count")))
+    val proto = pipeline.toExecutePipelineRequest(null).structuredPipeline.pipeline
+    assertThat(proto.stagesCount).isEqualTo(2)
+
+    val stage = proto.getStages(1)
+    assertThat(stage.name).isEqualTo("upsert")
+    assertThat(stage.argsCount).isEqualTo(1)
+    assertThat(stage.optionsCount).isEqualTo(0)
+  }
+
+  @Test
+  fun `target-collection upsert with collectionPath only generates upsert proto`() {
+    val pipeline = db.pipeline().collection("books").upsert("books_backup")
+    val proto = pipeline.toExecutePipelineRequest(null).structuredPipeline.pipeline
+    assertThat(proto.stagesCount).isEqualTo(2)
+
+    val stage = proto.getStages(1)
+    assertThat(stage.name).isEqualTo("upsert")
+    assertThat(stage.argsCount).isEqualTo(0)
+    assertThat(stage.optionsMap["collection"]?.referenceValue).isEqualTo("/books_backup")
+    assertThat(stage.optionsMap.containsKey("document_id")).isFalse()
+  }
+
+  @Test
+  fun `target-collection upsert with collectionPath and documentIdExpression generates upsert proto`() {
+    val pipeline =
+      db.pipeline().literals(mapOf("title" to "Upserted Book")).upsert("books", constant("book1"))
+    val proto = pipeline.toExecutePipelineRequest(null).structuredPipeline.pipeline
+    assertThat(proto.stagesCount).isEqualTo(2)
+
+    val stage = proto.getStages(1)
+    assertThat(stage.name).isEqualTo("upsert")
+    assertThat(stage.argsCount).isEqualTo(0)
+    assertThat(stage.optionsMap["collection"]?.referenceValue).isEqualTo("/books")
+    assertThat(stage.optionsMap["document_id"]?.stringValue).isEqualTo("book1")
+  }
+
+  @Test
+  fun `target-collection upsert with collectionPath, documentIdExpression, and additionalFields list generates upsert proto`() {
+    val pipeline =
+      db
+        .pipeline()
+        .literals(mapOf("title" to "Upserted Book", "count" to 1))
+        .upsert(
+          collectionPath = "books",
+          documentIdExpression = constant("book1"),
+          additionalFields = listOf(add(field("count"), constant(1)).`as`("count"))
         )
     val proto = pipeline.toExecutePipelineRequest(null).structuredPipeline.pipeline
     assertThat(proto.stagesCount).isEqualTo(2)


### PR DESCRIPTION
### Summary
Adds full DML stages (Delete, Update, Insert, Upsert), Literals source, and atomic execution option to the Android SDK (`firebase-android-sdk`) Firestore Pipelines subsystem to achieve parity with Web and Node SDKs.

### Key Changes
- **`stage.kt`**: Added `DeleteStage`, `UpdateStage`, `InsertStage`, `UpsertStage`, and `LiteralsSource`.
- **`options.kt`**: Added `hasAtomic()` helper method to `InternalOptions`.
- **`Pipeline.kt`**:
  - Added `withAtomic(atomic: Boolean)` method to `ExecuteOptions`.
  - Updated `toExecutePipelineRequest` to configure `newTransaction` (`readWrite`) and `autoCommitTransaction = true` when `atomic` is enabled.
  - Added `literals(vararg data: Map<String, Any?>)` source builder method to `PipelineSource`.
  - Added `delete()`, `update(...)`, `insert(...)`, and `upsert(...)` stage builder methods to `Pipeline`.
- **Unit & Integration Tests**:
  - Added unit test suite in `DmlTests.kt` verifying proto generation and options encoding for all stages.
  - Added integration test methods in `PipelineTest.java`.

### Buganizer Ticket
Fixes http://b/545136695 (under umbrella http://b/500350942)