### PR TITLE
Added consumer rules to prevent R8 missing-class warnings

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- [fixed] Added consumer ProGuard rules to prevent R8 missing-class warnings for
+  `ProfilingManager` and `ProfilingTrigger` on older compileSdk versions
+
 # 20.1.0
 
 - [feature] Added OOM and Anomaly trigger collection for the ProfilingManager API [#8343]

--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 - [fixed] Added consumer ProGuard rules to prevent R8 missing-class warnings for
-  `ProfilingManager` and `ProfilingTrigger` on older compileSdk versions
+  `ProfilingManager` and `ProfilingTrigger` on older compileSdk versions [#8567]
 
 # 20.1.0
 

--- a/firebase-crashlytics/consumer-rules.pro
+++ b/firebase-crashlytics/consumer-rules.pro
@@ -1,0 +1,21 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ProfilingManager was introduced in Android 15 (API level 35) and ProfilingTrigger
+# in Android 16 (API level 36). These APIs are guarded at runtime with SDK version
+# checks. Consumer applications compiling against older Android SDK versions
+# (for example, API level 34 or 35) do not have these classes in their compile
+# classpath android.jar. Suppress R8 missing class warnings
+-dontwarn android.os.ProfilingManager
+-dontwarn android.os.ProfilingTrigger**

--- a/firebase-crashlytics/firebase-crashlytics.gradle
+++ b/firebase-crashlytics/firebase-crashlytics.gradle
@@ -48,6 +48,7 @@ android {
 
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles 'consumer-rules.pro'
     }
     sourceSets {
         androidTest {


### PR DESCRIPTION
Added consumer ProGuard rules to prevent R8 missing-class warnings for `ProfilingManager` on compileSdk versions below 35, and `ProfilingTrigger` on compileSdk versions below 36