### PR TITLE
Removed usage of deprecated GMS Objects class

### DIFF
--- a/firebase-common/CHANGELOG.md
+++ b/firebase-common/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [changed] Internal adjustments
+
 # 22.2.0
 
 - [changed] Remvode support for reading the `recaptcha_site_key` value from the `google-services.json`

--- a/firebase-common/src/main/java/com/google/firebase/FirebaseOptions.java
+++ b/firebase-common/src/main/java/com/google/firebase/FirebaseOptions.java
@@ -22,9 +22,9 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.gms.common.annotation.KeepForSdk;
-import com.google.android.gms.common.internal.Objects;
 import com.google.android.gms.common.internal.Preconditions;
 import com.google.android.gms.common.internal.StringResourceValueReader;
+import java.util.Objects;
 
 /** Configurable Firebase options. */
 public final class FirebaseOptions {
@@ -253,19 +253,19 @@ public final class FirebaseOptions {
       return false;
     }
     FirebaseOptions other = (FirebaseOptions) o;
-    return Objects.equal(applicationId, other.applicationId)
-        && Objects.equal(apiKey, other.apiKey)
-        && Objects.equal(databaseUrl, other.databaseUrl)
-        && Objects.equal(gaTrackingId, other.gaTrackingId)
-        && Objects.equal(gcmSenderId, other.gcmSenderId)
-        && Objects.equal(storageBucket, other.storageBucket)
-        && Objects.equal(recaptchaSiteKey, other.recaptchaSiteKey)
-        && Objects.equal(projectId, other.projectId);
+    return Objects.equals(applicationId, other.applicationId)
+        && Objects.equals(apiKey, other.apiKey)
+        && Objects.equals(databaseUrl, other.databaseUrl)
+        && Objects.equals(gaTrackingId, other.gaTrackingId)
+        && Objects.equals(gcmSenderId, other.gcmSenderId)
+        && Objects.equals(storageBucket, other.storageBucket)
+        && Objects.equals(recaptchaSiteKey, other.recaptchaSiteKey)
+        && Objects.equals(projectId, other.projectId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(
+    return Objects.hash(
         applicationId,
         apiKey,
         databaseUrl,
@@ -278,7 +278,7 @@ public final class FirebaseOptions {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return com.google.android.gms.common.internal.Objects.toStringHelper(this)
         .add("applicationId", applicationId)
         .add("apiKey", apiKey)
         .add("databaseUrl", databaseUrl)

--- a/firebase-database/CHANGELOG.md
+++ b/firebase-database/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [changed] Internal adjustments
+
 # 22.0.1
 
 - [changed] Bumped internal dependencies.

--- a/firebase-database/src/main/java/com/google/firebase/database/Query.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/Query.java
@@ -19,7 +19,6 @@ import static com.google.firebase.database.core.utilities.Utilities.hardAssert;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
-import com.google.android.gms.common.internal.Objects;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.database.core.ChildEventRegistration;
 import com.google.firebase.database.core.EventRegistration;
@@ -43,6 +42,7 @@ import com.google.firebase.database.snapshot.PriorityIndex;
 import com.google.firebase.database.snapshot.PriorityUtilities;
 import com.google.firebase.database.snapshot.StringNode;
 import com.google.firebase.database.snapshot.ValueIndex;
+import java.util.Objects;
 
 /**
  * The Query class (and its subclass, {@link DatabaseReference}) are used for reading data.
@@ -93,7 +93,7 @@ public class Query {
       if (params.hasStart()) {
         Node startNode = params.getIndexStartValue();
         ChildKey startName = params.getIndexStartName();
-        if (!Objects.equal(startName, ChildKey.getMinName())
+        if (!Objects.equals(startName, ChildKey.getMinName())
             || !(startNode instanceof StringNode)) {
           throw new IllegalArgumentException(message);
         }

--- a/firebase-database/src/main/java/com/google/firebase/database/snapshot/IndexedNode.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/snapshot/IndexedNode.java
@@ -14,12 +14,12 @@
 
 package com.google.firebase.database.snapshot;
 
-import com.google.android.gms.common.internal.Objects;
 import com.google.firebase.database.collection.ImmutableSortedSet;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Represents a node together with an index. The index and node are updated in unison. In the case
@@ -100,7 +100,7 @@ public class IndexedNode implements Iterable<NamedNode> {
   @Override
   public Iterator<NamedNode> iterator() {
     ensureIndexed();
-    if (Objects.equal(this.indexed, FALLBACK_INDEX)) {
+    if (Objects.equals(this.indexed, FALLBACK_INDEX)) {
       return this.node.iterator();
     } else {
       return this.indexed.iterator();
@@ -109,7 +109,7 @@ public class IndexedNode implements Iterable<NamedNode> {
 
   public Iterator<NamedNode> reverseIterator() {
     ensureIndexed();
-    if (Objects.equal(this.indexed, FALLBACK_INDEX)) {
+    if (Objects.equals(this.indexed, FALLBACK_INDEX)) {
       return this.node.reverseIterator();
     } else {
       return this.indexed.reverseIterator();
@@ -118,10 +118,10 @@ public class IndexedNode implements Iterable<NamedNode> {
 
   public IndexedNode updateChild(ChildKey key, Node child) {
     Node newNode = this.node.updateImmediateChild(key, child);
-    if (Objects.equal(this.indexed, FALLBACK_INDEX) && !this.index.isDefinedOn(child)) {
+    if (Objects.equals(this.indexed, FALLBACK_INDEX) && !this.index.isDefinedOn(child)) {
       // doesn't affect the index, no need to create an index
       return new IndexedNode(newNode, this.index, FALLBACK_INDEX);
-    } else if (this.indexed == null || Objects.equal(this.indexed, FALLBACK_INDEX)) {
+    } else if (this.indexed == null || Objects.equals(this.indexed, FALLBACK_INDEX)) {
       // No need to index yet, index lazily
       return new IndexedNode(newNode, this.index, null);
     } else {
@@ -143,7 +143,7 @@ public class IndexedNode implements Iterable<NamedNode> {
       return null;
     } else {
       ensureIndexed();
-      if (Objects.equal(this.indexed, FALLBACK_INDEX)) {
+      if (Objects.equals(this.indexed, FALLBACK_INDEX)) {
         ChildKey firstKey = ((ChildrenNode) this.node).getFirstChildKey();
         return new NamedNode(firstKey, this.node.getImmediateChild(firstKey));
       } else {
@@ -157,7 +157,7 @@ public class IndexedNode implements Iterable<NamedNode> {
       return null;
     } else {
       ensureIndexed();
-      if (Objects.equal(this.indexed, FALLBACK_INDEX)) {
+      if (Objects.equals(this.indexed, FALLBACK_INDEX)) {
         ChildKey lastKey = ((ChildrenNode) this.node).getLastChildKey();
         return new NamedNode(lastKey, this.node.getImmediateChild(lastKey));
       } else {
@@ -171,7 +171,7 @@ public class IndexedNode implements Iterable<NamedNode> {
       throw new IllegalArgumentException("Index not available in IndexedNode!");
     }
     ensureIndexed();
-    if (Objects.equal(this.indexed, FALLBACK_INDEX)) {
+    if (Objects.equals(this.indexed, FALLBACK_INDEX)) {
       return this.node.getPredecessorChildKey(childKey);
     } else {
       NamedNode node = this.indexed.getPredecessorEntry(new NamedNode(childKey, childNode));

--- a/firebase-messaging/CHANGELOG.md
+++ b/firebase-messaging/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [changed] Internal adjustments
 - [fixed] FCM registration error due to FID_ALREADY_USED (#8507)
 - [fixed] StrictMode LeakedClosableViolation in TopicSubscriptionClient (#8534)
 

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/TopicOperation.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/TopicOperation.java
@@ -21,9 +21,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringDef;
 import androidx.annotation.VisibleForTesting;
-import com.google.android.gms.common.internal.Objects;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 final class TopicOperation {
@@ -116,7 +116,7 @@ final class TopicOperation {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(operation, topic);
+    return Objects.hash(operation, topic);
   }
 
   @StringDef({TopicOperations.OPERATION_SUBSCRIBE, TopicOperations.OPERATION_UNSUBSCRIBE})

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/testing/Bundles.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/testing/Bundles.java
@@ -21,10 +21,10 @@ import android.os.Bundle;
 import android.os.IBinder;
 import android.os.Parcel;
 import android.os.Parcelable;
-import com.google.android.gms.common.internal.Objects;
 import com.google.android.gms.common.internal.Preconditions;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -112,7 +112,7 @@ public final class Bundles {
               return false;
             }
           } else {
-            if (!Objects.equal(expectedValue, actualValue)) {
+            if (!Objects.equals(expectedValue, actualValue)) {
               return false;
             }
           }

--- a/firebase-ml-modeldownloader/CHANGELOG.md
+++ b/firebase-ml-modeldownloader/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [changed] Internal adjustments
 - [changed] Updated the Firebase ML deprecation message to link to the Firebase ML documentation for migration options.
 
 # 26.1.0

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/CustomModel.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/CustomModel.java
@@ -18,12 +18,12 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.VisibleForTesting;
-import com.google.android.gms.common.internal.Objects;
 import com.google.firebase.ml.modeldownloader.internal.ModelFileDownloadService;
 import dagger.assisted.Assisted;
 import dagger.assisted.AssistedFactory;
 import dagger.assisted.AssistedInject;
 import java.io.File;
+import java.util.Objects;
 
 /**
  * Stores information about custom models that are being downloaded or are already downloaded on a
@@ -232,8 +232,8 @@ public class CustomModel {
   @NonNull
   @Override
   public String toString() {
-    Objects.ToStringHelper stringHelper =
-        Objects.toStringHelper(this)
+    com.google.android.gms.common.internal.Objects.ToStringHelper stringHelper =
+        com.google.android.gms.common.internal.Objects.toStringHelper(this)
             .add("name", name)
             .add("modelHash", modelHash)
             .add("fileSize", fileSize);
@@ -266,18 +266,18 @@ public class CustomModel {
 
     CustomModel other = (CustomModel) o;
 
-    return Objects.equal(name, other.name)
-        && Objects.equal(modelHash, other.modelHash)
-        && Objects.equal(fileSize, other.fileSize)
-        && Objects.equal(localFilePath, other.localFilePath)
-        && Objects.equal(downloadId, other.downloadId)
-        && Objects.equal(downloadUrl, other.downloadUrl)
-        && Objects.equal(downloadUrlExpiry, other.downloadUrlExpiry);
+    return Objects.equals(name, other.name)
+        && Objects.equals(modelHash, other.modelHash)
+        && Objects.equals(fileSize, other.fileSize)
+        && Objects.equals(localFilePath, other.localFilePath)
+        && Objects.equals(downloadId, other.downloadId)
+        && Objects.equals(downloadUrl, other.downloadUrl)
+        && Objects.equals(downloadUrlExpiry, other.downloadUrlExpiry);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(
+    return Objects.hash(
         name, modelHash, fileSize, localFilePath, downloadId, downloadUrl, downloadUrlExpiry);
   }
 

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/CustomModelDownloadConditions.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/CustomModelDownloadConditions.java
@@ -18,7 +18,7 @@ import android.annotation.TargetApi;
 import android.os.Build.VERSION_CODES;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
-import com.google.android.gms.common.internal.Objects;
+import java.util.Objects;
 
 /**
  * Conditions to allow download of custom models.
@@ -188,6 +188,6 @@ public class CustomModelDownloadConditions {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(isChargingRequired, isWifiRequired, isDeviceIdleRequired);
+    return Objects.hash(isChargingRequired, isWifiRequired, isDeviceIdleRequired);
   }
 }

--- a/firebase-storage/CHANGELOG.md
+++ b/firebase-storage/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [changed] Internal adjustments
+
 # 22.0.1
 
 - [changed] Bumped internal dependencies.

--- a/firebase-storage/src/main/java/com/google/firebase/storage/internal/Util.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/internal/Util.java
@@ -19,7 +19,6 @@ import android.text.TextUtils;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import com.google.android.gms.common.internal.Objects;
 import com.google.android.gms.common.internal.Preconditions;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
@@ -33,6 +32,7 @@ import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -66,11 +66,6 @@ public class Util {
     return 0;
   }
 
-  /** Null-safe equivalent of {@code a.equals(b)}. */
-  public static boolean equals(@Nullable Object a, @Nullable Object b) {
-    return Objects.equal(a, b);
-  }
-
   /**
    * Normalizes a Firebase Storage uri into its "gs://" format and strips any trailing slash.
    *
@@ -100,7 +95,8 @@ public class Util {
       String scheme = uri.getScheme();
 
       if (scheme != null
-          && (equals(scheme.toLowerCase(), "http") || equals(scheme.toLowerCase(), "https"))) {
+          && (Objects.equals(scheme.toLowerCase(), "http")
+              || Objects.equals(scheme.toLowerCase(), "https"))) {
         String lowerAuthority = uri.getAuthority().toLowerCase();
         int indexOfAuth = lowerAuthority.indexOf(baseUrl.getAuthority());
         encodedPath = Slashes.slashize(uri.getEncodedPath());


### PR DESCRIPTION
The GMS Objects class is no longer recommended for usage and we are getting downstream edits to source because of it. Fixes the problem at the sources and moves to `java.util.Objects` for relevant calls.