### PR TITLE
fix: preserve keepSynced state across Query.get

### DIFF
--- a/firebase-database/CHANGELOG.md
+++ b/firebase-database/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [fixed] Fixed a crash when calling `keepSynced(true)` and `get()` on the same query.
+
 # 22.0.1
 
 - [changed] Bumped internal dependencies.

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/QueryTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/QueryTest.java
@@ -5049,6 +5049,32 @@ public class QueryTest {
   }
 
   @Test
+  public void testGetPreservesKeepSyncedState()
+      throws DatabaseException, InterruptedException, ExecutionException {
+    FirebaseDatabase writerDb = getNewDatabase();
+    FirebaseDatabase readerDb = getNewDatabase();
+    readerDb.setPersistenceEnabled(false);
+    DatabaseReference writer = writerDb.getReference().push();
+    DatabaseReference reader = translateReference(writer, readerDb);
+
+    await(writer.setValue(42L));
+
+    try {
+      reader.keepSynced(true);
+      assertEquals(42L, await(reader.get()).getValue());
+
+      reader.keepSynced(true);
+      assertEquals(42L, await(reader.get()).getValue());
+
+      DatabaseReference equivalentReader = translateReference(writer, readerDb);
+      equivalentReader.keepSynced(true);
+      assertEquals(42L, await(equivalentReader.get()).getValue());
+    } finally {
+      reader.keepSynced(false);
+    }
+  }
+
+  @Test
   public void testGetProbesInMemoryCacheForActiveListenerWhenOffline()
       throws DatabaseException,
           InterruptedException,

--- a/firebase-database/src/main/java/com/google/firebase/database/core/Repo.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/Repo.java
@@ -558,7 +558,8 @@ public class Repo implements PersistentConnection.Delegate {
                         QuerySpec spec = query.getSpec();
                         // EventRegistrations require a listener to be attached, so a dummy
                         // ValueEventListener was created.
-                        keepSynced(spec, /* keep= */ true, /* skipDedup= */ true);
+                        boolean addedKeepSyncedRegistration =
+                            keepSynced(spec, /* keep= */ true, /* skipDedup= */ true);
                         List<? extends Event> events;
                         if (spec.loadsAllData()) {
                           events = serverSyncTree.applyServerOverwrite(spec.getPath(), serverNode);
@@ -576,7 +577,9 @@ public class Repo implements PersistentConnection.Delegate {
                             InternalHelpers.createDataSnapshot(
                                 query.getRef(),
                                 IndexedNode.from(serverNode, query.getSpec().getIndex())));
-                        keepSynced(spec, /* keep= */ false, /* skipDedup= */ true);
+                        if (addedKeepSyncedRegistration) {
+                          keepSynced(spec, /* keep= */ false, /* skipDedup= */ true);
+                        }
                       }
                     });
           }
@@ -767,9 +770,9 @@ public class Repo implements PersistentConnection.Delegate {
     keepSynced(query, keep, /* skipDedup= */ false);
   }
 
-  public void keepSynced(QuerySpec query, boolean keep, final boolean skipDedup) {
+  public boolean keepSynced(QuerySpec query, boolean keep, final boolean skipDedup) {
     hardAssert(query.getPath().isEmpty() || !query.getPath().getFront().equals(Constants.DOT_INFO));
-    serverSyncTree.keepSynced(query, keep, skipDedup);
+    return serverSyncTree.keepSynced(query, keep, skipDedup);
   }
 
   PersistentConnection getConnection() {

--- a/firebase-database/src/main/java/com/google/firebase/database/core/SyncTree.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/SyncTree.java
@@ -851,16 +851,18 @@ public class SyncTree {
     keepSynced(query, keep, false);
   }
 
-  public void keepSynced(final QuerySpec query, final boolean keep, final boolean skipDedup) {
+  public boolean keepSynced(final QuerySpec query, final boolean keep, final boolean skipDedup) {
     if (keep && !keepSyncedQueries.contains(query)) {
       // TODO[persistence]: Find better / more efficient way to do keep-synced listeners.
       addEventRegistration(
           new KeepSyncedEventRegistration(query), /* skipListenerSetup= */ skipDedup);
       keepSyncedQueries.add(query);
+      return true;
     } else if (!keep && keepSyncedQueries.contains(query)) {
       removeEventRegistration(new KeepSyncedEventRegistration(query), skipDedup);
       keepSyncedQueries.remove(query);
     }
+    return false;
   }
 
   /**


### PR DESCRIPTION
Have the internal `SyncTree.keepSynced` operation report whether the requested transition actually added a registration, while retaining idempotent behavior for ordinary public `keepSynced` calls. Calling `keepSynced(true)` and `get()` on the same Realtime Database query can corrupt the SDK's internal keep-synced bookkeeping after the server response is applied.

With persistence disabled and no cached data, call `keepSynced(true)`, await `get()`, call `keepSynced(true)` again for the same path, and await another `get()`; both tasks return the server value without a duplicate-listen assertion; Repeat the second synchronization and read through a newly created `DatabaseReference` for the same path to verify deduplication follows `QuerySpec` identity rather than Java object identity.

Fixes #8433
