### PR TITLE
fix topic subscription when @ and + are encoded

### DIFF
--- a/firebase-messaging/CHANGELOG.md
+++ b/firebase-messaging/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [fixed] Topic subscribe and unsubscribe failed with HTTP 400 when the topic name contained
+  percent characters.
 - [changed] Internal adjustments
 
 # 25.1.2

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/TopicSubscriptionClient.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/TopicSubscriptionClient.java
@@ -15,6 +15,7 @@ package com.google.firebase.messaging;
 
 import static com.google.firebase.messaging.Constants.TAG;
 
+import android.net.Uri;
 import android.os.Build;
 import android.util.Log;
 import androidx.annotation.NonNull;
@@ -114,7 +115,7 @@ public class TopicSubscriptionClient {
                 + "/registrations/"
                 + fid
                 + "/topicSubscriptions/"
-                + topic
+                + Uri.encode(topic)
                 + ":"
                 + operation);
 

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/TopicSubscriptionClientRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/TopicSubscriptionClientRoboTest.java
@@ -16,6 +16,7 @@ package com.google.firebase.messaging;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -39,6 +40,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -185,6 +187,75 @@ public class TopicSubscriptionClientRoboTest {
 
     assertThat(errorStream.isClosed()).isTrue();
     verify(mockConnection).disconnect();
+  }
+
+  @Test
+  public void testSubscribe_percentCharactersInTopic_arePathEncodedOnce() throws Exception {
+    when(mockConnection.getResponseCode()).thenReturn(200);
+    String topic = "email.example.name%2Bafterplus%40example.com";
+
+    runOnBackground(() -> client.subscribe(topic));
+
+    assertThat(capturedRequestUrl().getPath())
+        .isEqualTo(
+            topicSubscriptionPath("email.example.name%252Bafterplus%2540example.com", "subscribe"));
+  }
+
+  @Test
+  public void testSubscribe_documentedTopicCharset_encodesOnlyPercent() throws Exception {
+    when(mockConnection.getResponseCode()).thenReturn(200);
+    String topic = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~%";
+
+    runOnBackground(() -> client.subscribe(topic));
+
+    String path = capturedRequestUrl().getPath();
+    assertThat(path)
+        .isEqualTo(
+            topicSubscriptionPath(
+                "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~%25",
+                "subscribe"));
+    assertThat(path).contains("-_.~%25");
+    assertThat(path).doesNotContain("%2D");
+    assertThat(path).doesNotContain("%5F");
+    assertThat(path).doesNotContain("%2E");
+    assertThat(path).doesNotContain("%7E");
+  }
+
+  @Test
+  public void testUnsubscribe_usesSameTopicEncodingAsSubscribe() throws Exception {
+    when(mockConnection.getResponseCode()).thenReturn(200);
+    String topic = "email.example.name%2Bafterplus%40example.com";
+    String encodedTopic = "email.example.name%252Bafterplus%2540example.com";
+
+    runOnBackground(() -> client.subscribe(topic));
+    String subscribePath = capturedRequestUrl().getPath();
+    clearInvocations(client);
+    runOnBackground(() -> client.unsubscribe(topic));
+    String unsubscribePath = capturedRequestUrl().getPath();
+
+    assertThat(subscribePath).isEqualTo(topicSubscriptionPath(encodedTopic, "subscribe"));
+    assertThat(unsubscribePath).isEqualTo(topicSubscriptionPath(encodedTopic, "unsubscribe"));
+    assertThat(subscribePath).endsWith(":subscribe");
+    assertThat(unsubscribePath).endsWith(":unsubscribe");
+    assertThat(subscribePath).doesNotContain("%3Asubscribe");
+    assertThat(unsubscribePath).doesNotContain("%3Aunsubscribe");
+  }
+
+  private URL capturedRequestUrl() throws IOException {
+    ArgumentCaptor<URL> urlCaptor = ArgumentCaptor.forClass(URL.class);
+    verify(client).createConnection(urlCaptor.capture());
+    return urlCaptor.getValue();
+  }
+
+  private static String topicSubscriptionPath(String encodedTopic, String operation) {
+    return "/v1/projects/"
+        + TEST_PROJECT_ID
+        + "/registrations/"
+        + TEST_FID
+        + "/topicSubscriptions/"
+        + encodedTopic
+        + ":"
+        + operation;
   }
 
   private static class CloseTrackingInputStream extends ByteArrayInputStream {


### PR DESCRIPTION
`FirebaseMessaging.subscribeToTopic()` / `unsubscribeFromTopic()` produced a 400 on any topic containing `%`, even though the documented grammar is `[a-zA-Z0-9-_.~%]{1,900}`. 

Introduced in [firebase-messaging 25.1.0](https://firebase.google.com/support/release-notes/android#messaging_v25-1-0) (BoM [34.15.0](https://firebase.google.com/support/release-notes/android#bom_v34-15-0), 16 Jun 2026) when FID registration landed ([#8087](https://github.com/firebase/firebase-android-sdk/pull/8087)) and `TopicSubscriptionClient` started concatenating the topic unescaped into `https://fcmregistrations.googleapis.com/v1/projects/{id}/registrations/{fid}/topicSubscriptions/{topic}:{op}`. 

The server percent-decodes the path before validating, so fields like `%2B` or `%40` become + / @ and the request is rejected. 

This is still present in 25.1.1 / 25.1.2. Pre-25.1.0 (GmsRpc, last good BoM [34.14.0](https://firebase.google.com/support/release-notes/android#bom_v34-14-0) / messaging 25.0.2) sent the topic as a `gcm.topic` value, so % survived.

This PR percent-escapes the topic path segment (`%` → `%25`) on both subscribe and unsubscribe so the wire form matches the documented name. Same class of bug as [firebase/quickstart-ios#242](https://github.com/firebase/quickstart-ios/issues/242), fixed by [firebase-ios-sdk#220](https://github.com/firebase/firebase-ios-sdk/pull/220).