### PR TITLE
Remove norelro linker flag to enable RELRO

### DIFF
--- a/firebase-crashlytics-ndk/CHANGELOG.md
+++ b/firebase-crashlytics-ndk/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- [changed] Enabled the Relocation Read-Only (RELRO) flag across Crashlytics NDK shared libraries,
+  making relocation sections read-only after loading to mitigate security exploits (#8566)
+
 # 20.1.0
 
 - [changed] Updated `firebase-crashlytics` dependency to 20.1.0

--- a/firebase-crashlytics-ndk/src/main/jni/libcrashlytics-common/Android.mk
+++ b/firebase-crashlytics-ndk/src/main/jni/libcrashlytics-common/Android.mk
@@ -38,7 +38,7 @@ LOCAL_CPPFLAGS := \
     -fsingle-precision-constant \
     -ffast-math \
 
-LOCAL_LDFLAGS := -flto -Wl,--gc-sections -Wl,--exclude-libs,ALL -Wl,-z,norelro -Wl,-z,max-page-size=16384
+LOCAL_LDFLAGS := -flto -Wl,--gc-sections -Wl,--exclude-libs,ALL -Wl,-z,max-page-size=16384
 LOCAL_LDLIBS := -llog -lz -ldl
 
 # Include all .cpp files in /src

--- a/firebase-crashlytics-ndk/src/main/jni/libcrashlytics-handler/Android.mk
+++ b/firebase-crashlytics-ndk/src/main/jni/libcrashlytics-handler/Android.mk
@@ -19,7 +19,7 @@ LOCAL_CPPFLAGS := \
     -fvisibility=hidden \
     -nostdlib++ \
 
-LOCAL_LDFLAGS := -Wl,--gc-sections -Wl,--exclude-libs,ALL -Wl,-z,norelro -Wl,-z,max-page-size=16384
+LOCAL_LDFLAGS := -Wl,--gc-sections -Wl,--exclude-libs,ALL -Wl,-z,max-page-size=16384
 LOCAL_LDLIBS := -llog -lz
 
 # Include all .cpp files in /src

--- a/firebase-crashlytics-ndk/src/main/jni/libcrashlytics-trampoline/Android.mk
+++ b/firebase-crashlytics-ndk/src/main/jni/libcrashlytics-trampoline/Android.mk
@@ -23,7 +23,7 @@ LOCAL_CPPFLAGS := \
     -fno-unroll-loops \
     -fno-ident \
 
-LOCAL_LDFLAGS := -Wl,--gc-sections -Wl,-z,norelro -Wl,-z,max-page-size=16384
+LOCAL_LDFLAGS := -Wl,--gc-sections -Wl,-z,max-page-size=16384
 LOCAL_LDLIBS := -llog
 
 LOCAL_SRC_FILES := $(LOCAL_PATH)/src/handler_trampoline.cpp

--- a/firebase-crashlytics-ndk/src/main/jni/libcrashlytics/Android.mk
+++ b/firebase-crashlytics-ndk/src/main/jni/libcrashlytics/Android.mk
@@ -36,7 +36,7 @@ LOCAL_CPPFLAGS := \
     -fsingle-precision-constant \
     -ffast-math \
 
-LOCAL_LDFLAGS := -flto -Wl,--gc-sections, -Wl,--exclude-libs,ALL -Wl,-z,norelro -Wl,-z,max-page-size=16384
+LOCAL_LDFLAGS := -flto -Wl,--gc-sections, -Wl,--exclude-libs,ALL -Wl,-z,max-page-size=16384
 LOCAL_LDLIBS := -llog
 
 # Include all .cpp files in /src


### PR DESCRIPTION
Removed the `norelro` linker flag to enable Relocation Read-Only (RELRO) across Crashlytics NDK binaries, making relocation sections read-only after loading to mitigate security exploits

Verified by running `llvm-readelf -l "$f" | grep GNU_RELRO` for each binary, see https://paste.googleplex.com/5633939205652480

This increases each file size by only 120–200 bytes per binary

Tested manually on a physical device
