### PR TITLE
Add missing turnComplete field for LiveSessionFutures

### DIFF
--- a/ai-logic/firebase-ai/CHANGELOG.md
+++ b/ai-logic/firebase-ai/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [changed] Added `turnComplete` support in the `LiveSessionFutures` Java API.
+
 # 17.16.0
 
 - [feature] Added support for on-device structured output generation using `generateObject` (#8395)

--- a/ai-logic/firebase-ai/gradle.properties
+++ b/ai-logic/firebase-ai/gradle.properties
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version=17.16.1
+version=17.17.0
 latestReleasedVersion=17.16.0

--- a/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/java/LiveSessionFutures.kt
+++ b/ai-logic/firebase-ai/src/main/kotlin/com/google/firebase/ai/java/LiveSessionFutures.kt
@@ -252,6 +252,16 @@ public abstract class LiveSessionFutures internal constructor() {
   public abstract fun send(content: Content): ListenableFuture<Unit>
 
   /**
+   * Sends [data][Content] to the model.
+   *
+   * Calling this after [startAudioConversation] will play the response audio immediately.
+   *
+   * @param content Client [Content] to be sent to the model.
+   * @param turnComplete Whether the user's input turn has finished.
+   */
+  public abstract fun send(content: Content, turnComplete: Boolean): ListenableFuture<Unit>
+
+  /**
    * Sends text to the model.
    *
    * Calling this after [startAudioConversation] will play the response audio immediately.
@@ -293,6 +303,9 @@ public abstract class LiveSessionFutures internal constructor() {
 
     override fun send(content: Content) =
       SuspendToFutureAdapter.launchFuture { session.send(content) }
+
+    override fun send(content: Content, turnComplete: Boolean) =
+      SuspendToFutureAdapter.launchFuture { session.send(content, turnComplete) }
 
     override fun sendFunctionResponse(functionList: List<FunctionResponsePart>) =
       SuspendToFutureAdapter.launchFuture { session.sendFunctionResponse(functionList) }


### PR DESCRIPTION
These fields were missing from the Kotlin API for a while but we never added them to Java when we introduced them.