### PR TITLE
chore(ai, appcheck): ensure companion Kotlindocs are generated

### DIFF
--- a/ai-logic/firebase-ai/firebase-ai.gradle.kts
+++ b/ai-logic/firebase-ai/firebase-ai.gradle.kts
@@ -128,6 +128,4 @@ dependencies {
   androidTestImplementation(libs.truth)
 }
 
-tasks.named("kotlindoc") {
-  dependsOn(":ai-logic:firebase-ai-ondevice:kotlindoc")
-}
+tasks.named("kotlindoc") { dependsOn(":ai-logic:firebase-ai-ondevice:kotlindoc") }

--- a/ai-logic/firebase-ai/firebase-ai.gradle.kts
+++ b/ai-logic/firebase-ai/firebase-ai.gradle.kts
@@ -127,3 +127,7 @@ dependencies {
   androidTestImplementation(libs.androidx.test.runner)
   androidTestImplementation(libs.truth)
 }
+
+tasks.named("kotlindoc") {
+  dependsOn(":ai-logic:firebase-ai-ondevice:kotlindoc")
+}

--- a/appcheck/firebase-appcheck/firebase-appcheck.gradle
+++ b/appcheck/firebase-appcheck/firebase-appcheck.gradle
@@ -90,3 +90,11 @@ dependencies {
     androidTestImplementation libs.junit
     androidTestImplementation libs.mockito.core
 }
+
+tasks.named("kotlindoc") {
+    dependsOn(
+        ":appcheck:firebase-appcheck-debug:kotlindoc",
+        ":appcheck:firebase-appcheck-playintegrity:kotlindoc",
+        ":appcheck:firebase-appcheck-recaptcha:kotlindoc"
+    )
+}


### PR DESCRIPTION
This PR configures the `kotlindoc` task dependencies for `firebase-ai` and `firebase-appcheck` so that companion modules automatically have their documentation generated whenever the parent SDK's documentation is built:

- **`firebase-ai`** depends on `:ai-logic:firebase-ai-ondevice:kotlindoc`.
- **`firebase-appcheck`** depends on:
    - `:appcheck:firebase-appcheck-debug:kotlindoc`
    - `:appcheck:firebase-appcheck-playintegrity:kotlindoc`
    - `:appcheck:firebase-appcheck-recaptcha:kotlindoc`

This ensures companion API reference docs are consistently generated and packaged into `kotlindoc.zip` during `./gradlew firebasePublish` as well as during local documentation builds.