### PR TITLE
Remove ml-vision from GenerateTutorialBundleTask.kt

### DIFF
--- a/plugins/src/main/java/com/google/firebase/gradle/bomgenerator/GenerateTutorialBundleTask.kt
+++ b/plugins/src/main/java/com/google/firebase/gradle/bomgenerator/GenerateTutorialBundleTask.kt
@@ -257,8 +257,6 @@ abstract class GenerateTutorialBundleTask : DefaultTask() {
           ArtifactTutorialMapping("Firebase Functions", "functions-dependency"),
         "com.google.firebase:firebase-inappmessaging-display" to
           ArtifactTutorialMapping("FIAM Display", "fiamd-dependency"),
-        "com.google.firebase:firebase-ml-vision" to
-          ArtifactTutorialMapping("Firebase MLKit Vision", "ml-vision-dependency"),
         "androidx.credentials:credentials" to
           ArtifactTutorialMapping("Auth Google Sign In", "auth-google-signin-first-dependency"),
         "androidx.credentials:credentials-play-services-auth" to


### PR DESCRIPTION
Firebase ML has been deprecated and we have removed it from the tutorial bundle XML file.

This PR should remove it from the XML generator.