### PR TITLE
[Infra] Clean up Robolectric test SDK configurations

### DIFF
--- a/firebase-common/src/test/java/com/google/firebase/platforminfo/FirebasePlatformLoggingTest.java
+++ b/firebase-common/src/test/java/com/google/firebase/platforminfo/FirebasePlatformLoggingTest.java
@@ -103,7 +103,7 @@ public class FirebasePlatformLoggingTest {
   }
 
   @Test
-  @Config(sdk = Build.OLDEST_SDK)
+  @Config(sdk = Config.OLDEST_SDK)
   public void test_embedded_atNotHighEnoughApiLevel() {
     ShadowPackageManager shadowPackageManager =
         shadowOf(ApplicationProvider.getApplicationContext().getPackageManager());

--- a/firebase-common/src/test/java/com/google/firebase/platforminfo/FirebasePlatformLoggingTest.java
+++ b/firebase-common/src/test/java/com/google/firebase/platforminfo/FirebasePlatformLoggingTest.java
@@ -103,10 +103,11 @@ public class FirebasePlatformLoggingTest {
   }
 
   @Test
-  @Config(sdk = Build.VERSION_CODES.N)
+  @Config(sdk = Build.OLDEST_SDK)
   public void test_embedded_atNotHighEnoughApiLevel() {
     ShadowPackageManager shadowPackageManager =
         shadowOf(ApplicationProvider.getApplicationContext().getPackageManager());
+    // Feature added in API Level 26. Test can be removed when minSDK reaches it.
     shadowPackageManager.setSystemFeature(PackageManager.FEATURE_EMBEDDED, true);
     withApp(
         "myApp",

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/NetworkConnectivityRestoredFlowUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/NetworkConnectivityRestoredFlowUnitTest.kt
@@ -131,7 +131,6 @@ class NetworkConnectivityRestoredFlowUnitTest {
   }
 
   @Test
-  @Config(sdk = [Build.VERSION_CODES.N])
   fun `networkConnectivityRestoredFlow() collection registers and unregisters callback`() =
     runTest {
       val connectivityManager: ConnectivityManager = mockk(relaxed = true)
@@ -154,7 +153,6 @@ class NetworkConnectivityRestoredFlowUnitTest {
     }
 
   @Test
-  @Config(sdk = [Build.VERSION_CODES.N])
   fun `networkConnectivityRestoredFlow() collection unregisters callback on exception`() =
     `networkConnectivityRestoredFlow() collection unregisters callback on exception` { callback ->
       every { registerDefaultNetworkCallback(any<NetworkCallback>()) } answers
@@ -193,7 +191,6 @@ class NetworkConnectivityRestoredFlowUnitTest {
   }
 
   @Test
-  @Config(sdk = [Build.VERSION_CODES.N])
   fun `networkConnectivityRestoredFlow() sequential collection registers and unregisters callback`() =
     `networkConnectivityRestoredFlow() sequential collection registers and unregisters callback` {
       _,
@@ -233,7 +230,6 @@ class NetworkConnectivityRestoredFlowUnitTest {
   }
 
   @Test
-  @Config(sdk = [Build.VERSION_CODES.N])
   fun `networkConnectivityRestoredFlow() parallel collection registers and unregisters callback`() =
     `networkConnectivityRestoredFlow() parallel collection registers and unregisters callback` {
       onRegisterCallback ->
@@ -292,7 +288,6 @@ class NetworkConnectivityRestoredFlowUnitTest {
   }
 
   @Test
-  @Config(sdk = [Build.VERSION_CODES.N])
   fun `networkConnectivityRestoredFlow() emits expected events API 24`() =
     testNetworkCallbackSequences(includeBlockedStatusChanged = false, api24CaptureCallback)
 

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/NetworkConnectivityRestoredFlowUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/NetworkConnectivityRestoredFlowUnitTest.kt
@@ -287,14 +287,19 @@ class NetworkConnectivityRestoredFlowUnitTest {
     }
   }
 
+  // TODO: Remove this test method once minSdkVersion>=29 (Build.VERSION_CODES.Q).
   @Test
-  fun `networkConnectivityRestoredFlow() emits expected events API 24`() =
-    testNetworkCallbackSequences(includeBlockedStatusChanged = false, api24CaptureCallback)
+  @Config(sdk = [Config.OLDEST_SDK])
+  fun `networkConnectivityRestoredFlow() emits expected events API less than 29`() =
+    testNetworkCallbackSequences(includeBlockedStatusChanged = false, captureCallback)
 
+  // TODO: Remove superfluous logic from this test method once minSdkVersion>=29.
+  // Namely, remove the `@Config` annotation and all traces of the `includeBlockedStatusChanged`
+  // parameter, since its value will unconditionally be `true`.
   @Test
   @Config(sdk = [Build.VERSION_CODES.Q])
   fun `networkConnectivityRestoredFlow() emits expected events API 29`() =
-    testNetworkCallbackSequences(includeBlockedStatusChanged = true, api29CaptureCallback)
+    testNetworkCallbackSequences(includeBlockedStatusChanged = true, captureCallback)
 
   private fun testNetworkCallbackSequences(
     // Specify includeBlockedStatusChanged=true if, and only if, the API level of the test
@@ -574,12 +579,8 @@ private fun networkCallbackSequenceArb(
   }
 }
 
-private val api24CaptureCallback:
+private val captureCallback:
   MockKVerificationScope.(ConnectivityManager, CapturingSlot<NetworkCallback>) -> Unit =
   { connectivityManager, slot ->
     connectivityManager.registerDefaultNetworkCallback(capture(slot))
   }
-
-// API 29 uses the same API as 24; however, create a distinct variable for it to avoid confusion
-// at the usage sites.
-private val api29CaptureCallback = api24CaptureCallback


### PR DESCRIPTION
Update Robolectric test `@Config` annotations across unit tests. In `FirebasePlatformLoggingTest`, replace explicit
`Build.VERSION_CODES.N` with `Build.OLDEST_SDK` for tests that verify functionality in older API levels, and add an explanatory comment.

In `NetworkConnectivityRestoredFlowUnitTest`, remove redundant `@Config(sdk = [Build.VERSION_CODES.N])` annotations for tests which are no longer restricted to run in that version (since the min version is now `N`).

NO_RELEASE_CHANGE